### PR TITLE
Resolve relative documents

### DIFF
--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"github.com/getkin/kin-openapi/jsoninfo"
 )
 
 type Header struct {
@@ -12,6 +13,10 @@ type Header struct {
 
 	// Optional schema
 	Schema *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+}
+
+func (value *Header) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, value)
 }
 
 func (value *Header) Validate(c context.Context) error {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -56,6 +57,38 @@ func (swaggerLoader *SwaggerLoader) loadSwaggerFromURIInternal(location *url.URL
 		return nil, err
 	}
 	return swaggerLoader.loadSwaggerFromDataWithPathInternal(data, location)
+}
+
+// loadSingleElementFromURI read the data from ref and unmarshal to JSON to the
+// passed element.
+func (swaggerLoader *SwaggerLoader) loadSingleElementFromURI(ref string, rootPath *url.URL, element json.Unmarshaler) error {
+	if !swaggerLoader.IsExternalRefsAllowed {
+		return fmt.Errorf("Encountered non-allowed external reference: '%s'", ref)
+	}
+
+	parsedURL, err := url.Parse(ref)
+	if err != nil {
+		return err
+	}
+
+	if parsedURL.Fragment != "" {
+		panic("DO NOT CALL this function with files which contains more than one element definition")
+	}
+
+	resolvedPath, err := resolvePath(rootPath, parsedURL)
+	if err != nil {
+		return fmt.Errorf("Error while resolving path: %v", err)
+	}
+
+	data, err := readUrl(resolvedPath)
+	if err != nil {
+		return err
+	}
+	if err := yaml.Unmarshal(data, element); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func readUrl(location *url.URL) ([]byte, error) {
@@ -206,6 +239,10 @@ func resolvePath(basePath *url.URL, componentPath *url.URL) (*url.URL, error) {
 		return join(basePath, componentPath)
 	}
 	return componentPath, nil
+}
+
+func isSingleRefElement(ref string) bool {
+	return !strings.Contains(ref, "#")
 }
 
 func (swaggerLoader *SwaggerLoader) resolveComponent(swagger *Swagger, ref string, prefix string, path *url.URL) (
@@ -404,22 +441,32 @@ func (swaggerLoader *SwaggerLoader) resolveResponseRef(swagger *Swagger, compone
 	// Resolve ref
 	const prefix = "#/components/responses/"
 	if ref := component.Ref; len(ref) > 0 {
-		components, id, componentPath, err := swaggerLoader.resolveComponent(swagger, ref, prefix, path)
-		if err != nil {
-			return err
+
+		if isSingleRefElement(ref) {
+			var resp Response
+			if err := swaggerLoader.loadSingleElementFromURI(ref, path, &resp); err != nil {
+				return err
+			}
+
+			component.Value = &resp
+		} else {
+			components, id, componentPath, err := swaggerLoader.resolveComponent(swagger, ref, prefix, path)
+			if err != nil {
+				return err
+			}
+			definitions := components.Responses
+			if definitions == nil {
+				return failedToResolveRefFragmentPart(ref, "responses")
+			}
+			resolved := definitions[id]
+			if resolved == nil {
+				return failedToResolveRefFragmentPart(ref, id)
+			}
+			if err := swaggerLoader.resolveResponseRef(swagger, resolved, componentPath); err != nil {
+				return err
+			}
+			component.Value = resolved.Value
 		}
-		definitions := components.Responses
-		if definitions == nil {
-			return failedToResolveRefFragmentPart(ref, "responses")
-		}
-		resolved := definitions[id]
-		if resolved == nil {
-			return failedToResolveRefFragmentPart(ref, id)
-		}
-		if err := swaggerLoader.resolveResponseRef(swagger, resolved, componentPath); err != nil {
-			return err
-		}
-		component.Value = resolved.Value
 	}
 	value := component.Value
 	if value == nil {

--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -63,7 +63,7 @@ func (swaggerLoader *SwaggerLoader) loadSwaggerFromURIInternal(location *url.URL
 // passed element.
 func (swaggerLoader *SwaggerLoader) loadSingleElementFromURI(ref string, rootPath *url.URL, element json.Unmarshaler) error {
 	if !swaggerLoader.IsExternalRefsAllowed {
-		return fmt.Errorf("Encountered non-allowed external reference: '%s'", ref)
+		return fmt.Errorf("encountered non-allowed external reference: '%s'", ref)
 	}
 
 	parsedURL, err := url.Parse(ref)
@@ -72,12 +72,12 @@ func (swaggerLoader *SwaggerLoader) loadSingleElementFromURI(ref string, rootPat
 	}
 
 	if parsedURL.Fragment != "" {
-		panic("References to files which contains more than one element definition are not supported")
+		return errors.New("references to files which contain more than one element definition are not supported")
 	}
 
 	resolvedPath, err := resolvePath(rootPath, parsedURL)
 	if err != nil {
-		return fmt.Errorf("Error while resolving path: %v", err)
+		return fmt.Errorf("could not resolve path: %v", err)
 	}
 
 	data, err := readUrl(resolvedPath)

--- a/openapi3/swagger_loader_relative_refs_test.go
+++ b/openapi3/swagger_loader_relative_refs_test.go
@@ -903,4 +903,3 @@ paths:
   /pets:
     $ref: relativeDocs/CustomTestPath.yml
 `
-

--- a/openapi3/swagger_loader_relative_refs_test.go
+++ b/openapi3/swagger_loader_relative_refs_test.go
@@ -716,3 +716,191 @@ const externalRequestResponseHeaderRefTemplate = `
         }
     }
 }`
+
+// Relative Schema Documents Tests
+var relativeDocRefsTestDataEntries = []refTestDataEntry{
+	{
+		name:            "SchemaRef",
+		contentTemplate: relativeSchemaDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.Schemas["TestSchema"].Value.Type)
+			require.Equal(t, "string", swagger.Components.Schemas["TestSchema"].Value.Type)
+		},
+	},
+	{
+		name:            "ResponseRef",
+		contentTemplate: relativeResponseDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.Responses["TestResponse"].Value.Description)
+			require.Equal(t, "description", swagger.Components.Responses["TestResponse"].Value.Description)
+		},
+	},
+	{
+		name:            "ParameterRef",
+		contentTemplate: relativeParameterDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.Parameters["TestParameter"].Value.Name)
+			require.Equal(t, "param", swagger.Components.Parameters["TestParameter"].Value.Name)
+			require.Equal(t, true, swagger.Components.Parameters["TestParameter"].Value.Required)
+		},
+	},
+	{
+		name:            "ExampleRef",
+		contentTemplate: relativeExampleDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.Examples["TestExample"].Value.Summary)
+			require.NotNil(t, "param", swagger.Components.Examples["TestExample"].Value.Value)
+			require.Equal(t, "An example", swagger.Components.Examples["TestExample"].Value.Summary)
+		},
+	},
+	{
+		name:            "RequestRef",
+		contentTemplate: relativeRequestDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.RequestBodies["TestRequestBody"].Value.Description)
+			require.Equal(t, "example request", swagger.Components.RequestBodies["TestRequestBody"].Value.Description)
+		},
+	},
+	{
+		name:            "HeaderRef",
+		contentTemplate: relativeHeaderDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.Headers["TestHeader"].Value.Description)
+			require.Equal(t, "description", swagger.Components.Headers["TestHeader"].Value.Description)
+		},
+	},
+	{
+		name:            "HeaderRef",
+		contentTemplate: relativeHeaderDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, "param", swagger.Components.Headers["TestHeader"].Value.Description)
+			require.Equal(t, "description", swagger.Components.Headers["TestHeader"].Value.Description)
+		},
+	},
+	{
+		name:            "SecuritySchemeRef",
+		contentTemplate: relativeSecuritySchemeDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Type)
+			require.NotNil(t, swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Scheme)
+			require.Equal(t, "http", swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Type)
+			require.Equal(t, "basic", swagger.Components.SecuritySchemes["TestSecurityScheme"].Value.Scheme)
+		},
+	},
+	{
+		name:            "PathRef",
+		contentTemplate: relativePathDocsRefTemplate,
+		testFunc: func(t *testing.T, swagger *openapi3.Swagger) {
+			require.NotNil(t, swagger.Paths["/pets"])
+			require.NotNil(t, swagger.Paths["/pets"].Get.Responses["200"])
+			require.NotNil(t, swagger.Paths["/pets"].Get.Responses["200"].Value.Content["application/json"])
+		},
+	},
+}
+
+func TestLoadSpecWithRelativeDocumentRefs(t *testing.T) {
+	for _, td := range relativeDocRefsTestDataEntries {
+		t.Logf("testcase '%s'", td.name)
+
+		spec := []byte(td.contentTemplate)
+		loader := openapi3.NewSwaggerLoader()
+		loader.IsExternalRefsAllowed = true
+		swagger, err := loader.LoadSwaggerFromDataWithPath(spec, &url.URL{Path: "testdata/"})
+		require.NoError(t, err)
+		td.testFunc(t, swagger)
+	}
+}
+
+const relativeSchemaDocsRefTemplate = `
+openapi: 3.0.0
+info: 
+  title: ""
+  version: "1.0"
+paths: {}
+components: 
+  schemas: 
+    TestSchema: 
+      $ref: relativeDocs/CustomTestSchema.yml
+`
+
+const relativeResponseDocsRefTemplate = `
+openapi: 3.0.0
+info: 
+  title: ""
+  version: "1.0"
+paths: {}
+components: 
+  responses: 
+    TestResponse: 
+      $ref: relativeDocs/CustomTestResponse.yml
+`
+
+const relativeParameterDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  parameters:
+    TestParameter: 
+      $ref: relativeDocs/CustomTestParameter.yml
+`
+
+const relativeExampleDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  examples:
+    TestExample:
+      $ref: relativeDocs/CustomTestExample.yml
+`
+
+const relativeRequestDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  requestBodies:
+    TestRequestBody:
+      $ref: relativeDocs/CustomTestRequestBody.yml
+`
+
+const relativeHeaderDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  headers:
+    TestHeader:
+      $ref: relativeDocs/CustomTestHeader.yml
+`
+
+const relativeSecuritySchemeDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "1.0"
+paths: {}
+components:
+  securitySchemes:
+    TestSecurityScheme:
+      $ref: relativeDocs/CustomTestSecurityScheme.yml
+`
+const relativePathDocsRefTemplate = `
+openapi: 3.0.0
+info:
+  title: ""
+  version: "2.0"
+paths:
+  /pets:
+    $ref: relativeDocs/CustomTestPath.yml
+`
+

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -443,4 +443,3 @@ func TestLoadYamlFileWithExternalPathRef(t *testing.T) {
 	require.NotNil(t, swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
 	require.Equal(t, "string", swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
 }
-

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -325,6 +325,16 @@ func TestLoadFileWithExternalSchemaRef(t *testing.T) {
 	require.NotNil(t, swagger.Components.Schemas["AnotherTestSchema"].Value.Type)
 }
 
+func TestLoadFileWithExternalSchemaRefSingleComponent(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromFile("testdata/testrefsinglecomponent.openapi.json")
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Components.Responses["SomeResponse"])
+	require.Equal(t, "this is a single response definition", swagger.Components.Responses["SomeResponse"].Value.Description)
+}
+
 func TestLoadRequestResponseHeaderRef(t *testing.T) {
 	spec := []byte(`
 {
@@ -432,4 +442,14 @@ func TestLoadYamlFileWithExternalPathRef(t *testing.T) {
 
 	require.NotNil(t, swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
 	require.Equal(t, "string", swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
+}
+
+func TestLoadYamlFileWithExternalSchemaRefSingleComponent(t *testing.T) {
+	loader := openapi3.NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	swagger, err := loader.LoadSwaggerFromFile("testdata/testrefsinglecomponent.openapi.yml")
+	require.NoError(t, err)
+
+	require.NotNil(t, swagger.Components.Responses["SomeResponse"])
+	require.Equal(t, "this is a single response definition", swagger.Components.Responses["SomeResponse"].Value.Description)
 }

--- a/openapi3/swagger_loader_test.go
+++ b/openapi3/swagger_loader_test.go
@@ -444,12 +444,3 @@ func TestLoadYamlFileWithExternalPathRef(t *testing.T) {
 	require.Equal(t, "string", swagger.Paths["/test"].Get.Responses["200"].Value.Content["application/json"].Schema.Value.Type)
 }
 
-func TestLoadYamlFileWithExternalSchemaRefSingleComponent(t *testing.T) {
-	loader := openapi3.NewSwaggerLoader()
-	loader.IsExternalRefsAllowed = true
-	swagger, err := loader.LoadSwaggerFromFile("testdata/testrefsinglecomponent.openapi.yml")
-	require.NoError(t, err)
-
-	require.NotNil(t, swagger.Components.Responses["SomeResponse"])
-	require.Equal(t, "this is a single response definition", swagger.Components.Responses["SomeResponse"].Value.Description)
-}

--- a/openapi3/testdata/relativeDocs/CustomTestExample.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestExample.yml
@@ -1,0 +1,5 @@
+summary: An example
+value: |
+        {
+          "example": "hello"
+        }

--- a/openapi3/testdata/relativeDocs/CustomTestHeader.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestHeader.yml
@@ -1,0 +1,1 @@
+description: description

--- a/openapi3/testdata/relativeDocs/CustomTestParameter.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestParameter.yml
@@ -1,0 +1,3 @@
+name: param
+in: path
+required: true

--- a/openapi3/testdata/relativeDocs/CustomTestPath.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestPath.yml
@@ -1,0 +1,14 @@
+get:
+  operationId: findAllDefinitions
+  responses:
+    "200":
+      content:
+        application/json:
+          schema:
+            properties:
+              pets:
+                items:
+                  type: array
+                  properties:
+                    repository:
+                      name: string

--- a/openapi3/testdata/relativeDocs/CustomTestRequestBody.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestRequestBody.yml
@@ -1,0 +1,1 @@
+description: example request

--- a/openapi3/testdata/relativeDocs/CustomTestResponse.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestResponse.yml
@@ -1,0 +1,1 @@
+description: description

--- a/openapi3/testdata/relativeDocs/CustomTestSchema.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestSchema.yml
@@ -1,0 +1,1 @@
+type: string

--- a/openapi3/testdata/relativeDocs/CustomTestSecurityScheme.yml
+++ b/openapi3/testdata/relativeDocs/CustomTestSecurityScheme.yml
@@ -1,0 +1,2 @@
+type: http
+scheme: basic

--- a/openapi3/testdata/singleresponse.openapi.json
+++ b/openapi3/testdata/singleresponse.openapi.json
@@ -1,0 +1,3 @@
+{
+  "description": "this is a single response definition"
+}

--- a/openapi3/testdata/singleresponse.openapi.yml
+++ b/openapi3/testdata/singleresponse.openapi.yml
@@ -1,0 +1,2 @@
+---
+description: this is a single response definition

--- a/openapi3/testdata/testrefsinglecomponent.openapi.json
+++ b/openapi3/testdata/testrefsinglecomponent.openapi.json
@@ -1,0 +1,15 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "",
+        "version": "1"
+    },
+    "paths": {},
+    "components": {
+        "responses": {
+            "SomeResponse": {
+                "$ref": "singleresponse.openapi.json"
+            }
+        }
+    }
+}

--- a/openapi3/testdata/testrefsinglecomponent.openapi.yml
+++ b/openapi3/testdata/testrefsinglecomponent.openapi.yml
@@ -1,0 +1,10 @@
+---
+openapi: 3.0.0
+info:
+  title: 'OAI Specification w/ refs in YAML'
+  version: '1'
+paths: {}
+components:
+  responses:
+    SomeResponse:
+      "$ref": singleresponse.openapi.yml


### PR DESCRIPTION
This pull request builds on this [proof of concept](https://github.com/getkin/kin-openapi/pull/81) to give `kin-openapi` the feature to resolve relative documents for OpenAPI 3 specs.

It can resolve relative document references for:

- examples
- headers
- parameters
- request bodies
- responses
- schemas
- security schemes
- paths

and includes tests for all of these.