### PR TITLE
Add support for path parameter refs

### DIFF
--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -125,6 +125,11 @@ func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger) (err error) 
 		if pathItem == nil {
 			continue
 		}
+		for _, parameter := range pathItem.Parameters {
+			if err = swaggerLoader.resolveParameterRef(swagger, parameter); err != nil {
+				return
+			}
+		}
 		for _, operation := range pathItem.Operations() {
 			for _, parameter := range operation.Parameters {
 				if err = swaggerLoader.resolveParameterRef(swagger, parameter); err != nil {

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -232,9 +232,11 @@ components:
   parameters:
     testParam:
       name: test
-      in: path
+      in: query
+      schema:
+        type: string
 paths:
-  '/{test}':
+  '/':
     parameters:
       - $ref: '#/components/parameters/testParam'
     get:
@@ -247,5 +249,5 @@ paths:
 	swagger, err := loader.LoadSwaggerFromYAMLData(spec)
 	require.NoError(t, err)
 
-	require.NotNil(t, swagger.Paths["/{test}"].Parameters[0].Value)
+	require.NotNil(t, swagger.Paths["/"].Parameters[0].Value)
 }

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -221,3 +221,31 @@ paths:
 	_, err := loader.LoadSwaggerFromYAMLData(spec)
 	require.Error(t, err)
 }
+
+func TestLoadPathParamRef(t *testing.T) {
+	spec := []byte(`
+openapi: '3.0.0'
+info:
+  title: ''
+  version: '1'
+components:
+  parameters:
+    testParam:
+      name: test
+      in: path
+paths:
+  '/{test}':
+    parameters:
+      - $ref: '#/components/parameters/testParam'
+    get:
+      responses:
+        '200':
+          description: Test call.
+`)
+
+	loader := openapi3.NewSwaggerLoader()
+	swagger, err := loader.LoadSwaggerFromYAMLData(spec)
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Paths["/{test}"].Parameters[0].Value)
+}


### PR DESCRIPTION
This adds a missing feature where path parameter references were ignored and the `param.Value` was  never filled in. Added a test which failed before but passes now.