### PR TITLE
Decoding of request body with content types "application/x-www-form-urlencoded" and "multipart/form-data"

### DIFF
--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
@@ -13,7 +14,7 @@ type Encoding struct {
 	ContentType   string                `json:"contentType,omitempty"`
 	Headers       map[string]*HeaderRef `json:"headers,omitempty"`
 	Style         string                `json:"style,omitempty"`
-	Explode       bool                  `json:"explode,omitempty"`
+	Explode       *bool                 `json:"explode,omitempty"`
 	AllowReserved bool                  `json:"allowReserved,omitempty"`
 }
 
@@ -45,6 +46,21 @@ func (encoding *Encoding) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, encoding)
 }
 
+// SerializationMethod returns a serialization method of request body.
+// When serialization method is not defined the method returns the default serialization method.
+func (encoding *Encoding) SerializationMethod() *SerializationMethod {
+	sm := &SerializationMethod{Style: SerializationForm, Explode: true}
+	if encoding != nil {
+		if encoding.Style != "" {
+			sm.Style = encoding.Style
+		}
+		if encoding.Explode != nil {
+			sm.Explode = *encoding.Explode
+		}
+	}
+	return sm
+}
+
 func (encoding *Encoding) Validate(c context.Context) error {
 	if encoding == nil {
 		return nil
@@ -57,5 +73,21 @@ func (encoding *Encoding) Validate(c context.Context) error {
 			return nil
 		}
 	}
+
+	// Validate a media types's serialization method.
+	sm := encoding.SerializationMethod()
+	switch {
+	case sm.Style == SerializationForm && sm.Explode,
+		sm.Style == SerializationForm && !sm.Explode,
+		sm.Style == SerializationSpaceDelimited && sm.Explode,
+		sm.Style == SerializationSpaceDelimited && !sm.Explode,
+		sm.Style == SerializationPipeDelimited && sm.Explode,
+		sm.Style == SerializationPipeDelimited && !sm.Explode,
+		sm.Style == SerializationDeepObject && sm.Explode:
+		// it is a valid
+	default:
+		return fmt.Errorf("Serialization method with style=%q and explode=%v is not supported by media type", sm.Style, sm.Explode)
+	}
+
 	return nil
 }

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -73,16 +73,6 @@ const (
 	ParameterInCookie = "cookie"
 )
 
-const (
-	SerializationSimple         = "simple"
-	SerializationLabel          = "label"
-	SerializationMatrix         = "matrix"
-	SerializationForm           = "form"
-	SerializationSpaceDelimited = "spaceDelimited"
-	SerializationPipeDelimited  = "pipeDelimited"
-	SerializationDeepObject     = "deepObject"
-)
-
 func NewPathParameter(name string) *Parameter {
 	return &Parameter{
 		Name:     name,
@@ -139,11 +129,6 @@ func (parameter *Parameter) MarshalJSON() ([]byte, error) {
 
 func (parameter *Parameter) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, parameter)
-}
-
-type SerializationMethod struct {
-	Style   string
-	Explode bool
 }
 
 // SerializationMethod returns a parameter's serialization method.

--- a/openapi3/serialization_method.go
+++ b/openapi3/serialization_method.go
@@ -1,0 +1,17 @@
+package openapi3
+
+const (
+	SerializationSimple         = "simple"
+	SerializationLabel          = "label"
+	SerializationMatrix         = "matrix"
+	SerializationForm           = "form"
+	SerializationSpaceDelimited = "spaceDelimited"
+	SerializationPipeDelimited  = "pipeDelimited"
+	SerializationDeepObject     = "deepObject"
+)
+
+// SerializationMethod describes a serialization method of HTTP request's parameters and body.
+type SerializationMethod struct {
+	Style   string
+	Explode bool
+}


### PR DESCRIPTION
Hello. 

The PR adds support for decoding of request body with content types `"application/x-www-form-urlencoded"` and `"multipart/form-data"`. Also I add a decoder's implementation for files (see `openapi3filter.FileBodyDecoder`). 

The PR extends functional that appeared in [PR-78](getkin#78).