### PR TITLE
Add Vulcain to the list of projects using kin-openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Here's some projects that depend on _kin-openapi_:
   * [github.com/getkin/kin](https://github.com/getkin/kin) - "A configurable backend"
   * [github.com/danielgtaylor/apisprout](https://github.com/danielgtaylor/apisprout) - "Lightweight, blazing fast, cross-platform OpenAPI 3 mock server with validation"
   * [github.com/deepmap/oapi-codegen](https://github.com/deepmap/oapi-codegen) - Generate Go server boilerplate from an OpenAPI 3 spec
+  * [github.com/dunglas/vulcain](https//github.com/dunglas/vulcain) - "Use HTTP/2 Server Push to create fast and idiomatic client-driven REST APIs"
   * (Feel free to add your project by [creating an issue](https://github.com/getkin/kin-openapi/issues/new) or a pull request)
 
 ## Alternative projects


### PR DESCRIPTION
Thanks for this library! Vulcain uses kin-openapi especially for this part: https://github.com/dunglas/vulcain/blob/master/docs/gateway/openapi.md