### PR TITLE
Support loading specifications from YAML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+
+# Macos file system
+.DS_Store
+
+# IntelliJ / GoLand
+.idea

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -9,8 +10,9 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -9,8 +9,8 @@ import (
 // Discriminator is specified by OpenAPI/Swagger standard version 3.0.
 type Discriminator struct {
 	ExtensionProps
-	PropertyName string                `json:"propertyName"`
-	Mapping      map[string]*SchemaRef `json:"mapping,omitempty"`
+	PropertyName string            `json:"propertyName"`
+	Mapping      map[string]string `json:"mapping,omitempty"`
 }
 
 func (value *Discriminator) MarshalJSON() ([]byte, error) {

--- a/openapi3/discriminator_test.go
+++ b/openapi3/discriminator_test.go
@@ -1,0 +1,43 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+var jsonSpecWithDiscriminator = []byte(`
+{
+	"openapi": "3.0.0",
+	"components": {
+		"schemas": {
+			"MyResponseType": {
+				"discriminator": {
+					"mapping": {
+						"cat": "#/components/schemas/Cat",
+						"dog": "#/components/schemas/Dog"
+					},
+					"propertyName": "pet_type"
+				},
+				"oneOf": [
+					{
+						"$ref": "#/components/schemas/Cat"
+					},
+					{
+						"$ref": "#/components/schemas/Dog"
+					}
+				]
+			},
+			"Cat": {"enum": ["chat"]},
+			"Dog": {"enum": ["chien"]}
+		}
+	}
+}
+`)
+
+func TestParsingDiscriminator(t *testing.T) {
+	loader, err := openapi3.NewSwaggerLoader().LoadSwaggerFromData(jsonSpecWithDiscriminator)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(loader.Components.Schemas["MyResponseType"].Value.OneOf))
+}

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -88,6 +88,20 @@ func (swaggerLoader *SwaggerLoader) LoadSwaggerFromFile(path string) (*Swagger, 
 	})
 }
 
+func (swaggerLoader *SwaggerLoader) LoadSwaggerFromYAMLFile(path string) (*Swagger, error) {
+	f := swaggerLoader.LoadSwaggerFromURIFunc
+	if f != nil {
+		return f(swaggerLoader, &url.URL{
+			Path: path,
+		})
+	}
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return swaggerLoader.LoadSwaggerFromYAMLData(data)
+}
+
 func (swaggerLoader *SwaggerLoader) LoadSwaggerFromData(data []byte) (*Swagger, error) {
 	swagger := &Swagger{}
 	if err := json.Unmarshal(data, swagger); err != nil {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -118,14 +118,6 @@ func (swaggerLoader *SwaggerLoader) LoadSwaggerFromYAMLData(data []byte) (*Swagg
 	return swagger, swaggerLoader.ResolveRefsIn(swagger, nil)
 }
 
-func (swaggerLoader *SwaggerLoader) LoadSwaggerFromYAMLDataWithPath(data []byte, path *url.URL) (*Swagger, error) {
-	swagger := &Swagger{}
-	if err := yaml.Unmarshal(data, swagger); err != nil {
-		return nil, err
-	}
-	return swagger, swaggerLoader.ResolveRefsIn(swagger, path)
-}
-
 func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger, path *url.URL) (err error) {
 	swaggerLoader.visited = make(map[interface{}]struct{})
 

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -405,3 +405,12 @@ func TestLoadFromDataWithExternalRequestResponseHeaderRemoteRef(t *testing.T) {
 	require.NotNil(t, swagger.Paths["/test"].Post.Responses["default"].Value.Headers["X-TEST-HEADER"].Value.Description)
 	require.Equal(t, "description", swagger.Paths["/test"].Post.Responses["default"].Value.Headers["X-TEST-HEADER"].Value.Description)
 }
+
+func TestLoadYamlFile(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromYAMLFile("testdata/test.openapi.yml")
+	require.NoError(t, err)
+
+	require.Equal(t, "OAI Specification in YAML", swagger.Info.Title)
+}

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -409,8 +409,17 @@ func TestLoadFromDataWithExternalRequestResponseHeaderRemoteRef(t *testing.T) {
 func TestLoadYamlFile(t *testing.T) {
 	loader := openapi3.NewSwaggerLoader()
 	loader.IsExternalRefsAllowed = true
-	swagger, err := loader.LoadSwaggerFromYAMLFile("testdata/test.openapi.yml")
+	swagger, err := loader.LoadSwaggerFromFile("testdata/test.openapi.yml")
 	require.NoError(t, err)
 
 	require.Equal(t, "OAI Specification in YAML", swagger.Info.Title)
+}
+
+func TestLoadYamlFileWithExternalSchemaRef(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromFile("testdata/testref.openapi.yml")
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Components.Schemas["AnotherTestSchema"].Value.Type)
 }

--- a/openapi3/testdata/components.openapi.yml
+++ b/openapi3/testdata/components.openapi.yml
@@ -1,0 +1,44 @@
+---
+openapi: 3.0.0
+info:
+  title: ''
+  version: '1'
+paths: {}
+components:
+  schemas:
+    Name:
+      type: string
+    CustomTestSchema:
+      "$ref": "#/components/schemas/Name"
+  responses:
+    Name:
+      description: description
+    CustomTestResponse:
+      "$ref": "#/components/responses/Name"
+  parameters:
+    Name:
+      name: id
+      in: header
+    CustomTestParameter:
+      "$ref": "#/components/parameters/Name"
+  examples:
+    Name:
+      description: description
+    CustomTestExample:
+      "$ref": "#/components/examples/Name"
+  requestBodies:
+    Name:
+      content: {}
+    CustomTestRequestBody:
+      "$ref": "#/components/requestBodies/Name"
+  headers:
+    Name:
+      description: description
+    CustomTestHeader:
+      "$ref": "#/components/headers/Name"
+  securitySchemes:
+    Name:
+      type: cookie
+      description: description
+    CustomTestSecurityScheme:
+      "$ref": "#/components/securitySchemes/Name"

--- a/openapi3/testdata/test.openapi.yml
+++ b/openapi3/testdata/test.openapi.yml
@@ -1,0 +1,10 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification in YAML'
+  version: 0.0.1
+paths: {}
+components:
+  schemas:
+    TestSchema:
+      type: string

--- a/openapi3/testdata/testref.openapi.yml
+++ b/openapi3/testdata/testref.openapi.yml
@@ -1,0 +1,10 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification w/ refs in YAML'
+  version: '1'
+paths: {}
+components:
+  schemas:
+    AnotherTestSchema:
+      "$ref": components.openapi.yml#/components/schemas/CustomTestSchema


### PR DESCRIPTION
This PR enables loading OAI specs from YAML files by making `LoadSwaggerFromDataWithPath` aware of the file extension.

If it is `yml` or `.yaml`, it tries unmarshalling YAML, otherwise it behaves like before.