### PR TITLE
Un-strict validation of "format" in schemas

### DIFF
--- a/jsoninfo/unsupported_properties_error.go
+++ b/jsoninfo/unsupported_properties_error.go
@@ -18,7 +18,7 @@ type UnsupportedPropertiesError struct {
 
 func NewUnsupportedPropertiesError(v interface{}, m map[string]json.RawMessage) error {
 	return &UnsupportedPropertiesError{
-		Value: v,
+		Value:                 v,
 		UnsupportedProperties: m,
 	}
 }

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -472,34 +472,14 @@ func (schema *Schema) validate(c context.Context, stack []*Schema) (err error) {
 			return
 		}
 	}
+
 	schemaType := schema.Type
 	switch schemaType {
 	case "":
 	case "boolean":
 	case "number":
-		if format := schema.Format; len(format) > 0 {
-			switch format {
-			case "float", "double":
-			default:
-				return unsupportedFormat(format)
-			}
-		}
 	case "integer":
-		if format := schema.Format; len(format) > 0 {
-			switch format {
-			case "int32", "int64":
-			default:
-				return unsupportedFormat(format)
-			}
-		}
 	case "string":
-		if format := schema.Format; len(format) > 0 {
-			switch format {
-			case "byte", "binary", "date", "date-time", "password":
-			default:
-				return unsupportedFormat(format)
-			}
-		}
 	case "array":
 		if schema.Items == nil {
 			return errors.New("When schema type is 'array', schema 'items' must be non-null")
@@ -508,6 +488,7 @@ func (schema *Schema) validate(c context.Context, stack []*Schema) (err error) {
 	default:
 		return fmt.Errorf("Unsupported 'type' value '%s'", schemaType)
 	}
+
 	if ref := schema.Items; ref != nil {
 		v := ref.Value
 		if v == nil {
@@ -1199,8 +1180,4 @@ func isSliceOfUniqueItems(xs []interface{}) bool {
 		m[x] = struct{}{}
 	}
 	return s == len(m)
-}
-
-func unsupportedFormat(format string) error {
-	return fmt.Errorf("Unsupported 'format' value '%s'", format)
 }

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -500,7 +500,14 @@ func (schema *Schema) validate(c context.Context, stack []*Schema) (err error) {
 	case "string":
 		if format := schema.Format; len(format) > 0 {
 			switch format {
+			// Supported by OpenAPIv3.0.1:
 			case "byte", "binary", "date", "date-time", "password":
+				// In JSON Draft-07 (not validated yet though):
+			case "regex":
+			case "time", "email", "idn-email":
+			case "hostname", "idn-hostname", "ipv4", "ipv6":
+			case "uri", "uri-reference", "iri", "iri-reference", "uri-template":
+			case "json-pointer", "relative-json-pointer":
 			default:
 				return unsupportedFormat(format)
 			}

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -622,9 +622,8 @@ var typeExamples = []schemaTypeExample{
 			"date",
 			"date-time",
 			"password",
-		},
-		AllInvalid: []string{
-			"unsupported",
+			// Not supported bu allowed:
+			"uri",
 		},
 	},
 
@@ -635,9 +634,8 @@ var typeExamples = []schemaTypeExample{
 			"",
 			"float",
 			"double",
-		},
-		AllInvalid: []string{
-			"unsupported",
+			// Not supported but allowed:
+			"f32",
 		},
 	},
 
@@ -648,9 +646,8 @@ var typeExamples = []schemaTypeExample{
 			"",
 			"int32",
 			"int64",
-		},
-		AllInvalid: []string{
-			"unsupported",
+			// Not supported but allowed:
+			"uint8",
 		},
 	},
 }

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -405,7 +405,7 @@ var schemaExamples = []schemaExample{
 	},
 	{
 		Schema: &openapi3.Schema{
-			Type: "object",
+			Type:                        "object",
 			AdditionalPropertiesAllowed: openapi3.BoolPtr(true),
 		},
 		Serialization: map[string]interface{}{

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -622,8 +622,11 @@ var typeExamples = []schemaTypeExample{
 			"date",
 			"date-time",
 			"password",
-			// Not supported bu allowed:
+			// Not supported but allowed:
 			"uri",
+		},
+		AllInvalid: []string{
+			"code/golang",
 		},
 	},
 
@@ -634,7 +637,8 @@ var typeExamples = []schemaTypeExample{
 			"",
 			"float",
 			"double",
-			// Not supported but allowed:
+		},
+		AllInvalid: []string{
 			"f32",
 		},
 	},
@@ -646,7 +650,8 @@ var typeExamples = []schemaTypeExample{
 			"",
 			"int32",
 			"int64",
-			// Not supported but allowed:
+		},
+		AllInvalid: []string{
 			"uint8",
 		},
 	},


### PR DESCRIPTION
I merged https://github.com/getkin/kin-openapi/pull/18 too fast and now I need to allow more formats than OpenAPIv3.0.1 explicitly allows. (e.g. [these](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7)).

Note: additional schemas are not forbidden, from https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#data-types
> Formats such as "email", "uuid", and so on, MAY be used even though undefined by this specification.

@rikkkky I agree that strict validation is best. What do you think of this PR?
I'm starting to think that I should actually extend your code with the additional `format`s I want to support, since their validation will come eventually anyway. Thoughts?

Thanks

Yeah bear with me while I do that!
EDIT: done. Since it doesn't exactly break previous behaviour & I need this now I'll merge it once CI is happy.
