### PR TITLE
Add content-type wildcard support to validation

### DIFF
--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -34,7 +34,9 @@ func (content Content) Get(mime string) *MediaType {
 	// portion.
 	i := strings.IndexByte(mime, ';')
 	if i < 0 {
-		return content["*/*"]
+		// If there is no metadata then preserve the full mime type
+		// string for later wildcard searches.
+		i = len(mime)
 	}
 	mime = mime[:i]
 	if v := content[mime]; v != nil {
@@ -44,7 +46,10 @@ func (content Content) Get(mime string) *MediaType {
 	// try the x/* pattern.
 	i = strings.IndexByte(mime, '/')
 	if i < 0 {
-		return content["*/*"]
+		// In the case that the given mime type is not valid because it is
+		// missing the subtype we return nil so that this does not accidentally
+		// resolve with the wildcard.
+		return nil
 	}
 	mime = mime[:i] + "/*"
 	if v := content[mime]; v != nil {

--- a/openapi3/content_test.go
+++ b/openapi3/content_test.go
@@ -57,6 +57,42 @@ func TestContent_Get(t *testing.T) {
 			mime:    "text/plain;encoding=utf-16",
 			want:    fallback,
 		},
+		{
+			name:    "invalid mime type",
+			content: content,
+			mime:    "text;encoding=utf16",
+			want:    nil,
+		},
+		{
+			name:    "missing no encoding",
+			content: contentWithoutWildcards,
+			mime:    "text/plain",
+			want:    nil,
+		},
+		{
+			name:    "stripped match no encoding",
+			content: content,
+			mime:    "application/json",
+			want:    stripped,
+		},
+		{
+			name:    "wildcard match no encoding",
+			content: content,
+			mime:    "application/yaml",
+			want:    wildcard,
+		},
+		{
+			name:    "fallback match no encoding",
+			content: content,
+			mime:    "text/plain",
+			want:    fallback,
+		},
+		{
+			name:    "invalid mime type no encoding",
+			content: content,
+			mime:    "text",
+			want:    nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/openapi3/content_test.go
+++ b/openapi3/content_test.go
@@ -1,0 +1,71 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestContent_Get(t *testing.T) {
+	fallback := NewMediaType()
+	wildcard := NewMediaType()
+	stripped := NewMediaType()
+	fullMatch := NewMediaType()
+	content := Content{
+		"*/*":                             fallback,
+		"application/*":                   wildcard,
+		"application/json":                stripped,
+		"application/json;encoding=utf-8": fullMatch,
+	}
+	contentWithoutWildcards := Content{
+		"application/json":                stripped,
+		"application/json;encoding=utf-8": fullMatch,
+	}
+	tests := []struct {
+		name    string
+		content Content
+		mime    string
+		want    *MediaType
+	}{
+		{
+			name:    "missing",
+			content: contentWithoutWildcards,
+			mime:    "text/plain;encoding=utf-8",
+			want:    nil,
+		},
+		{
+			name:    "full match",
+			content: content,
+			mime:    "application/json;encoding=utf-8",
+			want:    fullMatch,
+		},
+		{
+			name:    "stripped match",
+			content: content,
+			mime:    "application/json;encoding=utf-16",
+			want:    stripped,
+		},
+		{
+			name:    "wildcard match",
+			content: content,
+			mime:    "application/yaml;encoding=utf-16",
+			want:    wildcard,
+		},
+		{
+			name:    "fallback match",
+			content: content,
+			mime:    "text/plain;encoding=utf-16",
+			want:    fallback,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Using require.True here because require.Same is not yet released.
+			// We're comparing pointer values and the require.Equal will
+			// dereference and compare the pointed to values rather than check
+			// if the memory addresses are the same. Once require.Same is released
+			// this test should convert to using that.
+			require.True(t, tt.want == tt.content.Get(tt.mime))
+		})
+	}
+}

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -154,16 +154,7 @@ func ValidateRequestBody(c context.Context, input *RequestValidationInput, reque
 	}
 
 	inputMIME := req.Header.Get("Content-Type")
-	mediaType := parseMediaType(inputMIME)
-	if mediaType == "" {
-		return &RequestError{
-			Input:       input,
-			RequestBody: requestBody,
-			Reason:      "content type is missed",
-		}
-	}
-
-	contentType := requestBody.Content[mediaType]
+	contentType := requestBody.Content.Get(inputMIME)
 	if contentType == nil {
 		return &RequestError{
 			Input:       input,

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -75,15 +75,7 @@ func ValidateResponse(c context.Context, input *ResponseValidationInput) error {
 	}
 
 	inputMIME := input.Header.Get("Content-Type")
-	mediaType := parseMediaType(inputMIME)
-	if mediaType == "" {
-		return &ResponseError{
-			Input:  input,
-			Reason: "content type of response body is missed",
-		}
-	}
-
-	contentType := content[mediaType]
+	contentType := content.Get(inputMIME)
 	if contentType == nil {
 		return &ResponseError{
 			Input:  input,


### PR DESCRIPTION
This implements the cascading wildcard behavior described in the OpenAPI
specification for request body and response body validation.

https://swagger.io/docs/specification/describing-request-body/

Closes #91 