### PR TITLE
Added default option for Parameters

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -155,6 +155,7 @@ type Parameter struct {
 	MinLength    uint64              `json:"minLength,omitempty"`
 	MaxLength    *uint64             `json:"maxLength,omitempty"`
 	Pattern      string              `json:"pattern,omitempty"`
+	Default      string              `json:"default,omitempty"`
 }
 
 type Response struct {


### PR DESCRIPTION
The default field is missing from parameter definition in V2