### PR TITLE
Fix typo in swagger v2 schemes

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -16,7 +16,7 @@ import (
 type Swagger struct {
 	Info                openapi3.Info                  `json:"info"`
 	ExternalDocs        *openapi3.ExternalDocs         `json:"externalDocs,omitempty"`
-	Schemes             []string                       `json:"schemas,omitempty"`
+	Schemes             []string                       `json:"schemes,omitempty"`
 	Host                string                         `json:"host,omitempty"`
 	BasePath            string                         `json:"basePath,omitempty"`
 	Paths               map[string]*PathItem           `json:"paths,omitempty"`

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -37,7 +37,7 @@ func TestConvOpenAPIV2ToV3(t *testing.T) {
 const exampleV2 = `
 {
   "info": {},
-  "schemas": ["https"],
+  "schemes": ["https"],
   "host": "test.example.com",
   "basePath": "/v2",
   "paths": {


### PR DESCRIPTION
There was a typo in the json field name which prevented the parser from loading schemes properly.

https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields