### PR TITLE
Support missing mime types in validation

### DIFF
--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -24,6 +24,12 @@ func NewContentWithJSONSchemaRef(schema *SchemaRef) Content {
 }
 
 func (content Content) Get(mime string) *MediaType {
+	// If the mime is empty then short-circuit to the wildcard.
+	// We do this here so that we catch only the specific case of
+	// and empty mime rather than a present, but invalid, mime type.
+	if mime == "" {
+		return content["*/*"]
+	}
 	// Start by making the most specific match possible
 	// by using the mime type in full.
 	if v := content[mime]; v != nil {

--- a/openapi3/content_test.go
+++ b/openapi3/content_test.go
@@ -93,6 +93,12 @@ func TestContent_Get(t *testing.T) {
 			mime:    "text",
 			want:    nil,
 		},
+		{
+			name:    "missing mime type",
+			content: content,
+			mime:    "",
+			want:    fallback,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When a mime type is missing, rather than present and invalid, we return
the */* match as the request is not invalid for refusing to send a mime
type.

The RFC defining content-type states that including is a `SHOULD` rather than a `MUST`.