### PR TITLE
Change type of scopes in openapi2 to map[string]string

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getkin/kin-openapi
+module github.com/mbilski/kin-openapi
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -178,14 +178,14 @@ type Header struct {
 type SecurityRequirements []map[string][]string
 
 type SecurityScheme struct {
-	Ref              string        `json:"$ref,omitempty"`
-	Description      string        `json:"description,omitempty"`
-	Type             string        `json:"type,omitempty"`
-	In               string        `json:"in,omitempty"`
-	Name             string        `json:"name,omitempty"`
-	Flow             string        `json:"flow,omitempty"`
-	AuthorizationURL string        `json:"authorizationUrl,omitempty"`
-	TokenURL         string        `json:"tokenUrl,omitempty"`
-	Scopes           []string      `json:"scopes,omitempty"`
-	Tags             openapi3.Tags `json:"tags,omitempty"`
+	Ref              string            `json:"$ref,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	Type             string            `json:"type,omitempty"`
+	In               string            `json:"in,omitempty"`
+	Name             string            `json:"name,omitempty"`
+	Flow             string            `json:"flow,omitempty"`
+	AuthorizationURL string            `json:"authorizationUrl,omitempty"`
+	TokenURL         string            `json:"tokenUrl,omitempty"`
+	Scopes           map[string]string `json:"scopes,omitempty"`
+	Tags             openapi3.Tags     `json:"tags,omitempty"`
 }

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -643,8 +643,8 @@ func FromV3SecurityScheme(swagger *openapi3.Swagger, ref *openapi3.SecuritySchem
 			} else {
 				return nil, nil
 			}
-			for scope := range flow.Scopes {
-				result.Scopes = append(result.Scopes, scope)
+			for scope, desc := range flow.Scopes {
+				result.Scopes[scope] = desc
 			}
 		}
 	default:


### PR DESCRIPTION
According to the spec https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#scopesObject the scopes are map, not a list.

```
{
  "write:pets": "modify pets in your account",
  "read:pets": "read your pets"
}
```