### PR TITLE
Add YAML tags to all exported struct attributes

### DIFF
--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -11,16 +11,16 @@ import (
 // Components is specified by OpenAPI/Swagger standard version 3.0.
 type Components struct {
 	ExtensionProps
-	Schemas         map[string]*SchemaRef         `json:"schemas,omitempty"`
-	Parameters      map[string]*ParameterRef      `json:"parameters,omitempty"`
-	Headers         map[string]*HeaderRef         `json:"headers,omitempty"`
-	RequestBodies   map[string]*RequestBodyRef    `json:"requestBodies,omitempty"`
-	Responses       map[string]*ResponseRef       `json:"responses,omitempty"`
-	SecuritySchemes map[string]*SecuritySchemeRef `json:"securitySchemes,omitempty"`
-	Examples        map[string]*ExampleRef        `json:"examples,omitempty"`
-	Tags            Tags                          `json:"tags,omitempty"`
-	Links           map[string]*LinkRef           `json:"links,omitempty"`
-	Callbacks       map[string]*CallbackRef       `json:"callbacks,omitempty"`
+	Schemas         map[string]*SchemaRef         `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+	Parameters      map[string]*ParameterRef      `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Headers         map[string]*HeaderRef         `json:"headers,omitempty" yaml:"headers,omitempty"`
+	RequestBodies   map[string]*RequestBodyRef    `json:"requestBodies,omitempty" yaml:"requestBodies,omitempty"`
+	Responses       map[string]*ResponseRef       `json:"responses,omitempty" yaml:"responses,omitempty"`
+	SecuritySchemes map[string]*SecuritySchemeRef `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
+	Examples        map[string]*ExampleRef        `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Tags            Tags                          `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Links           map[string]*LinkRef           `json:"links,omitempty" yaml:"links,omitempty"`
+	Callbacks       map[string]*CallbackRef       `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
 }
 
 func NewComponents() Components {

--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -9,8 +9,8 @@ import (
 // Discriminator is specified by OpenAPI/Swagger standard version 3.0.
 type Discriminator struct {
 	ExtensionProps
-	PropertyName string            `json:"propertyName"`
-	Mapping      map[string]string `json:"mapping,omitempty"`
+	PropertyName string            `json:"propertyName" yaml:"propertyName"`
+	Mapping      map[string]string `json:"mapping,omitempty" yaml:"mapping,omitempty"`
 }
 
 func (value *Discriminator) MarshalJSON() ([]byte, error) {

--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -11,11 +11,11 @@ import (
 type Encoding struct {
 	ExtensionProps
 
-	ContentType   string                `json:"contentType,omitempty"`
-	Headers       map[string]*HeaderRef `json:"headers,omitempty"`
-	Style         string                `json:"style,omitempty"`
-	Explode       *bool                 `json:"explode,omitempty"`
-	AllowReserved bool                  `json:"allowReserved,omitempty"`
+	ContentType   string                `json:"contentType,omitempty" yaml:"contentType,omitempty"`
+	Headers       map[string]*HeaderRef `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Style         string                `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode       *bool                 `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowReserved bool                  `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 }
 
 func NewEncoding() *Encoding {

--- a/openapi3/examples.go
+++ b/openapi3/examples.go
@@ -8,10 +8,10 @@ import (
 type Example struct {
 	ExtensionProps
 
-	Summary       string      `json:"summary,omitempty"`
-	Description   string      `json:"description,omitempty"`
-	Value         interface{} `json:"value,omitempty"`
-	ExternalValue string      `json:"externalValue,omitempty"`
+	Summary       string      `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description   string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Value         interface{} `json:"value,omitempty" yaml:"value,omitempty"`
+	ExternalValue string      `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
 }
 
 func NewExample(value interface{}) *Example {

--- a/openapi3/extension.go
+++ b/openapi3/extension.go
@@ -7,7 +7,7 @@ import (
 // ExtensionProps provides support for OpenAPI extensions.
 // It reads/writes all properties that begin with "x-".
 type ExtensionProps struct {
-	Extensions map[string]interface{} `json:"-"`
+	Extensions map[string]interface{} `json:"-" yaml:"-"`
 }
 
 // Assert that the type implements the interface

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -8,10 +8,10 @@ type Header struct {
 	ExtensionProps
 
 	// Optional description. Should use CommonMark syntax.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// Optional schema
-	Schema *SchemaRef `json:"schema,omitempty"`
+	Schema *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
 }
 
 func (value *Header) Validate(c context.Context) error {

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -11,12 +11,12 @@ import (
 // Info is specified by OpenAPI/Swagger standard version 3.0.
 type Info struct {
 	ExtensionProps
-	Title          string   `json:"title"` // Required
-	Description    string   `json:"description,omitempty"`
-	TermsOfService string   `json:"termsOfService,omitempty"`
-	Contact        *Contact `json:"contact,omitempty"`
-	License        *License `json:"license,omitempty"`
-	Version        string   `json:"version"` // Required
+	Title          string   `json:"title" yaml:"title"` // Required
+	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
+	TermsOfService string   `json:"termsOfService,omitempty" yaml:"termsOfService,omitempty"`
+	Contact        *Contact `json:"contact,omitempty" yaml:"contact,omitempty"`
+	License        *License `json:"license,omitempty" yaml:"license,omitempty"`
+	Version        string   `json:"version" yaml:"version"` // Required
 }
 
 func (value *Info) MarshalJSON() ([]byte, error) {
@@ -54,9 +54,9 @@ func (value *Info) Validate(c context.Context) error {
 // Contact is specified by OpenAPI/Swagger standard version 3.0.
 type Contact struct {
 	ExtensionProps
-	Name  string `json:"name,omitempty"`
-	URL   string `json:"url,omitempty"`
-	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
+	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
+	Email string `json:"email,omitempty" yaml:"email,omitempty"`
 }
 
 func (value *Contact) MarshalJSON() ([]byte, error) {
@@ -74,8 +74,8 @@ func (value *Contact) Validate(c context.Context) error {
 // License is specified by OpenAPI/Swagger standard version 3.0.
 type License struct {
 	ExtensionProps
-	Name string `json:"name"` // Required
-	URL  string `json:"url,omitempty"`
+	Name string `json:"name" yaml:"name"` // Required
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
 func (value *License) MarshalJSON() ([]byte, error) {

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -9,11 +9,11 @@ import (
 // Link is specified by OpenAPI/Swagger standard version 3.0.
 type Link struct {
 	ExtensionProps
-	Description string                 `json:"description,omitempty"`
-	Href        string                 `json:"href,omitempty"`
-	OperationID string                 `json:"operationId,omitempty"`
-	Parameters  map[string]interface{} `json:"parameters,omitempty"`
-	Headers     map[string]*Schema     `json:"headers,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Href        string                 `json:"href,omitempty" yaml:"href,omitempty"`
+	OperationID string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Headers     map[string]*Schema     `json:"headers,omitempty" yaml:"headers,omitempty"`
 }
 
 func (value *Link) MarshalJSON() ([]byte, error) {

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -10,10 +10,10 @@ import (
 type MediaType struct {
 	ExtensionProps
 
-	Schema   *SchemaRef             `json:"schema,omitempty"`
-	Example  interface{}            `json:"example,omitempty"`
-	Examples map[string]*ExampleRef `json:"examples,omitempty"`
-	Encoding map[string]*Encoding   `json:"encoding,omitempty"`
+	Schema   *SchemaRef             `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example  interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples map[string]*ExampleRef `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Encoding map[string]*Encoding   `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
 
 func NewMediaType() *MediaType {

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -13,36 +13,36 @@ type Operation struct {
 	ExtensionProps
 
 	// Optional tags for documentation.
-	Tags []string `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
 
 	// Optional short summary.
-	Summary string `json:"summary,omitempty"`
+	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
 
 	// Optional description. Should use CommonMark syntax.
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	// Optional operation ID.
-	OperationID string `json:"operationId,omitempty"`
+	OperationID string `json:"operationId,omitempty" yaml:"operationId,omitempty"`
 
 	// Optional parameters.
-	Parameters Parameters `json:"parameters,omitempty"`
+	Parameters Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 
 	// Optional body parameter.
-	RequestBody *RequestBodyRef `json:"requestBody,omitempty"`
+	RequestBody *RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 
 	// Responses.
-	Responses Responses `json:"responses"` // Required
+	Responses Responses `json:"responses" yaml:"responses"` // Required
 
 	// Optional callbacks
-	Callbacks map[string]*CallbackRef `json:"callbacks,omitempty"`
+	Callbacks map[string]*CallbackRef `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
 
-	Deprecated bool `json:"deprecated,omitempty"`
+	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 
 	// Optional security requirements that overrides top-level security.
-	Security *SecurityRequirements `json:"security,omitempty"`
+	Security *SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
 
 	// Optional servers that overrides top-level servers.
-	Servers *Servers `json:"servers,omitempty"`
+	Servers *Servers `json:"servers,omitempty" yaml:"servers,omitempty"`
 }
 
 func NewOperation() *Operation {

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -51,19 +51,19 @@ func (parameters Parameters) Validate(c context.Context) error {
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
 type Parameter struct {
 	ExtensionProps
-	Name            string                 `json:"name,omitempty"`
-	In              string                 `json:"in,omitempty"`
-	Description     string                 `json:"description,omitempty"`
-	Style           string                 `json:"style,omitempty"`
-	Explode         *bool                  `json:"explode,omitempty"`
-	AllowEmptyValue bool                   `json:"allowEmptyValue,omitempty"`
-	AllowReserved   bool                   `json:"allowReserved,omitempty"`
-	Deprecated      bool                   `json:"deprecated,omitempty"`
-	Required        bool                   `json:"required,omitempty"`
-	Schema          *SchemaRef             `json:"schema,omitempty"`
-	Example         interface{}            `json:"example,omitempty"`
-	Examples        map[string]*ExampleRef `json:"examples,omitempty"`
-	Content         Content                `json:"content,omitempty"`
+	Name            string                 `json:"name,omitempty" yaml:"name,omitempty"`
+	In              string                 `json:"in,omitempty" yaml:"in,omitempty"`
+	Description     string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Style           string                 `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode         *bool                  `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowEmptyValue bool                   `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool                   `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+	Deprecated      bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Required        bool                   `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *SchemaRef             `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example         interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples        map[string]*ExampleRef `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Content         Content                `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 const (

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -9,20 +9,20 @@ import (
 
 type PathItem struct {
 	ExtensionProps
-	Summary     string     `json:"summary,omitempty"`
-	Description string     `json:"description,omitempty"`
-	Connect     *Operation `json:"connect,omitempty"`
-	Delete      *Operation `json:"delete,omitempty"`
-	Get         *Operation `json:"get,omitempty"`
-	Head        *Operation `json:"head,omitempty"`
-	Options     *Operation `json:"options,omitempty"`
-	Patch       *Operation `json:"patch,omitempty"`
-	Post        *Operation `json:"post,omitempty"`
-	Put         *Operation `json:"put,omitempty"`
-	Trace       *Operation `json:"trace,omitempty"`
-	Servers     Servers    `json:"servers,omitempty"`
-	Parameters  Parameters `json:"parameters,omitempty"`
-	Ref         string     `json:"$ref,omitempty"`
+	Ref         string     `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Summary     string     `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string     `json:"description,omitempty" yaml:"description,omitempty"`
+	Connect     *Operation `json:"connect,omitempty" yaml:"connect,omitempty"`
+	Delete      *Operation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Get         *Operation `json:"get,omitempty" yaml:"get,omitempty"`
+	Head        *Operation `json:"head,omitempty" yaml:"head,omitempty"`
+	Options     *Operation `json:"options,omitempty" yaml:"options,omitempty"`
+	Patch       *Operation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Post        *Operation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put         *Operation `json:"put,omitempty" yaml:"put,omitempty"`
+	Trace       *Operation `json:"trace,omitempty" yaml:"trace,omitempty"`
+	Servers     Servers    `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Parameters  Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 }
 
 func (pathItem *PathItem) MarshalJSON() ([]byte, error) {

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -9,9 +9,9 @@ import (
 // RequestBody is specified by OpenAPI/Swagger 3.0 standard.
 type RequestBody struct {
 	ExtensionProps
-	Description string  `json:"description,omitempty"`
-	Required    bool    `json:"required,omitempty"`
-	Content     Content `json:"content,omitempty"`
+	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
+	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	Content     Content `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 func NewRequestBody() *RequestBody {

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -34,10 +34,10 @@ func (responses Responses) Validate(c context.Context) error {
 // Response is specified by OpenAPI/Swagger 3.0 standard.
 type Response struct {
 	ExtensionProps
-	Description string                `json:"description,omitempty"`
-	Headers     map[string]*HeaderRef `json:"headers,omitempty"`
-	Content     Content               `json:"content,omitempty"`
-	Links       map[string]*LinkRef   `json:"links,omitempty"`
+	Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Headers     map[string]*HeaderRef `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Content     Content               `json:"content,omitempty" yaml:"content,omitempty"`
+	Links       map[string]*LinkRef   `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 func NewResponse() *Response {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -49,56 +49,56 @@ func Uint64Ptr(value uint64) *uint64 {
 type Schema struct {
 	ExtensionProps
 
-	OneOf        []*SchemaRef  `json:"oneOf,omitempty"`
-	AnyOf        []*SchemaRef  `json:"anyOf,omitempty"`
-	AllOf        []*SchemaRef  `json:"allOf,omitempty"`
-	Not          *SchemaRef    `json:"not,omitempty"`
-	Type         string        `json:"type,omitempty"`
-	Format       string        `json:"format,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	Enum         []interface{} `json:"enum,omitempty"`
-	Default      interface{}   `json:"default,omitempty"`
-	Example      interface{}   `json:"example,omitempty"`
-	ExternalDocs interface{}   `json:"externalDocs,omitempty"`
+	OneOf        []*SchemaRef  `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	AnyOf        []*SchemaRef  `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	AllOf        []*SchemaRef  `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	Not          *SchemaRef    `json:"not,omitempty" yaml:"not,omitempty"`
+	Type         string        `json:"type,omitempty" yaml:"type,omitempty"`
+	Format       string        `json:"format,omitempty" yaml:"format,omitempty"`
+	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
+	Enum         []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default      interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
+	Example      interface{}   `json:"example,omitempty" yaml:"example,omitempty"`
+	ExternalDocs interface{}   `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 
 	// Object-related, here for struct compactness
-	AdditionalPropertiesAllowed *bool `json:"-" multijson:"additionalProperties,omitempty"`
+	AdditionalPropertiesAllowed *bool `json:"-" multijson:"additionalProperties,omitempty" yaml:"-"`
 	// Array-related, here for struct compactness
-	UniqueItems bool `json:"uniqueItems,omitempty"`
+	UniqueItems bool `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
 	// Number-related, here for struct compactness
-	ExclusiveMin bool `json:"exclusiveMinimum,omitempty"`
-	ExclusiveMax bool `json:"exclusiveMaximum,omitempty"`
+	ExclusiveMin bool `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMax bool `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
 	// Properties
-	Nullable  bool        `json:"nullable,omitempty"`
-	ReadOnly  bool        `json:"readOnly,omitempty"`
-	WriteOnly bool        `json:"writeOnly,omitempty"`
-	XML       interface{} `json:"xml,omitempty"`
+	Nullable  bool        `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	ReadOnly  bool        `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	WriteOnly bool        `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
+	XML       interface{} `json:"xml,omitempty" yaml:"xml,omitempty"`
 
 	// Number
-	Min        *float64 `json:"minimum,omitempty"`
-	Max        *float64 `json:"maximum,omitempty"`
-	MultipleOf *float64 `json:"multipleOf,omitempty"`
+	Min        *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	Max        *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	MultipleOf *float64 `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 
 	// String
-	MinLength       uint64  `json:"minLength,omitempty"`
-	MaxLength       *uint64 `json:"maxLength,omitempty"`
-	Pattern         string  `json:"pattern,omitempty"`
+	MinLength       uint64  `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MaxLength       *uint64 `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	Pattern         string  `json:"pattern,omitempty" yaml:"pattern,omitempty"`
 	compiledPattern *compiledPattern
 
 	// Array
-	MinItems uint64     `json:"minItems,omitempty"`
-	MaxItems *uint64    `json:"maxItems,omitempty"`
-	Items    *SchemaRef `json:"items,omitempty"`
+	MinItems uint64     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MaxItems *uint64    `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	Items    *SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
 
 	// Object
-	Required             []string              `json:"required,omitempty"`
-	Properties           map[string]*SchemaRef `json:"properties,omitempty"`
-	MinProps             uint64                `json:"minProperties,omitempty"`
-	MaxProps             *uint64               `json:"maxProperties,omitempty"`
-	AdditionalProperties *SchemaRef            `json:"-" multijson:"additionalProperties,omitempty"`
-	Discriminator        *Discriminator        `json:"discriminator,omitempty"`
+	Required             []string              `json:"required,omitempty" yaml:"required,omitempty"`
+	Properties           map[string]*SchemaRef `json:"properties,omitempty" yaml:"properties,omitempty"`
+	MinProps             uint64                `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	MaxProps             *uint64               `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	AdditionalProperties *SchemaRef            `json:"-" multijson:"additionalProperties,omitempty" yaml:"-"`
+	Discriminator        *Discriminator        `json:"discriminator,omitempty" yaml:"discriminator,omitempty"`
 
-	PatternProperties         string `json:"patternProperties,omitempty"`
+	PatternProperties         string `json:"patternProperties,omitempty" yaml:"patternProperties,omitempty"`
 	compiledPatternProperties *compiledPattern
 }
 

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -11,13 +11,13 @@ import (
 type SecurityScheme struct {
 	ExtensionProps
 
-	Type         string      `json:"type,omitempty"`
-	Description  string      `json:"description,omitempty"`
-	Name         string      `json:"name,omitempty"`
-	In           string      `json:"in,omitempty"`
-	Scheme       string      `json:"scheme,omitempty"`
-	BearerFormat string      `json:"bearerFormat,omitempty"`
-	Flows        *OAuthFlows `json:"flows,omitempty"`
+	Type         string      `json:"type,omitempty" yaml:"type,omitempty"`
+	Description  string      `json:"description,omitempty" yaml:"description,omitempty"`
+	Name         string      `json:"name,omitempty" yaml:"name,omitempty"`
+	In           string      `json:"in,omitempty" yaml:"in,omitempty"`
+	Scheme       string      `json:"scheme,omitempty" yaml:"scheme,omitempty"`
+	BearerFormat string      `json:"bearerFormat,omitempty" yaml:"bearerFormat,omitempty"`
+	Flows        *OAuthFlows `json:"flows,omitempty" yaml:"flows,omitempty"`
 }
 
 func NewSecurityScheme() *SecurityScheme {
@@ -141,10 +141,10 @@ func (ss *SecurityScheme) Validate(c context.Context) error {
 
 type OAuthFlows struct {
 	ExtensionProps
-	Implicit          *OAuthFlow `json:"implicit,omitempty"`
-	Password          *OAuthFlow `json:"password,omitempty"`
-	ClientCredentials *OAuthFlow `json:"clientCredentials,omitempty"`
-	AuthorizationCode *OAuthFlow `json:"authorizationCode,omitempty"`
+	Implicit          *OAuthFlow `json:"implicit,omitempty" yaml:"implicit,omitempty"`
+	Password          *OAuthFlow `json:"password,omitempty" yaml:"password,omitempty"`
+	ClientCredentials *OAuthFlow `json:"clientCredentials,omitempty" yaml:"clientCredentials,omitempty"`
+	AuthorizationCode *OAuthFlow `json:"authorizationCode,omitempty" yaml:"authorizationCode,omitempty"`
 }
 
 type oAuthFlowType int
@@ -182,10 +182,10 @@ func (flows *OAuthFlows) Validate(c context.Context) error {
 
 type OAuthFlow struct {
 	ExtensionProps
-	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
-	TokenURL         string            `json:"tokenUrl,omitempty"`
-	RefreshURL       string            `json:"refreshUrl,omitempty"`
-	Scopes           map[string]string `json:"scopes"`
+	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
+	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
+	RefreshURL       string            `json:"refreshUrl,omitempty" yaml:"refreshUrl,omitempty"`
+	Scopes           map[string]string `json:"scopes" yaml:"scopes"`
 }
 
 func (flow *OAuthFlow) MarshalJSON() ([]byte, error) {

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -36,9 +36,9 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string) 
 
 // Server is specified by OpenAPI/Swagger standard version 3.0.
 type Server struct {
-	URL         string                     `json:"url"`
-	Description string                     `json:"description,omitempty"`
-	Variables   map[string]*ServerVariable `json:"variables,omitempty"`
+	URL         string                     `json:"url" yaml:"url"`
+	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Variables   map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
 }
 
 func (server Server) ParameterNames() ([]string, error) {
@@ -114,9 +114,9 @@ func (server *Server) Validate(c context.Context) (err error) {
 
 // ServerVariable is specified by OpenAPI/Swagger standard version 3.0.
 type ServerVariable struct {
-	Enum        []interface{} `json:"enum,omitempty"`
-	Default     interface{}   `json:"default,omitempty"`
-	Description string        `json:"description,omitempty"`
+	Enum        []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default     interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
+	Description string        `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 func (serverVariable *ServerVariable) Validate(c context.Context) error {

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -9,13 +9,13 @@ import (
 
 type Swagger struct {
 	ExtensionProps
-	OpenAPI      string               `json:"openapi"` // Required
-	Info         *Info                `json:"info"`    // Required
-	Servers      Servers              `json:"servers,omitempty"`
-	Paths        Paths                `json:"paths"` // Required
-	Components   Components           `json:"components,omitempty"`
-	Security     SecurityRequirements `json:"security,omitempty"`
-	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty"`
+	OpenAPI      string               `json:"openapi" yaml:"openapi"` // Required
+	Info         *Info                `json:"info" yaml:"info"`       // Required
+	Servers      Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Paths        Paths                `json:"paths" yaml:"paths"` // Required
+	Components   Components           `json:"components,omitempty" yaml:"components,omitempty"`
+	Security     SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
+	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 func (swagger *Swagger) MarshalJSON() ([]byte, error) {

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -14,7 +14,7 @@ func (tags Tags) Get(name string) *Tag {
 
 // Tag is specified by OpenAPI/Swagger 3.0 standard.
 type Tag struct {
-	Name         string        `json:"name,omitempty"`
-	Description  string        `json:"description,omitempty"`
-	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty"`
+	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
+	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }


### PR DESCRIPTION
This PR adds `yaml` tags to all exported struct attributes. This provides compatibility with alternate YAML parsers like [go-yaml/yaml](https://github.com/go-yaml/yaml).