### PR TITLE
Rewrite refs to definitions and responses

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -155,6 +155,9 @@ type Parameter struct {
 	MinLength    uint64              `json:"minLength,omitempty"`
 	MaxLength    *uint64             `json:"maxLength,omitempty"`
 	Pattern      string              `json:"pattern,omitempty"`
+	Items        *openapi3.SchemaRef `json:"items,omitempty"`
+	MinItems     uint64              `json:"minItems,omitempty"`
+	MaxItems     *uint64             `json:"maxItems,omitempty"`
 	Default      interface{}         `json:"default,omitempty"`
 }
 

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -75,7 +75,7 @@ func ToV3Swagger(swagger *openapi2.Swagger) (*openapi3.Swagger, error) {
 			result.Components.Responses[k] = r
 		}
 	}
-	result.Components.Schemas = swagger.Definitions
+	result.Components.Schemas = ToV3Schemas(swagger.Definitions)
 	if m := swagger.SecurityDefinitions; m != nil {
 		resultSecuritySchemes := make(map[string]*openapi3.SecuritySchemeRef)
 		for k, v := range m {
@@ -164,7 +164,7 @@ func ToV3Parameter(parameter *openapi2.Parameter) (*openapi3.ParameterRef, *open
 		}
 		if schemaRef := parameter.Schema; schemaRef != nil {
 			// Assume it's JSON
-			result.WithJSONSchemaRef(schemaRef)
+			result.WithJSONSchemaRef(ToV3SchemaRef(schemaRef))
 		}
 		return nil, &openapi3.RequestBodyRef{
 			Value: result,
@@ -175,10 +175,10 @@ func ToV3Parameter(parameter *openapi2.Parameter) (*openapi3.ParameterRef, *open
 		Name:        parameter.Name,
 		Description: parameter.Description,
 		Required:    parameter.Required,
-		Schema:      parameter.Schema,
 	}
+
 	if parameter.Type != "" {
-		result.Schema = &openapi3.SchemaRef{
+		schema := &openapi3.SchemaRef{
 			Value: &openapi3.Schema{
 				Type:         parameter.Type,
 				Format:       parameter.Format,
@@ -190,8 +190,12 @@ func ToV3Parameter(parameter *openapi2.Parameter) (*openapi3.ParameterRef, *open
 				MinLength:    parameter.MinLength,
 				MaxLength:    parameter.MaxLength,
 				Default:      parameter.Default,
+				Items:        parameter.Items,
+				MinItems:     parameter.MinItems,
+				MaxItems:     parameter.MaxItems,
 			},
 		}
+		result.Schema = ToV3SchemaRef(schema)
 	}
 	return &openapi3.ParameterRef{
 		Value: result,
@@ -215,14 +219,28 @@ func ToV3Response(response *openapi2.Response) (*openapi3.ResponseRef, error) {
 	}, nil
 }
 
+func ToV3Schemas(defs map[string]*openapi3.SchemaRef) map[string]*openapi3.SchemaRef {
+	schemas := make(map[string]*openapi3.SchemaRef, len(defs))
+	for name, schema := range defs {
+		schemas[name] = ToV3SchemaRef(schema)
+	}
+	return schemas
+}
+
 func ToV3SchemaRef(schema *openapi3.SchemaRef) *openapi3.SchemaRef {
 	if ref := schema.Ref; len(ref) > 0 {
 		return &openapi3.SchemaRef{
 			Ref: ToV3Ref(ref),
 		}
 	}
-	if schema.Value != nil && schema.Value.Items != nil {
+	if schema.Value == nil {
+		return schema
+	}
+	if schema.Value.Items != nil {
 		schema.Value.Items = ToV3SchemaRef(schema.Value.Items)
+	}
+	for k, v := range schema.Value.Properties {
+		schema.Value.Properties[k] = ToV3SchemaRef(v)
 	}
 	return schema
 }
@@ -386,8 +404,14 @@ func FromV3SchemaRef(schema *openapi3.SchemaRef) *openapi3.SchemaRef {
 			Ref: FromV3Ref(ref),
 		}
 	}
-	if schema.Value != nil && schema.Value.Items != nil {
+	if schema.Value == nil {
+		return schema
+	}
+	if schema.Value.Items != nil {
 		schema.Value.Items = FromV3SchemaRef((schema.Value.Items))
+	}
+	for k, v := range schema.Value.Properties {
+		schema.Value.Properties[k] = FromV3SchemaRef(v)
 	}
 	return schema
 }
@@ -521,6 +545,7 @@ func FromV3Parameter(ref *openapi3.ParameterRef) (*openapi2.Parameter, error) {
 		Required:    parameter.Required,
 	}
 	if schemaRef := parameter.Schema; schemaRef != nil {
+		schemaRef = FromV3SchemaRef(schemaRef)
 		schema := schemaRef.Value
 		result.Type = schema.Type
 		result.Format = schema.Format
@@ -533,6 +558,9 @@ func FromV3Parameter(ref *openapi3.ParameterRef) (*openapi2.Parameter, error) {
 		result.MaxLength = schema.MaxLength
 		result.Pattern = schema.Pattern
 		result.Default = schema.Default
+		result.Items = schema.Items
+		result.MinItems = schema.MinItems
+		result.MaxItems = schema.MaxItems
 	}
 	return result, nil
 }

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -208,16 +208,23 @@ func ToV3Response(response *openapi2.Response) (*openapi3.ResponseRef, error) {
 		Description: response.Description,
 	}
 	if schemaRef := response.Schema; schemaRef != nil {
-		if ref := schemaRef.Ref; len(ref) > 0 {
-			schemaRef = &openapi3.SchemaRef{
-				Ref: ToV3Ref(ref),
-			}
-		}
-		result.WithJSONSchemaRef(schemaRef)
+		result.WithJSONSchemaRef(ToV3SchemaRef(schemaRef))
 	}
 	return &openapi3.ResponseRef{
 		Value: result,
 	}, nil
+}
+
+func ToV3SchemaRef(schema *openapi3.SchemaRef) *openapi3.SchemaRef {
+	if ref := schema.Ref; len(ref) > 0 {
+		return &openapi3.SchemaRef{
+			Ref: ToV3Ref(ref),
+		}
+	}
+	if schema.Value != nil && schema.Value.Items != nil {
+		schema.Value.Items = ToV3SchemaRef(schema.Value.Items)
+	}
+	return schema
 }
 
 var ref2To3 = map[string]string{
@@ -378,6 +385,9 @@ func FromV3SchemaRef(schema *openapi3.SchemaRef) *openapi3.SchemaRef {
 		return &openapi3.SchemaRef{
 			Ref: FromV3Ref(ref),
 		}
+	}
+	if schema.Value != nil && schema.Value.Items != nil {
+		schema.Value.Items = FromV3SchemaRef((schema.Value.Items))
 	}
 	return schema
 }

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -54,6 +54,9 @@ const exampleV2 = `
           "default": {
             "description": "default response"
           },
+          "403": {
+            "$ref": "#/responses/ForbiddenError"
+          },
           "404": {
             "description": "404 response"
           }
@@ -126,6 +129,28 @@ const exampleV2 = `
       }
     }
   },
+  "responses": {
+    "ForbiddenError": {
+      "description": "Insufficient permission to perform the requested action.",
+      "schema": {
+        "$ref": "#/definitions/Error"
+      }
+    }
+  },
+  "definitions": {
+    "Error": {
+      "description": "Error response.",
+      "type": "object",
+      "required": [
+        "message"
+      ],
+      "properties": {
+        "message": {
+          "type": "string"
+        }
+      }
+    }
+  },
   "security": [
     {
       "default_security_0": [
@@ -142,7 +167,34 @@ const exampleV3 = `
 {
   "openapi": "3.0",
   "info": {"title":"MyAPI","version":"0.1"},
-  "components": {},
+  "components": {
+    "responses": {
+      "ForbiddenError": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        },
+        "description": "Insufficient permission to perform the requested action."
+      }
+    },
+    "schemas": {
+      "Error": {
+        "description": "Error response.",
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "message"
+        ],
+        "type": "object"
+      }
+    }
+  },
   "tags": [
     {
       "name": "Example",
@@ -161,6 +213,9 @@ const exampleV3 = `
         "responses": {
           "default": {
             "description": "default response"
+          },
+          "403": {
+            "$ref": "#/components/responses/ForbiddenError"
           },
           "404": {
             "description": "404 response"

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -90,6 +90,15 @@ const exampleV2 = `
           }
         ],
         "responses": {
+          "200": {
+            "description": "ok",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Item"
+              }
+            }
+          },
           "default": {
             "description": "default response"
           },
@@ -138,6 +147,14 @@ const exampleV2 = `
     }
   },
   "definitions": {
+    "Item": {
+      "type": "object",
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      }
+    },
     "Error": {
       "description": "Error response.",
       "type": "object",
@@ -181,6 +198,14 @@ const exampleV3 = `
       }
     },
     "schemas": {
+      "Item": {
+        "type": "object",
+        "properties": {
+          "foo": {
+            "type": "string"
+          }
+        }
+      },
       "Error": {
         "description": "Error response.",
         "properties": {
@@ -254,6 +279,19 @@ const exampleV3 = `
           }
         },
         "responses": {
+          "200": {
+            "description": "ok",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Item"
+                  },
+                  "type": "array"
+                }
+              }
+            }
+          },
           "default": {
             "description": "default response"
           },

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -84,6 +84,17 @@ const exampleV2 = `
             "default": 250
           },
           {
+            "in": "query",
+            "name": "bbox",
+            "description": "Only return results that intersect the provided bounding box.",
+            "maxItems": 4,
+            "minItems": 4,
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          {
             "in": "body",
             "name": "body",
             "schema": {}
@@ -268,6 +279,19 @@ const exampleV3 = `
               "maximum": 10000,
               "minimum": 1,
               "type": "integer"
+            }
+          },
+          {
+            "description": "Only return results that intersect the provided bounding box.",
+            "in": "query",
+            "name": "bbox",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "maxItems": 4
             }
           }
         ],


### PR DESCRIPTION
This rewrites refs to definitions and responses and includes those members when creating a v2 spec from a v3 spec.

Fixes #75.