### PR TITLE
Include value of unexpected Content-Type headers

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -148,7 +148,7 @@ func ValidateRequestBody(c context.Context, input *RequestValidationInput, reque
 			return &RequestError{
 				Input:       input,
 				RequestBody: requestBody,
-				Reason:      "header 'Content-type' has unexpected value",
+				Reason:      fmt.Sprintf("header 'Content-Type' has unexpected value: %q", inputMIME),
 			}
 		}
 		schemaRef := contentType.Schema

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -73,7 +73,7 @@ func ValidateResponse(c context.Context, input *ResponseValidationInput) error {
 			if contentType == nil {
 				return &ResponseError{
 					Input:  input,
-					Reason: "input header 'Content-type' has unexpected value",
+					Reason: fmt.Sprintf("input header 'Content-Type' has unexpected value: %q", inputMIME),
 				}
 			}
 			schemaRef := contentType.Schema


### PR DESCRIPTION
The previous behavior just said there was an unexpected value, but
didn't tell you what it was. Including the received value makes it
easier to debug and fix the actual discrepancy.

I also changed "Content-type" to "Content-Type" (uppercase T) in these
error messages to match the canonical form of the header.