### PR TITLE
Add missing ExternalDocs to Operation, change ExternalDocs in Schema to use correct type

### DIFF
--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -43,6 +43,8 @@ type Operation struct {
 
 	// Optional servers that overrides top-level servers.
 	Servers *Servers `json:"servers,omitempty" yaml:"servers,omitempty"`
+
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 func NewOperation() *Operation {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -60,7 +60,7 @@ type Schema struct {
 	Enum         []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Default      interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
 	Example      interface{}   `json:"example,omitempty" yaml:"example,omitempty"`
-	ExternalDocs interface{}   `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 
 	// Object-related, here for struct compactness
 	AdditionalPropertiesAllowed *bool `json:"-" multijson:"additionalProperties,omitempty" yaml:"-"`


### PR DESCRIPTION
This PR adds the missing `ExternalDocs` field to the `Operation` type, and modifies the existing `ExternalDocs` field in the `Schema` type to use the correct type instead of `interface{}`