### PR TITLE
Fix server url matching

### DIFF
--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"context"
 	"errors"
+	"math"
 	"net/url"
 	"strings"
 )
@@ -75,8 +76,16 @@ func (server Server) MatchRawURL(input string) ([]string, string, bool) {
 			}
 			pattern = pattern[i+1:]
 
-			// Find next '.' or '/'
-			i = strings.IndexAny(input, "./")
+			// Find next matching pattern character or next '/' whichever comes first
+			np := strings.IndexByte(input, pattern[0])
+			ns := strings.IndexByte(input, '/')
+			if np < 0 {
+				i = ns
+			} else if ns < 0 {
+				i = np
+			} else {
+				i = int(math.Min(float64(np), float64(ns)))
+			}
 			if i < 0 {
 				i = len(input)
 			}

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -77,8 +77,12 @@ func (server Server) MatchRawURL(input string) ([]string, string, bool) {
 			pattern = pattern[i+1:]
 
 			// Find next matching pattern character or next '/' whichever comes first
-			np := strings.IndexByte(input, pattern[0])
+			np := -1
+			if len(pattern) > 0 {
+				np = strings.IndexByte(input, pattern[0])
+			}
 			ns := strings.IndexByte(input, '/')
+
 			if np < 0 {
 				i = ns
 			} else if ns < 0 {

--- a/openapi3/server_test.go
+++ b/openapi3/server_test.go
@@ -20,7 +20,7 @@ func TestServerParamNames(t *testing.T) {
 
 func TestServerParamValuesWithPath(t *testing.T) {
 	server := &openapi3.Server{
-		URL: "http://{arg0}.{arg1}.example.com/a/{arg3}-version/{arg4}c",
+		URL: "http://{arg0}.{arg1}.example.com/a/{arg3}-version/{arg4}c{arg5}",
 	}
 	for input, expected := range map[string]*serverMatch{
 		"http://x.example.com/a/b":                                    nil,
@@ -29,12 +29,12 @@ func TestServerParamValuesWithPath(t *testing.T) {
 		"http://x.y.example.com/a/c":                                  nil,
 		"http://baddomain.com/.example.com/a/1.0.0-version/c/d":       nil,
 		"http://baddomain.com/.example.com/a/1.0.0/2/2.0.0-version/c": nil,
-		"http://x.y.example.com/a/b-version/prefixedc":                newServerMatch("/", "x", "y", "b", "prefixed"),
-		"http://x.y.example.com/a/b-version/c":                        newServerMatch("/", "x", "y", "b", ""),
-		"http://x.y.example.com/a/b-version/c/":                       newServerMatch("/", "x", "y", "b", ""),
-		"http://x.y.example.com/a/b-version/c/d":                      newServerMatch("/d", "x", "y", "b", ""),
-		"http://domain0.domain1.example.com/a/b-version/c/d":          newServerMatch("/d", "domain0", "domain1", "b", ""),
-		"http://domain0.domain1.example.com/a/1.0.0-version/c/d":      newServerMatch("/d", "domain0", "domain1", "1.0.0", ""),
+		"http://x.y.example.com/a/b-version/prefixedc":                newServerMatch("/", "x", "y", "b", "prefixed", ""),
+		"http://x.y.example.com/a/b-version/c":                        newServerMatch("/", "x", "y", "b", "", ""),
+		"http://x.y.example.com/a/b-version/c/":                       newServerMatch("/", "x", "y", "b", "", ""),
+		"http://x.y.example.com/a/b-version/c/d":                      newServerMatch("/d", "x", "y", "b", "", ""),
+		"http://domain0.domain1.example.com/a/b-version/c/d":          newServerMatch("/d", "domain0", "domain1", "b", "", ""),
+		"http://domain0.domain1.example.com/a/1.0.0-version/c/d":      newServerMatch("/d", "domain0", "domain1", "1.0.0", "", ""),
 	} {
 		t.Run(input, testServerParamValues(t, server, input, expected))
 	}

--- a/openapi3/server_test.go
+++ b/openapi3/server_test.go
@@ -20,16 +20,21 @@ func TestServerParamNames(t *testing.T) {
 
 func TestServerParamValuesWithPath(t *testing.T) {
 	server := &openapi3.Server{
-		URL: "http://{arg0}.{arg1}.example.com/a/b",
+		URL: "http://{arg0}.{arg1}.example.com/a/{arg3}-version/{arg4}c",
 	}
 	for input, expected := range map[string]*serverMatch{
-		"http://x.example.com/a/b":                 nil,
-		"http://x.y.example.com/":                  nil,
-		"http://x.y.example.com/a/":                nil,
-		"http://x.y.example.com/a/b":               newServerMatch("/", "x", "y"),
-		"http://x.y.example.com/a/b/":              newServerMatch("/", "x", "y"),
-		"http://x.y.example.com/a/b/c":             newServerMatch("/c", "x", "y"),
-		"http://domain0.domain1.example.com/a/b/c": newServerMatch("/c", "domain0", "domain1"),
+		"http://x.example.com/a/b":                                    nil,
+		"http://x.y.example.com/":                                     nil,
+		"http://x.y.example.com/a/":                                   nil,
+		"http://x.y.example.com/a/c":                                  nil,
+		"http://baddomain.com/.example.com/a/1.0.0-version/c/d":       nil,
+		"http://baddomain.com/.example.com/a/1.0.0/2/2.0.0-version/c": nil,
+		"http://x.y.example.com/a/b-version/prefixedc":                newServerMatch("/", "x", "y", "b", "prefixed"),
+		"http://x.y.example.com/a/b-version/c":                        newServerMatch("/", "x", "y", "b", ""),
+		"http://x.y.example.com/a/b-version/c/":                       newServerMatch("/", "x", "y", "b", ""),
+		"http://x.y.example.com/a/b-version/c/d":                      newServerMatch("/d", "x", "y", "b", ""),
+		"http://domain0.domain1.example.com/a/b-version/c/d":          newServerMatch("/d", "domain0", "domain1", "b", ""),
+		"http://domain0.domain1.example.com/a/1.0.0-version/c/d":      newServerMatch("/d", "domain0", "domain1", "1.0.0", ""),
 	} {
 		t.Run(input, testServerParamValues(t, server, input, expected))
 	}


### PR DESCRIPTION
Current `MatchRawUrl` implementation for an openapi3 `Server` attempts to skip the url input to either `.` or `/` characters when encountering a variable instead of continuing to match the expected template:
https://github.com/getkin/kin-openapi/blob/c856265a25d59d95e8fcb863d779da672c0ac489/openapi3/server.go#L79

This fails in instances where a user is trying to match prefixed or suffixed templates:
- `http://example.com/a/prefix-{arg3}-suffix`
or simply trying to match any variable with a `.` in the value:
- `http://example.com/a/1.0.0` does not match `http://example.com/a/{arg3}` but `http://example.com/a/1-0-0` does.

This fix replaces `.` with the next character in the pattern or `/` whichever comes first.