### PR TITLE
Validate additional OpenAPI objects

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -129,7 +129,7 @@ type Operation struct {
 	Tags         []string               `json:"tags,omitempty"`
 	OperationID  string                 `json:"operationId,omitempty"`
 	Parameters   Parameters             `json:"parameters,omitempty"`
-	Responses    map[string]*Response   `json:"responses,omitempty"`
+	Responses    map[string]*Response   `json:"responses"`
 	Consumes     []string               `json:"consumes,omitempty"`
 	Produces     []string               `json:"produces,omitempty"`
 	Security     *SecurityRequirements  `json:"security,omitempty"`

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -13,7 +13,7 @@ import (
 func ToV3Swagger(swagger *openapi2.Swagger) (*openapi3.Swagger, error) {
 	result := &openapi3.Swagger{
 		OpenAPI: "3.0",
-		Info:    swagger.Info,
+		Info:    &swagger.Info,
 		Components: openapi3.Components{
 			Tags: swagger.Tags,
 		},
@@ -272,7 +272,7 @@ func ToV3SecurityScheme(securityScheme *openapi2.SecurityScheme) (*openapi3.Secu
 
 func FromV3Swagger(swagger *openapi3.Swagger) (*openapi2.Swagger, error) {
 	result := &openapi2.Swagger{
-		Info: swagger.Info,
+		Info: *swagger.Info,
 		Tags: swagger.Components.Tags,
 	}
 	isHTTPS := false

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -36,7 +36,7 @@ func TestConvOpenAPIV2ToV3(t *testing.T) {
 
 const exampleV2 = `
 {
-  "info": {},
+  "info": {"title":"MyAPI","version":"0.1"},
   "schemes": ["https"],
   "host": "test.example.com",
   "basePath": "/v2",
@@ -110,7 +110,7 @@ const exampleV2 = `
 const exampleV3 = `
 {
   "openapi": "3.0",
-  "info": {},
+  "info": {"title":"MyAPI","version":"0.1"},
   "components": {},
   "servers": [
     {

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -43,7 +43,15 @@ const exampleV2 = `
   "paths": {
     "/example": {
       "delete": {
-        "description": "example delete"
+        "description": "example delete",
+        "responses": {
+          "default": {
+            "description": "default response"
+          },
+          "404": {
+            "description": "404 response"
+          }
+        }
       },
       "get": {
         "operationId": "example-get",
@@ -79,19 +87,24 @@ const exampleV2 = `
         ]
       },
       "head": {
-        "description": "example head"
+        "description": "example head",
+        "responses": {}
       },
       "patch": {
-        "description": "example patch"
+        "description": "example patch",
+        "responses": {}
       },
       "post": {
-        "description": "example post"
+        "description": "example post",
+        "responses": {}
       },
       "put": {
-        "description": "example put"
+        "description": "example put",
+        "responses": {}
       },
       "options": {
-        "description": "example options"
+        "description": "example options",
+        "responses": {}
       }
     }
   },
@@ -120,7 +133,15 @@ const exampleV3 = `
   "paths": {
     "/example": {
       "delete": {
-        "description": "example delete"
+        "description": "example delete",
+        "responses": {
+          "default": {
+            "description": "default response"
+          },
+          "404": {
+            "description": "404 response"
+          }
+        }
       },
       "get": {
         "operationId": "example-get",
@@ -158,19 +179,24 @@ const exampleV3 = `
         ]
       },
       "head": {
-        "description": "example head"
+        "description": "example head",
+        "responses": {}
       },
       "options": {
-        "description": "example options"
+        "description": "example options",
+        "responses": {}
       },
       "patch": {
-        "description": "example patch"
+        "description": "example patch",
+        "responses": {}
       },
       "post": {
-        "description": "example post"
+        "description": "example post",
+        "responses": {}
       },
       "put": {
-        "description": "example put"
+        "description": "example put",
+        "responses": {}
       }
     }
   },

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -11,12 +11,12 @@ import (
 // Info is specified by OpenAPI/Swagger standard version 3.0.
 type Info struct {
 	ExtensionProps
-	Title          string   `json:"title,omitempty"`
+	Title          string   `json:"title"` // Required
 	Description    string   `json:"description,omitempty"`
 	TermsOfService string   `json:"termsOfService,omitempty"`
 	Contact        *Contact `json:"contact,omitempty"`
 	License        *License `json:"license,omitempty"`
-	Version        string   `json:"version,omitempty"`
+	Version        string   `json:"version"` // Required
 }
 
 func (value *Info) MarshalJSON() ([]byte, error) {
@@ -38,6 +38,10 @@ func (value *Info) Validate(c context.Context) error {
 		if err := license.Validate(c); err != nil {
 			return fmt.Errorf("Error when validating License: %s", err.Error())
 		}
+	}
+
+	if value.Version == "" {
+		return fmt.Errorf("Variable 'version' must be a non-empty JSON string")
 	}
 
 	return nil
@@ -66,7 +70,7 @@ func (value *Contact) Validate(c context.Context) error {
 // License is specified by OpenAPI/Swagger standard version 3.0.
 type License struct {
 	ExtensionProps
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"` // Required
 	URL  string `json:"url,omitempty"`
 }
 

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -36,12 +36,16 @@ func (value *Info) Validate(c context.Context) error {
 		return errors.New("Variable 'version' must be a non-empty JSON string")
 	}
 
-	if err := value.Contact.Validate(c); err != nil {
-		return fmt.Errorf("Error when validating Contact: %s", err.Error())
+	if contact := value.Contact; contact != nil {
+		if err := contact.Validate(c); err != nil {
+			return fmt.Errorf("Error when validating Contact: %s", err.Error())
+		}
 	}
 
-	if err := value.License.Validate(c); err != nil {
-		return fmt.Errorf("Error when validating License: %s", err.Error())
+	if license := value.License; license != nil {
+		if err := license.Validate(c); err != nil {
+			return fmt.Errorf("Error when validating License: %s", err.Error())
+		}
 	}
 
 	return nil

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -15,7 +15,7 @@ type Info struct {
 	Description    string   `json:"description,omitempty"`
 	TermsOfService string   `json:"termsOfService,omitempty"`
 	Contact        *Contact `json:"contact,omitempty"`
-	License        *License `json:"license"` // Required
+	License        *License `json:"license,omitempty"`
 	Version        string   `json:"version"` // Required
 }
 

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -11,12 +11,12 @@ import (
 // Info is specified by OpenAPI/Swagger standard version 3.0.
 type Info struct {
 	ExtensionProps
-	Title          string   `json:"title"` // Required
+	Title          string   `json:"title,omitempty"`
 	Description    string   `json:"description,omitempty"`
 	TermsOfService string   `json:"termsOfService,omitempty"`
 	Contact        *Contact `json:"contact,omitempty"`
 	License        *License `json:"license,omitempty"`
-	Version        string   `json:"version"` // Required
+	Version        string   `json:"version,omitempty"`
 }
 
 func (value *Info) MarshalJSON() ([]byte, error) {
@@ -28,14 +28,6 @@ func (value *Info) UnmarshalJSON(data []byte) error {
 }
 
 func (value *Info) Validate(c context.Context) error {
-	if value.Title == "" {
-		return errors.New("Variable 'title' must be a non-empty JSON string")
-	}
-
-	if value.Version == "" {
-		return errors.New("Variable 'version' must be a non-empty JSON string")
-	}
-
 	if contact := value.Contact; contact != nil {
 		if err := contact.Validate(c); err != nil {
 			return fmt.Errorf("Error when validating Contact: %s", err.Error())

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
@@ -36,11 +37,11 @@ func (value *Info) Validate(c context.Context) error {
 	}
 
 	if err := value.Contact.Validate(c); err != nil {
-		return err
+		return fmt.Errorf("Error when validating Contact: %s", err.Error())
 	}
 
 	if err := value.License.Validate(c); err != nil {
-		return err
+		return fmt.Errorf("Error when validating License: %s", err.Error())
 	}
 
 	return nil

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -1,18 +1,21 @@
 package openapi3
 
 import (
+	"context"
+	"errors"
+
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
 
 // Info is specified by OpenAPI/Swagger standard version 3.0.
 type Info struct {
 	ExtensionProps
-	Title          string   `json:"title,omitempty"`
+	Title          string   `json:"title"` // Required
 	Description    string   `json:"description,omitempty"`
 	TermsOfService string   `json:"termsOfService,omitempty"`
 	Contact        *Contact `json:"contact,omitempty"`
-	License        *License `json:"license,omitempty"`
-	Version        string   `json:"version,omitempty"`
+	License        *License `json:"license"` // Required
+	Version        string   `json:"version"` // Required
 }
 
 func (value *Info) MarshalJSON() ([]byte, error) {
@@ -21,6 +24,26 @@ func (value *Info) MarshalJSON() ([]byte, error) {
 
 func (value *Info) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *Info) Validate(c context.Context) error {
+	if value.Title == "" {
+		return errors.New("Variable 'title' must be a non-empty JSON string")
+	}
+
+	if value.Version == "" {
+		return errors.New("Variable 'version' must be a non-empty JSON string")
+	}
+
+	if err := value.Contact.Validate(c); err != nil {
+		return err
+	}
+
+	if err := value.License.Validate(c); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Contact is specified by OpenAPI/Swagger standard version 3.0.
@@ -39,6 +62,10 @@ func (value *Contact) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, value)
 }
 
+func (value *Contact) Validate(c context.Context) error {
+	return nil
+}
+
 // License is specified by OpenAPI/Swagger standard version 3.0.
 type License struct {
 	ExtensionProps
@@ -52,4 +79,11 @@ func (value *License) MarshalJSON() ([]byte, error) {
 
 func (value *License) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, value)
+}
+
+func (value *License) Validate(c context.Context) error {
+	if value.Name == "" {
+		return errors.New("Variable 'name' must be a non-empty JSON string")
+	}
+	return nil
 }

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -44,6 +44,10 @@ func (value *Info) Validate(c context.Context) error {
 		return fmt.Errorf("Variable 'version' must be a non-empty JSON string")
 	}
 
+	if value.Title == "" {
+		return fmt.Errorf("Variable 'title' must be a non-empty JSON string")
+	}
+
 	return nil
 }
 

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
@@ -29,8 +30,8 @@ type Operation struct {
 	// Optional body parameter.
 	RequestBody *RequestBodyRef `json:"requestBody,omitempty"`
 
-	// Optional responses.
-	Responses Responses `json:"responses,omitempty"`
+	// Responses.
+	Responses Responses `json:"responses"` // Required
 
 	// Optional callbacks
 	Callbacks map[string]*CallbackRef `json:"callbacks,omitempty"`
@@ -94,6 +95,8 @@ func (operation *Operation) Validate(c context.Context) error {
 		if err := v.Validate(c); err != nil {
 			return err
 		}
+	} else {
+		return fmt.Errorf("Variable 'Responses' must be a JSON object")
 	}
 	return nil
 }

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 )
@@ -35,7 +36,7 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string) 
 
 // Server is specified by OpenAPI/Swagger standard version 3.0.
 type Server struct {
-	URL         string                     `json:"url,omitempty"`
+	URL         string                     `json:"url"`
 	Description string                     `json:"description,omitempty"`
 	Variables   map[string]*ServerVariable `json:"variables,omitempty"`
 }
@@ -100,6 +101,9 @@ func (server Server) MatchRawURL(input string) ([]string, string, bool) {
 }
 
 func (server *Server) Validate(c context.Context) (err error) {
+	if server.URL == "" {
+		return fmt.Errorf("Variable 'URL' must be a non-empty JSON string")
+	}
 	for _, v := range server.Variables {
 		if err = v.Validate(c); err != nil {
 			return

--- a/openapi3/server_test.go
+++ b/openapi3/server_test.go
@@ -1,6 +1,8 @@
 package openapi3_test
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -41,6 +43,44 @@ func TestServerParamValuesNoPath(t *testing.T) {
 		"https://domain0.domain1.example.com/": newServerMatch("/", "domain0", "domain1"),
 	} {
 		t.Run(input, testServerParamValues(t, server, input, expected))
+	}
+}
+
+func validServer() *openapi3.Server {
+	return &openapi3.Server{
+		URL: "http://my.cool.website",
+	}
+}
+
+func invalidServer() *openapi3.Server {
+	return &openapi3.Server{}
+}
+
+func TestServerValidation(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         *openapi3.Server
+		expectedError error
+	}{
+		{
+			"when no URL is provided",
+			invalidServer(),
+			fmt.Errorf("Variable 'URL' must be a non-empty JSON string"),
+		},
+		{
+			"when a URL is provided",
+			validServer(),
+			nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := context.Background()
+			validationErr := test.input.Validate(c)
+
+			require.Equal(t, test.expectedError, validationErr, "expected errors (or lack of) to match")
+		})
 	}
 }
 

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -10,7 +10,7 @@ import (
 type Swagger struct {
 	ExtensionProps
 	OpenAPI      string               `json:"openapi"` // Required
-	Info         Info                 `json:"info,omitempty"`
+	Info         Info                 `json:"info"`    // Required
 	Servers      Servers              `json:"servers,omitempty"`
 	Paths        Paths                `json:"paths,omitempty"`
 	Components   Components           `json:"components,omitempty"`

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
@@ -45,21 +46,21 @@ func (swagger *Swagger) AddServer(server *Server) {
 
 func (swagger *Swagger) Validate(c context.Context) error {
 	if err := swagger.Components.Validate(c); err != nil {
-		return err
+		return fmt.Errorf("Error when validating Components: %s", err.Error())
 	}
 	if v := swagger.Security; v != nil {
 		if err := v.Validate(c); err != nil {
-			return err
+			return fmt.Errorf("Error when validating Security: %s", err.Error())
 		}
 	}
 	if v := swagger.Servers; v != nil {
 		if err := v.Validate(c); err != nil {
-			return err
+			return fmt.Errorf("Error when validating Servers: %s", err.Error())
 		}
 	}
 	if v := swagger.Paths; v != nil {
 		if err := v.Validate(c); err != nil {
-			return err
+			return fmt.Errorf("Error when validating Paths: %s", err.Error())
 		}
 	}
 	if v := swagger.Info; true {

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -45,6 +45,9 @@ func (swagger *Swagger) AddServer(server *Server) {
 }
 
 func (swagger *Swagger) Validate(c context.Context) error {
+	if swagger.OpenAPI == "" {
+		return fmt.Errorf("Variable 'openapi' must be a non-empty JSON string")
+	}
 	if err := swagger.Components.Validate(c); err != nil {
 		return fmt.Errorf("Error when validating Components: %s", err.Error())
 	}

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -10,7 +10,7 @@ import (
 type Swagger struct {
 	ExtensionProps
 	OpenAPI      string               `json:"openapi"` // Required
-	Info         Info                 `json:"info"`    // Required
+	Info         Info                 `json:"info,omitempty"`
 	Servers      Servers              `json:"servers,omitempty"`
 	Paths        Paths                `json:"paths,omitempty"`
 	Components   Components           `json:"components,omitempty"`

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -52,11 +52,6 @@ func (swagger *Swagger) Validate(c context.Context) error {
 			return err
 		}
 	}
-	if paths := swagger.Paths; paths != nil {
-		if err := paths.Validate(c); err != nil {
-			return err
-		}
-	}
 	if v := swagger.Servers; v != nil {
 		if err := v.Validate(c); err != nil {
 			return err

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -10,7 +10,7 @@ import (
 type Swagger struct {
 	ExtensionProps
 	OpenAPI      string               `json:"openapi"` // Required
-	Info         Info                 `json:"info"`    // Required
+	Info         *Info                `json:"info"`    // Required
 	Servers      Servers              `json:"servers,omitempty"`
 	Paths        Paths                `json:"paths"` // Required
 	Components   Components           `json:"components,omitempty"`
@@ -68,10 +68,12 @@ func (swagger *Swagger) Validate(c context.Context) error {
 	} else {
 		return fmt.Errorf("Variable 'paths' must be a JSON object")
 	}
-	if v := swagger.Info; true {
+	if v := swagger.Info; v != nil {
 		if err := v.Validate(c); err != nil {
 			return fmt.Errorf("Error when validating Info: %s", err.Error())
 		}
+	} else {
+		return fmt.Errorf("Variable 'info' must be a JSON object")
 	}
 	return nil
 }

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -12,7 +12,7 @@ type Swagger struct {
 	OpenAPI      string               `json:"openapi"` // Required
 	Info         Info                 `json:"info"`    // Required
 	Servers      Servers              `json:"servers,omitempty"`
-	Paths        Paths                `json:"paths,omitempty"`
+	Paths        Paths                `json:"paths"` // Required
 	Components   Components           `json:"components,omitempty"`
 	Security     SecurityRequirements `json:"security,omitempty"`
 	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty"`
@@ -65,6 +65,8 @@ func (swagger *Swagger) Validate(c context.Context) error {
 		if err := v.Validate(c); err != nil {
 			return fmt.Errorf("Error when validating Paths: %s", err.Error())
 		}
+	} else {
+		return fmt.Errorf("Variable 'paths' must be a JSON object")
 	}
 	if v := swagger.Info; true {
 		if err := v.Validate(c); err != nil {

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -62,5 +62,10 @@ func (swagger *Swagger) Validate(c context.Context) error {
 			return err
 		}
 	}
+	if v := swagger.Info; true {
+		if err := v.Validate(c); err != nil {
+			return fmt.Errorf("Error when validating Info: %s", err.Error())
+		}
+	}
 	return nil
 }

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -79,7 +79,7 @@ func ExampleSwaggerLoader() {
 }
 
 func TestResolveSchemaRef(t *testing.T) {
-	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1",description":"An API"},"components":{"schemas":{"B":{"type":"string"},"A":{"allOf":[{"$ref":"#/components/schemas/B"}]}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1",description":"An API"},"paths":{},"components":{"schemas":{"B":{"type":"string"},"A":{"allOf":[{"$ref":"#/components/schemas/B"}]}}}}`)
 	loader := openapi3.NewSwaggerLoader()
 	doc, err := loader.LoadSwaggerFromData(source)
 	require.NoError(t, err)
@@ -168,10 +168,10 @@ func TestResolveSchemaExternalRef(t *testing.T) {
 	rootLocation := &url.URL{Scheme: "http", Host: "example.com", Path: "spec.json"}
 	externalLocation := &url.URL{Scheme: "http", Host: "example.com", Path: "external.json"}
 	rootSpec := []byte(fmt.Sprintf(
-		`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"components":{"schemas":{"Root":{"allOf":[{"$ref":"%s#/components/schemas/External"}]}}}}`,
+		`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"paths":{},"components":{"schemas":{"Root":{"allOf":[{"$ref":"%s#/components/schemas/External"}]}}}}`,
 		externalLocation.String(),
 	))
-	externalSpec := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"External Spec"},"components":{"schemas":{"External":{"type":"string"}}}}`)
+	externalSpec := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"External Spec"},"paths":{},"components":{"schemas":{"External":{"type":"string"}}}}`)
 	multipleSourceLoader := &multipleSourceSwaggerLoaderExample{
 		Sources: []*sourceExample{
 			{

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -79,7 +79,7 @@ func ExampleSwaggerLoader() {
 }
 
 func TestResolveSchemaRef(t *testing.T) {
-	source := []byte(`{"openapi":"3.0.0","info":{"description":"An API"},"components":{"schemas":{"B":{"type":"string"},"A":{"allOf":[{"$ref":"#/components/schemas/B"}]}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1",description":"An API"},"components":{"schemas":{"B":{"type":"string"},"A":{"allOf":[{"$ref":"#/components/schemas/B"}]}}}}`)
 	loader := openapi3.NewSwaggerLoader()
 	doc, err := loader.LoadSwaggerFromData(source)
 	require.NoError(t, err)
@@ -92,7 +92,7 @@ func TestResolveSchemaRef(t *testing.T) {
 }
 
 func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
-	source := []byte(`{"openapi":"3.0.0","info":{"description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
 	loader := openapi3.NewSwaggerLoader()
 	doc, err := loader.LoadSwaggerFromData(source)
 	require.NoError(t, err)
@@ -168,10 +168,10 @@ func TestResolveSchemaExternalRef(t *testing.T) {
 	rootLocation := &url.URL{Scheme: "http", Host: "example.com", Path: "spec.json"}
 	externalLocation := &url.URL{Scheme: "http", Host: "example.com", Path: "external.json"}
 	rootSpec := []byte(fmt.Sprintf(
-		`{"openapi":"3.0.0","info":{"description":"An API"},"components":{"schemas":{"Root":{"allOf":[{"$ref":"%s#/components/schemas/External"}]}}}}`,
+		`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"components":{"schemas":{"Root":{"allOf":[{"$ref":"%s#/components/schemas/External"}]}}}}`,
 		externalLocation.String(),
 	))
-	externalSpec := []byte(`{"openapi":"3.0.0","info":{"description":"External Spec"},"components":{"schemas":{"External":{"type":"string"}}}}`)
+	externalSpec := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"External Spec"},"components":{"schemas":{"External":{"type":"string"}}}}`)
 	multipleSourceLoader := &multipleSourceSwaggerLoaderExample{
 		Sources: []*sourceExample{
 			{

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -79,7 +79,7 @@ func ExampleSwaggerLoader() {
 }
 
 func TestResolveSchemaRef(t *testing.T) {
-	source := []byte(`{"info":{"description":"An API"},"components":{"schemas":{"B":{"type":"string"},"A":{"allOf":[{"$ref":"#/components/schemas/B"}]}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"description":"An API"},"components":{"schemas":{"B":{"type":"string"},"A":{"allOf":[{"$ref":"#/components/schemas/B"}]}}}}`)
 	loader := openapi3.NewSwaggerLoader()
 	doc, err := loader.LoadSwaggerFromData(source)
 	require.NoError(t, err)
@@ -92,12 +92,12 @@ func TestResolveSchemaRef(t *testing.T) {
 }
 
 func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
-	source := []byte(`{"info":{"description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
 	loader := openapi3.NewSwaggerLoader()
 	doc, err := loader.LoadSwaggerFromData(source)
 	require.NoError(t, err)
 	err = doc.Validate(loader.Context)
-	require.EqualError(t, err, "Found unresolved ref: ''")
+	require.EqualError(t, err, "Error when validating Paths: Found unresolved ref: ''")
 }
 
 func TestResolveResponseExampleRef(t *testing.T) {
@@ -168,10 +168,10 @@ func TestResolveSchemaExternalRef(t *testing.T) {
 	rootLocation := &url.URL{Scheme: "http", Host: "example.com", Path: "spec.json"}
 	externalLocation := &url.URL{Scheme: "http", Host: "example.com", Path: "external.json"}
 	rootSpec := []byte(fmt.Sprintf(
-		`{"info":{"description":"An API"},"components":{"schemas":{"Root":{"allOf":[{"$ref":"%s#/components/schemas/External"}]}}}}`,
+		`{"openapi":"3.0.0","info":{"description":"An API"},"components":{"schemas":{"Root":{"allOf":[{"$ref":"%s#/components/schemas/External"}]}}}}`,
 		externalLocation.String(),
 	))
-	externalSpec := []byte(`{"info":{"description":"External Spec"},"components":{"schemas":{"External":{"type":"string"}}}}`)
+	externalSpec := []byte(`{"openapi":"3.0.0","info":{"description":"External Spec"},"components":{"schemas":{"External":{"type":"string"}}}}`)
 	multipleSourceLoader := &multipleSourceSwaggerLoaderExample{
 		Sources: []*sourceExample{
 			{

--- a/openapi3/swagger_test.go
+++ b/openapi3/swagger_test.go
@@ -96,7 +96,9 @@ func eqYAML(t *testing.T, expected, actual []byte) {
 
 var specYAML = []byte(`
 openapi: '3.0'
-info: {}
+info:
+  title: MyAPI
+  version: '0.1'
 paths:
   "/hello":
     parameters:
@@ -149,7 +151,10 @@ components:
 var specJSON = []byte(`
 {
   "openapi": "3.0",
-  "info": {},
+  "info": {
+    "title": "MyAPI",
+    "version": "0.1"
+  },
   "paths": {
     "/hello": {
       "parameters": [
@@ -252,6 +257,10 @@ func spec() *openapi3.Swagger {
 	example := map[string]string{"name": "Some example"}
 	return &openapi3.Swagger{
 		OpenAPI: "3.0",
+		Info: openapi3.Info{
+			Title:   "MyAPI",
+			Version: "0.1",
+		},
 		Paths: openapi3.Paths{
 			"/hello": &openapi3.PathItem{
 				Post: &openapi3.Operation{

--- a/openapi3/swagger_test.go
+++ b/openapi3/swagger_test.go
@@ -257,7 +257,7 @@ func spec() *openapi3.Swagger {
 	example := map[string]string{"name": "Some example"}
 	return &openapi3.Swagger{
 		OpenAPI: "3.0",
-		Info: openapi3.Info{
+		Info: &openapi3.Info{
 			Title:   "MyAPI",
 			Version: "0.1",
 		},

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -844,7 +844,11 @@ func TestDecodeParameter(t *testing.T) {
 						path = "/{" + path + "}"
 					}
 
-					spec := &openapi3.Swagger{OpenAPI: "3.0.0"}
+					info := &openapi3.Info{
+						Title:   "MyAPI",
+						Version: "0.1",
+					}
+					spec := &openapi3.Swagger{OpenAPI: "3.0.0", Info: info}
 					op := &openapi3.Operation{OperationID: "test", Parameters: []*openapi3.ParameterRef{{Value: tc.param}}}
 					spec.AddOperation("/test"+path, http.MethodGet, op)
 					router := NewRouter()

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -844,7 +844,7 @@ func TestDecodeParameter(t *testing.T) {
 						path = "/{" + path + "}"
 					}
 
-					spec := &openapi3.Swagger{}
+					spec := &openapi3.Swagger{OpenAPI: "3.0.0"}
 					op := &openapi3.Operation{OperationID: "test", Parameters: []*openapi3.ParameterRef{{Value: tc.param}}}
 					spec.AddOperation("/test"+path, http.MethodGet, op)
 					router := NewRouter()

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -849,7 +849,7 @@ func TestDecodeParameter(t *testing.T) {
 						Version: "0.1",
 					}
 					spec := &openapi3.Swagger{OpenAPI: "3.0.0", Info: info}
-					op := &openapi3.Operation{OperationID: "test", Parameters: []*openapi3.ParameterRef{{Value: tc.param}}}
+					op := &openapi3.Operation{OperationID: "test", Parameters: []*openapi3.ParameterRef{{Value: tc.param}}, Responses: make(openapi3.Responses)}
 					spec.AddOperation("/test"+path, http.MethodGet, op)
 					router := NewRouter()
 					require.NoError(t, router.AddSwagger(spec), "failed to create a router")

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -22,6 +22,7 @@ func TestRouter(t *testing.T) {
 	helloTRACE := &openapi3.Operation{}
 	paramsGET := &openapi3.Operation{}
 	swagger := &openapi3.Swagger{
+		OpenAPI: "3.0.0",
 		Paths: openapi3.Paths{
 			"/hello": &openapi3.PathItem{
 				Connect: helloCONNECT,

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -11,16 +11,16 @@ import (
 
 func TestRouter(t *testing.T) {
 	// Build swagger
-	helloCONNECT := &openapi3.Operation{}
-	helloDELETE := &openapi3.Operation{}
-	helloGET := &openapi3.Operation{}
-	helloHEAD := &openapi3.Operation{}
-	helloOPTIONS := &openapi3.Operation{}
-	helloPATCH := &openapi3.Operation{}
-	helloPOST := &openapi3.Operation{}
-	helloPUT := &openapi3.Operation{}
-	helloTRACE := &openapi3.Operation{}
-	paramsGET := &openapi3.Operation{}
+	helloCONNECT := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloDELETE := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloGET := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloHEAD := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloOPTIONS := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloPATCH := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloPOST := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloPUT := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	helloTRACE := &openapi3.Operation{Responses: make(openapi3.Responses)}
+	paramsGET := &openapi3.Operation{Responses: make(openapi3.Responses)}
 	swagger := &openapi3.Swagger{
 		OpenAPI: "3.0.0",
 		Info: &openapi3.Info{

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -23,6 +23,10 @@ func TestRouter(t *testing.T) {
 	paramsGET := &openapi3.Operation{}
 	swagger := &openapi3.Swagger{
 		OpenAPI: "3.0.0",
+		Info: &openapi3.Info{
+			Title:   "MyAPI",
+			Version: "0.1",
+		},
 		Paths: openapi3.Paths{
 			"/hello": &openapi3.PathItem{
 				Connect: helloCONNECT,

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -46,6 +46,7 @@ func TestFilter(t *testing.T) {
 
 	// Declare router
 	swagger := &openapi3.Swagger{
+		OpenAPI: "3.0.0",
 		Servers: openapi3.Servers{
 			{
 				URL: "http://example.com/api/",
@@ -71,8 +72,8 @@ func TestFilter(t *testing.T) {
 						},
 						{
 							Value: &openapi3.Parameter{
-								In:   "query",
-								Name: "contentArg",
+								In:      "query",
+								Name:    "contentArg",
 								Content: openapi3.NewContentWithJSONSchema(complexArgSchema),
 							},
 						},
@@ -103,9 +104,9 @@ func TestFilter(t *testing.T) {
 
 		// Validate request
 		requestValidationInput := &openapi3filter.RequestValidationInput{
-			Request:    httpReq,
-			PathParams: pathParams,
-			Route:      route,
+			Request:      httpReq,
+			PathParams:   pathParams,
+			Route:        route,
 			ParamDecoder: decoder,
 		}
 		if err := openapi3filter.ValidateRequest(context.TODO(), requestValidationInput); err != nil {
@@ -407,7 +408,8 @@ func TestOperationOrSwaggerSecurity(t *testing.T) {
 
 	// Create the swagger
 	swagger := &openapi3.Swagger{
-		Paths: map[string]*openapi3.PathItem{},
+		OpenAPI: "3.0.0",
+		Paths:   map[string]*openapi3.PathItem{},
 		Security: openapi3.SecurityRequirements{
 			{
 				securitySchemes[1].Name: {},
@@ -540,7 +542,8 @@ func TestAnySecurityRequirementMet(t *testing.T) {
 
 	// Create the swagger
 	swagger := openapi3.Swagger{
-		Paths: map[string]*openapi3.PathItem{},
+		OpenAPI: "3.0.0",
+		Paths:   map[string]*openapi3.PathItem{},
 		Components: openapi3.Components{
 			SecuritySchemes: map[string]*openapi3.SecuritySchemeRef{},
 		},
@@ -631,7 +634,8 @@ func TestAllSchemesMet(t *testing.T) {
 
 	// Create the swagger
 	swagger := openapi3.Swagger{
-		Paths: map[string]*openapi3.PathItem{},
+		OpenAPI: "3.0.0",
+		Paths:   map[string]*openapi3.PathItem{},
 		Components: openapi3.Components{
 			SecuritySchemes: map[string]*openapi3.SecuritySchemeRef{},
 		},

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -91,6 +91,7 @@ func TestFilter(t *testing.T) {
 							},
 						},
 					},
+					Responses: make(openapi3.Responses),
 				},
 			},
 		},
@@ -452,7 +453,8 @@ func TestOperationOrSwaggerSecurity(t *testing.T) {
 		}
 		swagger.Paths[tc.name] = &openapi3.PathItem{
 			Get: &openapi3.Operation{
-				Security: securityRequirements,
+				Security:  securityRequirements,
+				Responses: make(openapi3.Responses),
 			},
 		}
 	}
@@ -584,7 +586,8 @@ func TestAnySecurityRequirementMet(t *testing.T) {
 		// Create the path with the security requirements
 		swagger.Paths[tc.name] = &openapi3.PathItem{
 			Get: &openapi3.Operation{
-				Security: &securityRequirements,
+				Security:  &securityRequirements,
+				Responses: make(openapi3.Responses),
 			},
 		}
 	}
@@ -684,6 +687,7 @@ func TestAllSchemesMet(t *testing.T) {
 				Security: &openapi3.SecurityRequirements{
 					securityRequirement,
 				},
+				Responses: make(openapi3.Responses),
 			},
 		}
 	}

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -47,6 +47,10 @@ func TestFilter(t *testing.T) {
 	// Declare router
 	swagger := &openapi3.Swagger{
 		OpenAPI: "3.0.0",
+		Info: &openapi3.Info{
+			Title:   "MyAPI",
+			Version: "0.1",
+		},
 		Servers: openapi3.Servers{
 			{
 				URL: "http://example.com/api/",
@@ -409,7 +413,11 @@ func TestOperationOrSwaggerSecurity(t *testing.T) {
 	// Create the swagger
 	swagger := &openapi3.Swagger{
 		OpenAPI: "3.0.0",
-		Paths:   map[string]*openapi3.PathItem{},
+		Info: &openapi3.Info{
+			Title:   "MyAPI",
+			Version: "0.1",
+		},
+		Paths: map[string]*openapi3.PathItem{},
 		Security: openapi3.SecurityRequirements{
 			{
 				securitySchemes[1].Name: {},
@@ -543,7 +551,11 @@ func TestAnySecurityRequirementMet(t *testing.T) {
 	// Create the swagger
 	swagger := openapi3.Swagger{
 		OpenAPI: "3.0.0",
-		Paths:   map[string]*openapi3.PathItem{},
+		Info: &openapi3.Info{
+			Title:   "MyAPI",
+			Version: "0.1",
+		},
+		Paths: map[string]*openapi3.PathItem{},
 		Components: openapi3.Components{
 			SecuritySchemes: map[string]*openapi3.SecuritySchemeRef{},
 		},
@@ -635,7 +647,11 @@ func TestAllSchemesMet(t *testing.T) {
 	// Create the swagger
 	swagger := openapi3.Swagger{
 		OpenAPI: "3.0.0",
-		Paths:   map[string]*openapi3.PathItem{},
+		Info: &openapi3.Info{
+			Title:   "MyAPI",
+			Version: "0.1",
+		},
+		Paths: map[string]*openapi3.PathItem{},
 		Components: openapi3.Components{
 			SecuritySchemes: map[string]*openapi3.SecuritySchemeRef{},
 		},


### PR DESCRIPTION
Hello! I'm incorporating this library into an OpenAPI validation and management service and have noticed that the included validation functions don't check the `openapi` version object (i.e. it can be omitted and validation succeeds).

I've made the following changes in an attempt to address this:

- Adds validation to the `openapi` object
- Removes redundant validation on the `paths` object
- Annotates validation errors in nested objects

@nogates