### PR TITLE
Update expectedType SchemaError message

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1139,10 +1139,10 @@ func (schema *Schema) expectedType(typ string, fast bool) error {
 		return errSchema
 	}
 	return &SchemaError{
-		Value:       schema.Type,
+		Value:       typ,
 		Schema:      schema,
 		SchemaField: "type",
-		Reason:      "Field must be set to " + typ + " or not be present",
+		Reason:      "Field must be set to " + schema.Type + " or not be present",
 	}
 }
 


### PR DESCRIPTION
Fixing the schema error to state the value as the type passed in and in the reason state what the type should have been. Before this fix it was backwards which made reading the error confusing.