### PR TITLE
Fix bug in bearerFormat validation

### DIFF
--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -85,7 +85,6 @@ func (ss *SecurityScheme) Validate(c context.Context) error {
 	switch ss.Type {
 	case "apiKey":
 		hasIn = true
-		hasBearerFormat = true
 	case "http":
 		scheme := ss.Scheme
 		switch scheme {
@@ -120,14 +119,9 @@ func (ss *SecurityScheme) Validate(c context.Context) error {
 	}
 
 	// Validate "format"
-	if hasBearerFormat {
-		switch ss.BearerFormat {
-		case "", "JWT":
-		default:
-			return fmt.Errorf("Security scheme has unsupported 'bearerFormat' value '%s'", ss.BearerFormat)
-		}
-	} else if len(ss.BearerFormat) > 0 {
-		return errors.New("Security scheme of type 'apiKey' can't have 'bearerFormat'")
+	// "bearerFormat" is an arbitrary string so we only check if the scheme supports it
+	if !hasBearerFormat && len(ss.BearerFormat) > 0 {
+		return fmt.Errorf("Security scheme of type '%v' can't have 'bearerFormat'", ss.Type)
 	}
 
 	// Validate "flow"

--- a/openapi3/security_scheme_test.go
+++ b/openapi3/security_scheme_test.go
@@ -59,12 +59,24 @@ var securitySchemeExamples = []securitySchemeExample{
 		valid: true,
 	},
 	{
-		title: "JWT Bearer Sample",
+		title: "apiKey with bearerFormat",
+		raw: []byte(`
+{
+  "type": "apiKey",
+	"in": "header",
+	"name": "X-API-KEY",
+  "bearerFormat": "Arbitrary text"
+}
+`),
+		valid: false,
+	},
+	{
+		title: "Bearer Sample with arbitrary format",
 		raw: []byte(`
 {
   "type": "http",
   "scheme": "bearer",
-  "bearerFormat": "JWT"
+  "bearerFormat": "Arbitrary text"
 }
 `),
 		valid: true,


### PR DESCRIPTION
The `bearerFormat` field in security schemas would only permit the values "JWT" and "", whereas the spec allows it to contain arbitrary strings. `bearerFormat` was also accepted for authentication types where it's
invalid, like "apiKey". Fixed the bug, modified one test and added another.

This fixes https://github.com/getkin/kin-openapi/issues/97.