### PR TITLE
$ref in paths block

### DIFF
--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -22,6 +22,7 @@ type PathItem struct {
 	Trace       *Operation `json:"trace,omitempty"`
 	Servers     Servers    `json:"servers,omitempty"`
 	Parameters  Parameters `json:"parameters,omitempty"`
+	Ref         string     `json:"$ref,omitempty"`
 }
 
 func (pathItem *PathItem) MarshalJSON() ([]byte, error) {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -651,5 +651,5 @@ func (swaggerLoader *SwaggerLoader) resolvePathItemRef(swagger *Swagger, entrypo
 }
 
 func unescapeRefString(ref string) string {
-	return strings.ReplaceAll(strings.ReplaceAll(ref, "~1", "/"), "~0", "~")
+	return strings.Replace(strings.Replace(ref, "~1", "/", -1), "~0", "~", -1)
 }

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -423,3 +423,13 @@ func TestLoadYamlFileWithExternalSchemaRef(t *testing.T) {
 
 	require.NotNil(t, swagger.Components.Schemas["AnotherTestSchema"].Value.Type)
 }
+
+func TestLoadYamlFileWithExternalPathRef(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromFile("testdata/pathref.openapi.yml")
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
+	require.Equal(t, "string", swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
+}

--- a/openapi3/testdata/circularref.openapi.yml
+++ b/openapi3/testdata/circularref.openapi.yml
@@ -1,0 +1,19 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification in YAML'
+  version: 0.0.1
+paths:
+  /test:
+    get:
+      responses:
+        "200":
+          $ref: '#/components/responses/GetTestOK'
+components:
+  responses:
+    GetTestOK:
+      description: OK
+      content:
+        application/json:
+          schema:
+            $ref: 'pathref.openapi.yml#/components/schemas/TestSchema'

--- a/openapi3/testdata/pathref.openapi.yml
+++ b/openapi3/testdata/pathref.openapi.yml
@@ -1,0 +1,12 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification in YAML'
+  version: 0.0.1
+paths:
+  /test:
+    $ref: 'circularref.openapi.yml#/paths/~1test'
+components:
+  schemas:
+    TestSchema:
+      type: string


### PR DESCRIPTION
Hi! Thank you for the great library.

I'd like to use `$ref` in `paths` block.
I know we already have an opening pr for it https://github.com/getkin/kin-openapi/pull/73
But unfortunately it doesn't seem active with some change requests.
Then I tried to make another implementation.
I would be happy if this pr helps ones waiting for this feature :)

As you can see in the commit list, I made 3 changes;
1. Divided resolveComponent() into swagger part and component part
2. Supported `$ref` in `paths` block
3. Reset loader's internal state except from internal loading call

3rd change is needed, because in 2nd change, we need to have global state to avoid infinite recursion although we can use one SwaggerLoader for multiple loadings.

I also made a unit test case for this feature, and checked all tests passed.

Thank you for reviewing :)