### PR TITLE
feat(schema): add discriminator struct to match OpenAPI

### DIFF
--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -1,0 +1,26 @@
+package openapi3
+
+import (
+	"context"
+
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
+// Discriminator is specified by OpenAPI/Swagger standard version 3.0.
+type Discriminator struct {
+	ExtensionProps
+	PropertyName string                `json:"propertyName"`
+	Mapping      map[string]*SchemaRef `json:"mapping,omitempty"`
+}
+
+func (value *Discriminator) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(value)
+}
+
+func (value *Discriminator) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *Discriminator) Validate(c context.Context) error {
+	return nil
+}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -96,7 +96,7 @@ type Schema struct {
 	MinProps             uint64                `json:"minProperties,omitempty"`
 	MaxProps             *uint64               `json:"maxProperties,omitempty"`
 	AdditionalProperties *SchemaRef            `json:"-" multijson:"additionalProperties,omitempty"`
-	Discriminator        Discriminator         `json:"discriminator,omitempty"`
+	Discriminator        *Discriminator        `json:"discriminator,omitempty"`
 
 	PatternProperties         string `json:"patternProperties,omitempty"`
 	compiledPatternProperties *compiledPattern

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -96,7 +96,7 @@ type Schema struct {
 	MinProps             uint64                `json:"minProperties,omitempty"`
 	MaxProps             *uint64               `json:"maxProperties,omitempty"`
 	AdditionalProperties *SchemaRef            `json:"-" multijson:"additionalProperties,omitempty"`
-	Discriminator        string                `json:"discriminator,omitempty"`
+	Discriminator        Discriminator         `json:"discriminator,omitempty"`
 
 	PatternProperties         string `json:"patternProperties,omitempty"`
 	compiledPatternProperties *compiledPattern


### PR DESCRIPTION
Here is a PR to handle the discriminator object rather than a string.

It would #25 

Love the library :)  I'm using it to do all sorts of swagger tests