### PR TITLE
Fix crash in parameter validation

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -74,6 +74,13 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 // The function returns RequestError with ErrInvalidRequired cause when a value of a required parameter is not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
 func ValidateParameter(c context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
+	// The code below validates parameters with schemas, and will crash on
+	// content-based parameters which have no direct schema. Skip validating
+	// content based ones for now.
+	if parameter.Schema == nil && parameter.Content != nil {
+		return nil
+	}
+
 	value, err := decodeParameter(parameter, input)
 	if err != nil {
 		return &RequestError{Input: input, Parameter: parameter, Err: err}

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -56,6 +56,15 @@ func TestFilter(t *testing.T) {
 								Schema: openapi3.NewStringSchema().WithMaxLength(2).NewRef(),
 							},
 						},
+						{
+							Value: &openapi3.Parameter{
+								In:     "query",
+								Name:   "contentArg",
+								//Schema: openapi3.NewStringSchema().WithMaxLength(2).NewRef(),
+								Content:openapi3.NewContentWithJSONSchema(
+									openapi3.NewStringSchema().WithMaxLength(2)),
+							},
+						},
 					},
 				},
 			},
@@ -162,6 +171,15 @@ func TestFilter(t *testing.T) {
 	}
 	err = expect(req, resp)
 	// require.IsType(t, &openapi3filter.ResponseError{}, err)
+	require.NoError(t, err)
+
+	// Content arguments are currently not validated, so they should be
+	// accepted. Make sure this code path is handled.
+	req = ExampleRequest{
+		Method: "POST",
+		URL:    "http://example.com/api/prefix/v/suffix?contentArg=EXCEEDS_MAX_LENGTH",
+	}
+	err = expect(req, resp)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Parameters specified using Content instead of Schema crashed the
openapi3 filter. Skip validation of content parameters to fix the
crash.