### PR TITLE
Load request body examples ref

### DIFF
--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -296,6 +296,12 @@ func (swaggerLoader *SwaggerLoader) resolveRequestBodyRef(swagger *Swagger, comp
 		return nil
 	}
 	for _, contentType := range value.Content {
+		for name, example := range contentType.Examples {
+			if err := swaggerLoader.resolveExampleRef(swagger, example); err != nil {
+				return err
+			}
+			contentType.Examples[name] = example
+		}
 		if schema := contentType.Schema; schema != nil {
 			if err := swaggerLoader.resolveSchemaRef(swagger, schema); err != nil {
 				return err

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -251,3 +251,35 @@ paths:
 
 	require.NotNil(t, swagger.Paths["/"].Parameters[0].Value)
 }
+
+func TestLoadRequestExampleRef(t *testing.T) {
+	spec := []byte(`
+openapi: '3.0.0'
+info:
+  title: ''
+  version: '1'
+components:
+  examples:
+    test:
+      value:
+        hello: world
+paths:
+  '/':
+    post:
+      requestBody:
+        content:
+          application/json:
+            examples:
+              test:
+                $ref: "#/components/examples/test"
+      responses:
+        '200':
+          description: Test call.
+`)
+
+	loader := openapi3.NewSwaggerLoader()
+	swagger, err := loader.LoadSwaggerFromYAMLData(spec)
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Paths["/"].Post.RequestBody.Value.Content.Get("application/json").Examples["test"])
+}


### PR DESCRIPTION
This PR fixes a bug related to loading references in request body examples. I'm running into this with one of our OpenAPI docs. Included test shows how to trigger the problem and that it's fixed by just copying the logic from the response function over to the request function.