### PR TITLE
add missing `nil` check in `resolveSchemaRef()`

### DIFF
--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -375,6 +375,9 @@ func (swaggerLoader *SwaggerLoader) resolveSchemaRef(swagger *Swagger, component
 		component.Value = resolved.Value
 	}
 	value := component.Value
+	if value == nil {
+		return nil
+	}
 
 	// ResolveRefs referred schemas
 	if v := value.Items; v != nil {

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -85,6 +85,15 @@ func TestResolveSchemaRef(t *testing.T) {
 	require.NotNil(t, refAVisited.Value)
 }
 
+func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
+	source := []byte(`{"info":{"description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
+	loader := openapi3.NewSwaggerLoader()
+	doc, err := loader.LoadSwaggerFromData(source)
+	require.NoError(t, err)
+	err = doc.Validate(loader.Context)
+	require.EqualError(t, err, "Found unresolved ref: ''")
+}
+
 type sourceExample struct {
 	Location *url.URL
 	Spec     []byte


### PR DESCRIPTION
Howdie! Great project!

We're getting the following panic:

> panic: runtime error: invalid memory address or nil pointer dereference [recovered]
> 	panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x158 pc=0x11e54af]
> 
> goroutine 21 [running]:
> testing.tRunner.func1(0xc4202801e0)
> 	/Users/.../go/src/testing/testing.go:742 +0x29d
> panic(0x17b9c00, 0x1d93d80)
> 	/Users/.../go/src/runtime/panic.go:502 +0x229
> .../vendor/github.com/getkin/kin-openapi/openapi3.(*SwaggerLoader).resolveSchemaRef(0xc420274840, 0xc420229e60, 0xc420316640, 0xc420390598, 0x0)
> 	.../vendor/github.com/getkin/kin-openapi/openapi3/swagger_loader.go:380 +0x16f

After reviewing swagger_loader.go, I noticed that all of the other `resolve...Ref()` methods have a `nil`-check that is missing from `resolveSchemaRef()`

This PR puts the missing check in, and I can confirm that this resolves our panic

Cheers!