### PR TITLE
POC reference single file definitions

### DIFF
--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -325,6 +325,16 @@ func TestLoadFileWithExternalSchemaRef(t *testing.T) {
 	require.NotNil(t, swagger.Components.Schemas["AnotherTestSchema"].Value.Type)
 }
 
+func TestLoadFileWithExternalSchemaRefSingleComponent(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromFile("testdata/testrefsinglecomponent.openapi.json")
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Components.Responses["SomeResponse"])
+	require.Equal(t, "this is a single response definition", swagger.Components.Responses["SomeResponse"].Value.Description)
+}
+
 func TestLoadRequestResponseHeaderRef(t *testing.T) {
 	spec := []byte(`
 {
@@ -422,4 +432,14 @@ func TestLoadYamlFileWithExternalSchemaRef(t *testing.T) {
 	require.NoError(t, err)
 
 	require.NotNil(t, swagger.Components.Schemas["AnotherTestSchema"].Value.Type)
+}
+
+func TestLoadYamlFileWithExternalSchemaRefSingleComponent(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromFile("testdata/testrefsinglecomponent.openapi.yml")
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Components.Responses["SomeResponse"])
+	require.Equal(t, "this is a single response definition", swagger.Components.Responses["SomeResponse"].Value.Description)
 }

--- a/openapi3/testdata/singleresponse.openapi.json
+++ b/openapi3/testdata/singleresponse.openapi.json
@@ -1,0 +1,3 @@
+{
+  "description": "this is a single response definition"
+}

--- a/openapi3/testdata/singleresponse.openapi.yml
+++ b/openapi3/testdata/singleresponse.openapi.yml
@@ -1,0 +1,2 @@
+---
+description: this is a single response definition

--- a/openapi3/testdata/testrefsinglecomponent.openapi.json
+++ b/openapi3/testdata/testrefsinglecomponent.openapi.json
@@ -1,0 +1,15 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "1"
+    },
+    "paths": {},
+    "components": {
+        "responses": {
+            "SomeResponse": {
+                "$ref": "singleresponse.openapi.json"
+            }
+        }
+    }
+}

--- a/openapi3/testdata/testrefsinglecomponent.openapi.yml
+++ b/openapi3/testdata/testrefsinglecomponent.openapi.yml
@@ -1,0 +1,10 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification w/ refs in YAML'
+  version: '1'
+paths: {}
+components:
+  responses:
+    SomeResponse:
+      "$ref": singleresponse.openapi.yml


### PR DESCRIPTION
While trying to use this package with one an OpenAPI v3 spec that I have, I stumbled of not being able to use with it because in how I structured the spec across several files.

In such definition, I have elements which are referenced, but those references are to files where each file only contains the definition of one element and not an entirely OpenAPI definition.

If I understood correctly, according the [OpenAPI reference object section](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#reference-object) which follows the [JSON Reference RFC](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03), the [section 4](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-40) mentions the resolution and the _fragment_ is not mandatory, so it should be fine to define elements in a single file and reference. them.

I wanted to have a try and see if this package was not loading them because of a bug; after a few hours, I've realized that it isn't a bug, it's something not contemplated and I wanted to see if I could quickly implement it with only a few changes, however I wasn't able to do so.

I could have opened an issue regarding this feature, however I though that it was better to show the test which I used for identifying the problem because it clarifies what I explained above and also the dirty implementation, which I quickly wrote for passing the test (which only cover the response reference) for gathering feedback from you about if it could be a possible way in how to tackle the problem.

I may be able to find some time to work in this features in the following weeks, if it's something that you could consider to add, because I would love to have it, so I would appreciate some guidance in how to implemented despite of the way provided in this proof of concept is fine or not.