### PR TITLE
Security scheme: adding in:cookie as an option

### DIFF
--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -108,7 +108,7 @@ func (ss *SecurityScheme) Validate(c context.Context) error {
 		switch ss.In {
 		case "query", "header", "cookie":
 		default:
-			return fmt.Errorf("Security scheme of type 'apiKey' should have 'in'. It can be 'query' or 'header', not '%s'", ss.In)
+			return fmt.Errorf("Security scheme of type 'apiKey' should have 'in'. It can be 'query', 'header' or 'cookie', not '%s'", ss.In)
 		}
 		if ss.Name == "" {
 			return errors.New("Security scheme of type 'apiKey' should have 'name'")

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -106,7 +106,7 @@ func (ss *SecurityScheme) Validate(c context.Context) error {
 	// Validate "in" and "name"
 	if hasIn {
 		switch ss.In {
-		case "query", "header":
+		case "query", "header", "cookie":
 		default:
 			return fmt.Errorf("Security scheme of type 'apiKey' should have 'in'. It can be 'query' or 'header', not '%s'", ss.In)
 		}

--- a/openapi3/security_scheme_test.go
+++ b/openapi3/security_scheme_test.go
@@ -146,4 +146,15 @@ var securitySchemeExamples = []securitySchemeExample{
 `),
 		valid: false,
 	},
+	{
+		title: "Apikey Cookie",
+		raw: []byte(`
+{
+  "type": "apiKey",
+	"in": "cookie",
+	"name": "somecookie"
+}
+`),
+		valid: true,
+	},
 }


### PR DESCRIPTION
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#securitySchemeObject


```
in: The location of the API key. Valid values are "query", "header" or "cookie".
```



