### PR TITLE
Tags at the root

### DIFF
--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -12,11 +12,10 @@ import (
 
 func ToV3Swagger(swagger *openapi2.Swagger) (*openapi3.Swagger, error) {
 	result := &openapi3.Swagger{
-		OpenAPI: "3.0",
-		Info:    &swagger.Info,
-		Components: openapi3.Components{
-			Tags: swagger.Tags,
-		},
+		OpenAPI:    "3.0",
+		Info:       &swagger.Info,
+		Components: openapi3.Components{},
+		Tags:       swagger.Tags,
 	}
 	host := swagger.Host
 	if len(host) > 0 {
@@ -273,7 +272,7 @@ func ToV3SecurityScheme(securityScheme *openapi2.SecurityScheme) (*openapi3.Secu
 func FromV3Swagger(swagger *openapi3.Swagger) (*openapi2.Swagger, error) {
 	result := &openapi2.Swagger{
 		Info: *swagger.Info,
-		Tags: swagger.Components.Tags,
+		Tags: swagger.Tags,
 	}
 	isHTTPS := false
 	isHTTP := false

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -40,6 +40,12 @@ const exampleV2 = `
   "schemes": ["https"],
   "host": "test.example.com",
   "basePath": "/v2",
+  "tags": [
+    {
+      "name": "Example",
+      "description": "An example tag."
+    }
+  ],
   "paths": {
     "/example": {
       "delete": {
@@ -57,6 +63,9 @@ const exampleV2 = `
         "operationId": "example-get",
         "summary": "example get",
         "description": "example get",
+        "tags": [
+          "Example"
+        ],
         "parameters": [
           {
             "in": "query",
@@ -125,6 +134,12 @@ const exampleV3 = `
   "openapi": "3.0",
   "info": {"title":"MyAPI","version":"0.1"},
   "components": {},
+  "tags": [
+    {
+      "name": "Example",
+      "description": "An example tag."
+    }
+  ],
   "servers": [
     {
       "url": "https://test.example.com/v2"
@@ -147,6 +162,9 @@ const exampleV3 = `
         "operationId": "example-get",
         "summary": "example get",
         "description": "example get",
+        "tags": [
+          "Example"
+        ],
         "parameters": [
           {
             "in": "query",

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -18,7 +18,6 @@ type Components struct {
 	Responses       map[string]*ResponseRef       `json:"responses,omitempty" yaml:"responses,omitempty"`
 	SecuritySchemes map[string]*SecuritySchemeRef `json:"securitySchemes,omitempty" yaml:"securitySchemes,omitempty"`
 	Examples        map[string]*ExampleRef        `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Tags            Tags                          `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Links           map[string]*LinkRef           `json:"links,omitempty" yaml:"links,omitempty"`
 	Callbacks       map[string]*CallbackRef       `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
 }

--- a/openapi3/swagger.go
+++ b/openapi3/swagger.go
@@ -15,6 +15,7 @@ type Swagger struct {
 	Servers      Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Paths        Paths                `json:"paths" yaml:"paths"` // Required
 	Components   Components           `json:"components,omitempty" yaml:"components,omitempty"`
+	Tags         Tags                 `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Security     SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
 	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }


### PR DESCRIPTION
This moves tags in v3 from `components` to the root.  See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#openapi-object.