### PR TITLE
Allow any type of default and serialize v3 parameter schema

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -155,7 +155,7 @@ type Parameter struct {
 	MinLength    uint64              `json:"minLength,omitempty"`
 	MaxLength    *uint64             `json:"maxLength,omitempty"`
 	Pattern      string              `json:"pattern,omitempty"`
-	Default      string              `json:"default,omitempty"`
+	Default      interface{}         `json:"default,omitempty"`
 }
 
 type Response struct {

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -189,6 +189,7 @@ func ToV3Parameter(parameter *openapi2.Parameter) (*openapi3.ParameterRef, *open
 				ExclusiveMax: parameter.ExclusiveMax,
 				MinLength:    parameter.MinLength,
 				MaxLength:    parameter.MaxLength,
+				Default:      parameter.Default,
 			},
 		}
 	}
@@ -461,7 +462,6 @@ func FromV3Parameter(ref *openapi3.ParameterRef) (*openapi2.Parameter, error) {
 		In:          parameter.In,
 		Name:        parameter.Name,
 		Required:    parameter.Required,
-		Schema:      parameter.Schema,
 	}
 	if schemaRef := parameter.Schema; schemaRef != nil {
 		schema := schemaRef.Value
@@ -469,12 +469,13 @@ func FromV3Parameter(ref *openapi3.ParameterRef) (*openapi2.Parameter, error) {
 		result.Format = schema.Format
 		result.Enum = schema.Enum
 		result.Minimum = schema.Min
-		result.Maximum = schema.Min
+		result.Maximum = schema.Max
 		result.ExclusiveMin = schema.ExclusiveMin
 		result.ExclusiveMax = schema.ExclusiveMax
 		result.MinLength = schema.MinLength
 		result.MaxLength = schema.MaxLength
 		result.Pattern = schema.Pattern
+		result.Default = schema.Default
 	}
 	return result, nil
 }

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -63,6 +63,15 @@ const exampleV2 = `
             "name": "x"
           },
           {
+            "in": "query",
+            "name": "y",
+            "description": "The y parameter",
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10000,
+            "default": 250
+          },
+          {
             "in": "body",
             "name": "body",
             "schema": {}
@@ -151,6 +160,17 @@ const exampleV3 = `
           {
             "in": "query",
             "name": "x"
+          },
+          {
+            "description": "The y parameter",
+            "in": "query",
+            "name": "y",
+            "schema": {
+              "default": 250,
+              "maximum": 10000,
+              "minimum": 1,
+              "type": "integer"
+            }
           }
         ],
         "requestBody": {


### PR DESCRIPTION
This makes it so the [v2 parameter default](https://swagger.io/docs/specification/2-0/describing-parameters/#default) is included as the [v3 parameter schema default](https://swagger.io/docs/specification/describing-parameters/#default).

Also includes a fix for serializing the v3 parameter schema max as a v2 parameter maximum.

Test change covers both.