### PR TITLE
Use `net/http` method constants

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -9,6 +9,7 @@ package openapi2
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -57,44 +58,44 @@ type PathItem struct {
 func (pathItem *PathItem) Operations() map[string]*Operation {
 	operations := make(map[string]*Operation, 8)
 	if v := pathItem.Delete; v != nil {
-		operations["DELETE"] = v
+		operations[http.MethodDelete] = v
 	}
 	if v := pathItem.Get; v != nil {
-		operations["GET"] = v
+		operations[http.MethodGet] = v
 	}
 	if v := pathItem.Head; v != nil {
-		operations["HEAD"] = v
+		operations[http.MethodHead] = v
 	}
 	if v := pathItem.Options; v != nil {
-		operations["OPTIONS"] = v
+		operations[http.MethodOptions] = v
 	}
 	if v := pathItem.Patch; v != nil {
-		operations["PATCH"] = v
+		operations[http.MethodPatch] = v
 	}
 	if v := pathItem.Post; v != nil {
-		operations["POST"] = v
+		operations[http.MethodPost] = v
 	}
 	if v := pathItem.Put; v != nil {
-		operations["PUT"] = v
+		operations[http.MethodPut] = v
 	}
 	return operations
 }
 
 func (pathItem *PathItem) GetOperation(method string) *Operation {
 	switch method {
-	case "DELETE":
+	case http.MethodDelete:
 		return pathItem.Delete
-	case "GET":
+	case http.MethodGet:
 		return pathItem.Get
-	case "HEAD":
+	case http.MethodHead:
 		return pathItem.Head
-	case "OPTIONS":
+	case http.MethodOptions:
 		return pathItem.Options
-	case "PATCH":
+	case http.MethodPatch:
 		return pathItem.Patch
-	case "POST":
+	case http.MethodPost:
 		return pathItem.Post
-	case "PUT":
+	case http.MethodPut:
 		return pathItem.Put
 	default:
 		panic(fmt.Errorf("Unsupported HTTP method '%s'", method))
@@ -103,19 +104,19 @@ func (pathItem *PathItem) GetOperation(method string) *Operation {
 
 func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
 	switch method {
-	case "DELETE":
+	case http.MethodDelete:
 		pathItem.Delete = operation
-	case "GET":
+	case http.MethodGet:
 		pathItem.Get = operation
-	case "HEAD":
+	case http.MethodHead:
 		pathItem.Head = operation
-	case "OPTIONS":
+	case http.MethodOptions:
 		pathItem.Options = operation
-	case "PATCH":
+	case http.MethodPatch:
 		pathItem.Patch = operation
-	case "POST":
+	case http.MethodPost:
 		pathItem.Post = operation
-	case "PUT":
+	case http.MethodPut:
 		pathItem.Put = operation
 	default:
 		panic(fmt.Errorf("Unsupported HTTP method '%s'", method))

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
@@ -36,54 +37,54 @@ func (pathItem *PathItem) UnmarshalJSON(data []byte) error {
 func (pathItem *PathItem) Operations() map[string]*Operation {
 	operations := make(map[string]*Operation, 4)
 	if v := pathItem.Connect; v != nil {
-		operations["CONNECT"] = v
+		operations[http.MethodConnect] = v
 	}
 	if v := pathItem.Delete; v != nil {
-		operations["DELETE"] = v
+		operations[http.MethodDelete] = v
 	}
 	if v := pathItem.Get; v != nil {
-		operations["GET"] = v
+		operations[http.MethodGet] = v
 	}
 	if v := pathItem.Head; v != nil {
-		operations["HEAD"] = v
+		operations[http.MethodHead] = v
 	}
 	if v := pathItem.Options; v != nil {
-		operations["OPTIONS"] = v
+		operations[http.MethodOptions] = v
 	}
 	if v := pathItem.Patch; v != nil {
-		operations["PATCH"] = v
+		operations[http.MethodPatch] = v
 	}
 	if v := pathItem.Post; v != nil {
-		operations["POST"] = v
+		operations[http.MethodPost] = v
 	}
 	if v := pathItem.Put; v != nil {
-		operations["PUT"] = v
+		operations[http.MethodPut] = v
 	}
 	if v := pathItem.Trace; v != nil {
-		operations["TRACE"] = v
+		operations[http.MethodTrace] = v
 	}
 	return operations
 }
 
 func (pathItem *PathItem) GetOperation(method string) *Operation {
 	switch method {
-	case "CONNECT":
+	case http.MethodConnect:
 		return pathItem.Connect
-	case "DELETE":
+	case http.MethodDelete:
 		return pathItem.Delete
-	case "GET":
+	case http.MethodGet:
 		return pathItem.Get
-	case "HEAD":
+	case http.MethodHead:
 		return pathItem.Head
-	case "OPTIONS":
+	case http.MethodOptions:
 		return pathItem.Options
-	case "PATCH":
+	case http.MethodPatch:
 		return pathItem.Patch
-	case "POST":
+	case http.MethodPost:
 		return pathItem.Post
-	case "PUT":
+	case http.MethodPut:
 		return pathItem.Put
-	case "TRACE":
+	case http.MethodTrace:
 		return pathItem.Trace
 	default:
 		panic(fmt.Errorf("Unsupported HTTP method '%s'", method))
@@ -92,23 +93,23 @@ func (pathItem *PathItem) GetOperation(method string) *Operation {
 
 func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
 	switch method {
-	case "CONNECT":
+	case http.MethodConnect:
 		pathItem.Connect = operation
-	case "DELETE":
+	case http.MethodDelete:
 		pathItem.Delete = operation
-	case "GET":
+	case http.MethodGet:
 		pathItem.Get = operation
-	case "HEAD":
+	case http.MethodHead:
 		pathItem.Head = operation
-	case "OPTIONS":
+	case http.MethodOptions:
 		pathItem.Options = operation
-	case "PATCH":
+	case http.MethodPatch:
 		pathItem.Patch = operation
-	case "POST":
+	case http.MethodPost:
 		pathItem.Post = operation
-	case "PUT":
+	case http.MethodPut:
 		pathItem.Put = operation
-	case "TRACE":
+	case http.MethodTrace:
 		pathItem.Trace = operation
 	default:
 		panic(fmt.Errorf("Unsupported HTTP method '%s'", method))

--- a/openapi3filter/router_test.go
+++ b/openapi3filter/router_test.go
@@ -128,31 +128,31 @@ func TestRouter(t *testing.T) {
 			}
 		}
 	}
-	expect("GET", "/not_existing", nil, nil)
-	expect("DELETE", "/hello", helloDELETE, nil)
-	expect("GET", "/hello", helloGET, nil)
-	expect("HEAD", "/hello", helloHEAD, nil)
-	expect("PATCH", "/hello", helloPATCH, nil)
-	expect("POST", "/hello", helloPOST, nil)
-	expect("PUT", "/hello", helloPUT, nil)
-	expect("GET", "/params/a/b/c/d", paramsGET, map[string]string{
+	expect(http.MethodGet, "/not_existing", nil, nil)
+	expect(http.MethodDelete, "/hello", helloDELETE, nil)
+	expect(http.MethodGet, "/hello", helloGET, nil)
+	expect(http.MethodHead, "/hello", helloHEAD, nil)
+	expect(http.MethodPatch, "/hello", helloPATCH, nil)
+	expect(http.MethodPost, "/hello", helloPOST, nil)
+	expect(http.MethodPut, "/hello", helloPUT, nil)
+	expect(http.MethodGet, "/params/a/b/c/d", paramsGET, map[string]string{
 		"x": "a",
 		"y": "b",
 		"z": "c/d",
 	})
-	expect("POST", "/partial", nil, nil)
+	expect(http.MethodPost, "/partial", nil, nil)
 	swagger.Servers = append(swagger.Servers, &openapi3.Server{
 		URL: "https://www.example.com/api/v1/",
 	}, &openapi3.Server{
 		URL: "https://{d0}.{d1}.com/api/v1/",
 	})
-	expect("GET", "/hello", nil, nil)
-	expect("GET", "/api/v1/hello", nil, nil)
-	expect("GET", "www.example.com/api/v1/hello", nil, nil)
-	expect("GET", "https:///api/v1/hello", nil, nil)
-	expect("GET", "https://www.example.com/hello", nil, nil)
-	expect("GET", "https://www.example.com/api/v1/hello", helloGET, map[string]string{})
-	expect("GET", "https://domain0.domain1.com/api/v1/hello", helloGET, map[string]string{
+	expect(http.MethodGet, "/hello", nil, nil)
+	expect(http.MethodGet, "/api/v1/hello", nil, nil)
+	expect(http.MethodGet, "www.example.com/api/v1/hello", nil, nil)
+	expect(http.MethodGet, "https:///api/v1/hello", nil, nil)
+	expect(http.MethodGet, "https://www.example.com/hello", nil, nil)
+	expect(http.MethodGet, "https://www.example.com/api/v1/hello", helloGET, map[string]string{})
+	expect(http.MethodGet, "https://domain0.domain1.com/api/v1/hello", helloGET, map[string]string{
 		"d0": "domain0",
 		"d1": "domain1",
 	})


### PR DESCRIPTION
Use the `net/http` method constants to the operation methods.

Currently, hardcoded by a naive string type. But each method already provided from the `net/http` package.
Also, `Operations` are certainly http(s) access operations. I think using them is not wrong.