### PR TITLE
Resolve example references

### DIFF
--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -336,11 +336,11 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 		if contentType == nil {
 			continue
 		}
-		for i, example := range contentType.Examples {
+		for name, example := range contentType.Examples {
 			if err := swaggerLoader.resolveExampleRef(swagger, example); err != nil {
 				return err
 			}
-			contentType.Examples[i] = example
+			contentType.Examples[name] = example
 		}
 		if schema := contentType.Schema; schema != nil {
 			if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -336,6 +336,12 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 		if contentType == nil {
 			continue
 		}
+		for i, example := range contentType.Examples {
+			if err := swaggerLoader.resolveExampleRef(swagger, example); err != nil {
+				return err
+			}
+			contentType.Examples[i] = example
+		}
 		if schema := contentType.Schema; schema != nil {
 			if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {
 				return err


### PR DESCRIPTION
This adds support for resolving [example references in media types](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#mediaTypeObject) when using the `examples` list. Here is a sample:

```yaml
# ...
components:
  examples:
    foo:
      value:
        msg: Hello, world!
paths:
  /path:
    get:
      responses:
        200:
          application/json:
            examples:
              test:
                $ref: "#/components/examples/foo"
# ...
```

Without this change you get back the raw ref when trying to output the example:

```js
{
  "$ref": "#/components/examples/foo"
}
```