### PR TITLE
Added MediaType definition to be interpreted as JSON

### DIFF
--- a/openapi3filter/media_type.go
+++ b/openapi3filter/media_type.go
@@ -2,7 +2,7 @@ package openapi3filter
 
 // Definition of MediaType to be interpreted as JSON
 var DefaultJSONMediaTypes = []string{
-	"aplication/json",
+	"application/json",
 }
 
 func isMediaTypeJSON(mediaType string) bool {

--- a/openapi3filter/media_type.go
+++ b/openapi3filter/media_type.go
@@ -1,0 +1,15 @@
+package openapi3filter
+
+// Definition of MediaType to be interpreted as JSON
+var DefaultJSONMediaTypes = []string{
+	"aplication/json",
+}
+
+func isMediaTypeJSON(mediaType string) bool {
+	for _, mt := range DefaultJSONMediaTypes {
+		if mediaType == mt {
+			return true
+		}
+	}
+	return false
+}

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -152,7 +152,7 @@ func ValidateRequestBody(c context.Context, input *RequestValidationInput, reque
 			}
 		}
 		schemaRef := contentType.Schema
-		if schemaRef != nil && mediaType == "application/json" {
+		if schemaRef != nil && isMediaTypeJSON(mediaType) {
 			schema := schemaRef.Value
 			body := req.Body
 			defer body.Close()

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -77,7 +77,7 @@ func ValidateResponse(c context.Context, input *ResponseValidationInput) error {
 				}
 			}
 			schemaRef := contentType.Schema
-			if schemaRef != nil && mediaType == "application/json" {
+			if schemaRef != nil && isMediaTypeJSON(mediaType) {
 				schema := schemaRef.Value
 
 				// Read request body


### PR DESCRIPTION
I also want to validate MediaType other than application/json as JSON.

- `application/json-patch+json`
    - [RFC 6902 - JavaScript Object Notation (JSON) Patch](https://tools.ietf.org/html/rfc6902)
- `application/problem+json`
    - [RFC 7807 - Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807)

Therefore, MediaType to be treated as JSON can be designated externally.
I am glad if you get input if there is any sense of incongruity in this IF.