### PR TITLE
Security requirements validation

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -65,9 +65,10 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 	if security == nil {
 		if input.Route.Swagger == nil {
 			return errRouteMissingSwagger
+		} else {
+			// Use the global security requirements.
+			security = &input.Route.Swagger.Security
 		}
-		// Use the global security requirements.
-		security = &input.Route.Swagger.Security
 	}
 	if security != nil {
 		if err := ValidateSecurityRequirements(c, input, *security); err != nil {

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -61,6 +61,14 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 
 	// Security
 	security := operation.Security
+	// If there aren't any security requirements for the operation
+	if security == nil {
+		if input.Route.Swagger == nil {
+			return errRouteMissingSwagger
+		}
+		// Use the global security requirements.
+		security = &input.Route.Swagger.Security
+	}
 	if security != nil {
 		if err := ValidateSecurityRequirements(c, input, *security); err != nil {
 			return err

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -63,11 +63,11 @@ func ValidateRequest(c context.Context, input *RequestValidationInput) error {
 	security := operation.Security
 	// If there aren't any security requirements for the operation
 	if security == nil {
-		if input.Route.Swagger == nil {
+		if route.Swagger == nil {
 			return errRouteMissingSwagger
 		} else {
 			// Use the global security requirements.
-			security = &input.Route.Swagger.Security
+			security = &route.Swagger.Security
 		}
 	}
 	if security != nil {

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -276,8 +276,8 @@ func validateSecurityRequirement(c context.Context, input *RequestValidationInpu
 		return ErrAuthenticationServiceMissing
 	}
 
-	if len(names) > 0 {
-		name := names[0]
+	// For each scheme for the requirement
+	for _, name := range names {
 		var securityScheme *openapi3.SecurityScheme
 		if securitySchemes != nil {
 			if ref := securitySchemes[name]; ref != nil {
@@ -291,12 +291,15 @@ func validateSecurityRequirement(c context.Context, input *RequestValidationInpu
 			}
 		}
 		scopes := securityRequirement[name]
-		return f(c, &AuthenticationInput{
+		err := f(c, &AuthenticationInput{
 			RequestValidationInput: input,
 			SecuritySchemeName:     name,
 			SecurityScheme:         securityScheme,
 			Scopes:                 scopes,
 		})
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -242,7 +242,6 @@ func ValidateSecurityRequirements(c context.Context, input *RequestValidationInp
 	for i := 0; i < len(srs); i++ {
 		ok := <-doneChan
 		if ok {
-			close(doneChan)
 			return nil
 		}
 	}

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -291,13 +291,12 @@ func validateSecurityRequirement(c context.Context, input *RequestValidationInpu
 			}
 		}
 		scopes := securityRequirement[name]
-		err := f(c, &AuthenticationInput{
+		if err := f(c, &AuthenticationInput{
 			RequestValidationInput: input,
 			SecuritySchemeName:     name,
 			SecurityScheme:         securityScheme,
 			Scopes:                 scopes,
-		})
-		if err != nil {
+		}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When no [security requirements are defined for an operation](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-8), the [global security requirements](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields) need to be used according, which is what I implemented in the first commit.  

The second one modifies the way a security requirement is validated. Before, only the first scheme was validated, but according to the [spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#fixed-fields-8), all schemes must be valid for the request to be security requirement to be met.