### PR TITLE
fix: openapi3 operation AddResponse nil pointer

### DIFF
--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -65,7 +65,8 @@ func (operation *Operation) AddParameter(p *Parameter) {
 func (operation *Operation) AddResponse(status int, response *Response) {
 	responses := operation.Responses
 	if responses == nil {
-		operation.Responses = NewResponses()
+		responses = NewResponses()
+		operation.Responses = responses
 	}
 	if status == 0 {
 		responses["default"] = &ResponseRef{

--- a/openapi3/operation_test.go
+++ b/openapi3/operation_test.go
@@ -1,0 +1,32 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var operation *Operation
+
+func initOperation() {
+	operation = NewOperation()
+	operation.Description = "Some description"
+	operation.Summary = "Some summary"
+	operation.Tags = []string{"tag1", "tag2"}
+}
+
+func TestAddParameter(t *testing.T) {
+	initOperation()
+	operation.AddParameter(NewQueryParameter("param1"))
+	operation.AddParameter(NewCookieParameter("param2"))
+	require.Equal(t, "param1", operation.Parameters.GetByInAndName("query", "param1").Name)
+	require.Equal(t, "param2", operation.Parameters.GetByInAndName("cookie", "param2").Name)
+}
+
+func TestAddResponse(t *testing.T) {
+	initOperation()
+	operation.AddResponse(200, NewResponse())
+	operation.AddResponse(400, NewResponse())
+	require.NotNil(t, "status 200", operation.Responses.Get(200).Value)
+	require.NotNil(t, "status 400", operation.Responses.Get(400).Value)
+}


### PR DESCRIPTION
Fix a bug which will cause nil pointer panic. In the previous code in openapi3/operation:AddRespinse(), when operation.Responses == nil, any assignments to responses variable will panic as nil pointer since NewResponses() only assign to operation.Responses and remains responses to be nil.