### PR TITLE
Resolve Ref Inside Path Item

### DIFF
--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -22,6 +22,7 @@ type PathItem struct {
 	Trace       *Operation `json:"trace,omitempty"`
 	Servers     Servers    `json:"servers,omitempty"`
 	Parameters  Parameters `json:"parameters,omitempty"`
+	Ref         string     `json:"$ref,omitempty"`
 }
 
 func (pathItem *PathItem) MarshalJSON() ([]byte, error) {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -150,10 +150,6 @@ func (swaggerLoader *SwaggerLoader) ResolveRefsIn(swagger *Swagger, path *url.UR
 		if pathItem == nil {
 			continue
 		}
-		// Refer on documentation at Open Api Specification 3.0 at
-		// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject
-		// there is one property is $ref, to get the configuration at another reference object. For this time this issue
-		// will be fix, with the rules the value just come from relative path file or network file
 		if pathItem.Ref != "" {
 			if err = swaggerLoader.resolvePathItemRef(swagger, endpoint, pathItem.Ref); err != nil {
 				return


### PR DESCRIPTION
At [documentation OpenAPI Specification 3](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#pathItemObject) there is $ref property to get object from reference. But there is no explaination, how to use reference object either using relative path or network file or components. 

Inside this pr, the $ref object can be read but just working on relative path or network file. For component, i dont know what the key it will be use for that
