### PR TITLE
Add content parameter validation

### DIFF
--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -854,7 +854,7 @@ func TestDecodeParameter(t *testing.T) {
 					require.NoError(t, err, "failed to find a route")
 
 					input := &RequestValidationInput{Request: req, PathParams: pathParams, Route: route}
-					got, err := decodeParameter(tc.param, input)
+					got, err := decodeStyledParameter(tc.param, input)
 
 					if tc.err != nil {
 						require.Error(t, err)

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -87,13 +87,9 @@ func ValidateParameter(c context.Context, input *RequestValidationInput, paramet
 
 	// Validation will ensure that we either have content or schema.
 	if parameter.Content != nil {
-		var schemaRef *openapi3.SchemaRef
-		value, schemaRef, err = decodeContentParameter(parameter, input)
+		value, schema, err = decodeContentParameter(parameter, input)
 		if err != nil {
 			return err
-		}
-		if schemaRef != nil {
-			schema = schemaRef.Value
 		}
 	} else {
 		value, err = decodeStyledParameter(parameter, input)

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -74,11 +74,34 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 // The function returns RequestError with ErrInvalidRequired cause when a value of a required parameter is not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
 func ValidateParameter(c context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
-	value, err := decodeParameter(parameter, input)
-	if err != nil {
-		return &RequestError{Input: input, Parameter: parameter, Err: err}
+	if parameter.Schema == nil && parameter.Content == nil {
+		// We have no schema for the parameter. Assume that everything passes
+		// a schema-less check, but this could also be an error. The Swagger
+		// validation allows this to happen.
+		return nil
 	}
 
+	var value interface{}
+	var err error
+	var schema *openapi3.Schema
+
+	// Validation will ensure that we either have content or schema.
+	if parameter.Content != nil {
+		var schemaRef *openapi3.SchemaRef
+		value, schemaRef, err = decodeContentParameter(parameter, input)
+		if err != nil {
+			return err
+		}
+		if schemaRef != nil {
+			schema = schemaRef.Value
+		}
+	} else {
+		value, err = decodeStyledParameter(parameter, input)
+		if err != nil {
+			return &RequestError{Input: input, Parameter: parameter, Err: err}
+		}
+		schema = parameter.Schema.Value
+	}
 	// Validate a parameter's value.
 	if value == nil {
 		if parameter.Required {
@@ -86,7 +109,6 @@ func ValidateParameter(c context.Context, input *RequestValidationInput, paramet
 		}
 		return nil
 	}
-	schema := parameter.Schema.Value
 	if schema == nil {
 		// A parameter's schema is not defined so skip validation of a parameter's value.
 		return nil

--- a/openapi3filter/validate_request_input.go
+++ b/openapi3filter/validate_request_input.go
@@ -10,12 +10,13 @@ import (
 // This function takes a parameter definition from the swagger spec, and
 // the value which we received for it. It is expected to return the
 // value unmarshaled into an interface which can be traversed for
-// validation, it should also return the content type, eg (application/json)
-// as a string, so that we know which schema to use for validation.
+// validation, it should also return the schema to be used for validating the
+// object, since there can be more than one in the content spec.
+//
 // If a query parameter appears multiple times, values[] will have more
 // than one  value, but for all other parameter types it should have just
 // one.
-type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (interface{}, string, error)
+type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (interface{}, *openapi3.Schema, error)
 
 type RequestValidationInput struct {
 	Request      *http.Request

--- a/openapi3filter/validate_request_input.go
+++ b/openapi3filter/validate_request_input.go
@@ -3,14 +3,27 @@ package openapi3filter
 import (
 	"net/http"
 	"net/url"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
+// This function takes a parameter definition from the swagger spec, and
+// the value which we received for it. It is expected to return the
+// value unmarshaled into an interface which can be traversed for
+// validation, it should also return the content type, eg (application/json)
+// as a string, so that we know which schema to use for validation.
+// If a query parameter appears multiple times, values[] will have more
+// than one  value, but for all other parameter types it should have just
+// one.
+type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (interface{}, string, error)
+
 type RequestValidationInput struct {
-	Request     *http.Request
-	PathParams  map[string]string
-	QueryParams url.Values
-	Route       *Route
-	Options     *Options
+	Request      *http.Request
+	PathParams   map[string]string
+	QueryParams  url.Values
+	Route        *Route
+	Options      *Options
+	ParamDecoder ContentParameterDecoder
 }
 
 func (input *RequestValidationInput) GetQueryParams() url.Values {

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -209,10 +209,11 @@ func TestFilter(t *testing.T) {
 	require.IsType(t, &openapi3filter.RequestError{}, err)
 
 	// Now, repeat the above two test cases using a custom parameter decoder.
-	customDecoder := func(param *openapi3.Parameter, values []string) (interface{}, string, error) {
+	customDecoder := func(param *openapi3.Parameter, values []string) (interface{}, *openapi3.Schema, error) {
 		var value interface{}
 		err := json.Unmarshal([]byte(values[0]), &value)
-		return value, "application/something_funny", err
+		schema := param.Content.Get("application/something_funny").Schema.Value
+		return value, schema, err
 	}
 
 	req = ExampleRequest{


### PR DESCRIPTION
Fix crash in validation of parameters which are specified with
content rather than schema. The problem was that the presence
of a parameter with a nil schema in the Swagger spec would
crash the loop which validated over all parameters.

Added a callback to the request validation input so the user
can decode custom content types, and also implemented an
alternate code path for validation of content arguments. Added
an internal default parameter validator which is capable of
validating JSON encoded parameters.