### PR TITLE
Add strict marshal/unmarshal to ExternalDocs

### DIFF
--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -2,6 +2,8 @@ package openapi3
 
 // ExternalDocs is specified by OpenAPI/Swagger standard version 3.0.
 type ExternalDocs struct {
+	ExtensionProps
+
 	Description string `json:"description,omitempty"`
 	URL         string `json:"url,omitempty"`
 }

--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -1,9 +1,21 @@
 package openapi3
 
+import (
+	"github.com/getkin/kin-openapi/jsoninfo"
+)
+
 // ExternalDocs is specified by OpenAPI/Swagger standard version 3.0.
 type ExternalDocs struct {
 	ExtensionProps
 
 	Description string `json:"description,omitempty"`
 	URL         string `json:"url,omitempty"`
+}
+
+func (e *ExternalDocs) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(e)
+}
+
+func (e *ExternalDocs) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, e)
 }


### PR DESCRIPTION
My previous PR (https://github.com/getkin/kin-openapi/pull/163) added the `ExtensionProps` field to the `ExternalDocs` struct but forgot to include the strict marshal/unmarshal methods. 