### PR TITLE
openapi3: use map[string]string for mapping

### DIFF
--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -9,8 +9,8 @@ import (
 // Discriminator is specified by OpenAPI/Swagger standard version 3.0.
 type Discriminator struct {
 	ExtensionProps
-	PropertyName string                `json:"propertyName"`
-	Mapping      map[string]*SchemaRef `json:"mapping,omitempty"`
+	PropertyName string            `json:"propertyName"`
+	Mapping      map[string]string `json:"mapping,omitempty"`
 }
 
 func (value *Discriminator) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Technically this is a backwardly incompatible change, but
the Discriminator type has not been officially released yet,
so it should be OK.

Fixes issue #60.