### PR TITLE
Add some missing attributes to header object

### DIFF
--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
 
@@ -9,10 +10,13 @@ type Header struct {
 	ExtensionProps
 
 	// Optional description. Should use CommonMark syntax.
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-
-	// Optional schema
-	Schema *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Deprecated  bool                   `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Required    bool                   `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema      *SchemaRef             `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example     interface{}            `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples    map[string]*ExampleRef `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Content     Content                `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 func (value *Header) UnmarshalJSON(data []byte) error {


### PR DESCRIPTION
## Description

Accordingly to the spec, the header object supports almost everything that is supported in the parameter object. Thus, I've added some of these attributes to the header (though I haven't added all. There are still some missing ones, like style, that might need a bit more work)