### PR TITLE
fix email validation

### DIFF
--- a/openapi3/schema_formats.go
+++ b/openapi3/schema_formats.go
@@ -19,7 +19,7 @@ func DefineStringFormat(name string, pattern string) {
 func init() {
 	// This pattern catches only some suspiciously wrong-looking email addresses.
 	// Use DefineStringFormat(...) if you need something stricter.
-	DefineStringFormat("email", `^[^@]+@[^@<>",\\w]+$`)
+	DefineStringFormat("email", `^[^@]+@[^@<>",\s]+$`)
 
 	// Base64
 	// The pattern supports base64 and b./ase64url. Padding ('=') is supported.


### PR DESCRIPTION
`^[\\w]` in regexp does not make sense, as it reads literally as "not \ and not w". It causes any email that contains `w` character in the domain to fail validation. Example

```go
func main() {
	payload := map[string]interface{}{
		"prop1": "name@www.site.com",
	}

	schema := `{
		"type": "object",
		"required": ["prop1"],
		"properties": {
			"prop1": {
				"type": "string",
				"format": "email"
			}
		}
	}
	`

	var dataSchema openapi3.Schema
	json.Unmarshal([]byte(schema), &dataSchema)
	err := dataSchema.VisitJSON(payload)
	fmt.Println(err)
}

```

gives `Error at "/prop1":JSON string doesn't match the format 'email (regular expression ^[^@]+@[^@<>",\\w]+$)'`

My understanding, `\\w` should be `\s` which is "any whitespace"