### PR TITLE
Parse parameters in URL at validation time

### DIFF
--- a/openapi3filter/router.go
+++ b/openapi3filter/router.go
@@ -162,11 +162,14 @@ func (router *Router) FindRoute(method string, url *url.URL) (*Route, map[string
 				Reason: "Does not match any server",
 			}
 		}
-		pathParams = make(map[string]string, 8)
-		paramNames, _ := server.ParameterNames()
-		for i, value := range paramValues {
-			name := paramNames[i]
-			pathParams[name] = value
+		paramNames := server.VariableNamesInURL
+		s := len(paramNames)
+		if s > 0 {
+			pathParams = make(map[string]string, s)
+			for i, value := range paramValues {
+				name := paramNames[i]
+				pathParams[name] = value
+			}
 		}
 	}
 

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -110,7 +110,8 @@ func TestRouter(t *testing.T) {
 	swagger.Servers = append(swagger.Servers, &openapi3.Server{
 		URL: "https://www.example.com/api/v1/",
 	}, &openapi3.Server{
-		URL: "https://{d0}.{d1}.com/api/v1/",
+		URL:                "https://{d0}.{d1}.com/api/v1/",
+		VariableNamesInURL: []string{"d0", "d1"},
 	})
 	expect("GET", "/hello", nil, nil)
 	expect("GET", "/api/v1/hello", nil, nil)


### PR DESCRIPTION
There may have some parameters define in 'url' of servers definition
and those parameter names will be need to store parameter values. In
current implementation we will parse 'url' to get parameters name for
each incoming request, now change to parse parameters in 'url' at spec
definition validation time and store results to avoid parse it for
each incoming request.