### PR TITLE
Add `uuid` case so schema validation doesn't fail

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -516,6 +516,7 @@ func (schema *Schema) validate(c context.Context, stack []*Schema) (err error) {
 			case "hostname", "idn-hostname", "ipv4", "ipv6":
 			case "uri", "uri-reference", "iri", "iri-reference", "uri-template":
 			case "json-pointer", "relative-json-pointer":
+			case "uuid":
 			default:
 				// Try to check for custom defined formats
 				if _, ok := SchemaStringFormats[format]; !ok {


### PR DESCRIPTION
This PR adds an empty case for `uuid` so schema validation doesn't fail when processing OAS files containing a `format: uuid` attribute.