### PR TITLE
Use the full version specifier

### DIFF
--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -12,7 +12,7 @@ import (
 
 func ToV3Swagger(swagger *openapi2.Swagger) (*openapi3.Swagger, error) {
 	result := &openapi3.Swagger{
-		OpenAPI:    "3.0",
+		OpenAPI:    "3.0.2",
 		Info:       &swagger.Info,
 		Components: openapi3.Components{},
 		Tags:       swagger.Tags,

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -140,7 +140,7 @@ const exampleV2 = `
 
 const exampleV3 = `
 {
-  "openapi": "3.0",
+  "openapi": "3.0.2",
   "info": {"title":"MyAPI","version":"0.1"},
   "components": {},
   "tags": [


### PR DESCRIPTION
The [OpenAPI spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md) requires that the full version identifier be used.