### PR TITLE
add nil check in request body validation

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -135,7 +135,7 @@ func ValidateRequestBody(c context.Context, input *RequestValidationInput, reque
 		data []byte
 	)
 
-	if req.Body != http.NoBody {
+	if req.Body != http.NoBody && req.Body != nil {
 		defer req.Body.Close()
 		var err error
 		if data, err = ioutil.ReadAll(req.Body); err != nil {


### PR DESCRIPTION
While the Go docs make the guarantee that the request body for servers will always be non-nil, the same cannot be made for outgoing HTTP requests.

openapi3filter.ValidateRequest can be used to validate incoming requests as well as outgoing requests. While http.NoBody can be used in an outgoing client request to explicitly signal that a request has zero bytes, one can simply set Request.Body to nil. Under these circumstances, it is possible to encounter a nil pointer dereference. This PR amends the existing request body check to also check for nil.