### PR TITLE
fix: make link.Headers use HeaderRef

### DIFF
--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/getkin/kin-openapi/jsoninfo"
 )
@@ -9,11 +10,12 @@ import (
 // Link is specified by OpenAPI/Swagger standard version 3.0.
 type Link struct {
 	ExtensionProps
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Href        string                 `json:"href,omitempty" yaml:"href,omitempty"`
-	OperationID string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Parameters  map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Headers     map[string]*HeaderRef  `json:"headers,omitempty" yaml:"headers,omitempty"`
+	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Server       *Server                `json:"server,omitempty" yaml:"server,omitempty"`
+	RequestBody  interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 }
 
 func (value *Link) MarshalJSON() ([]byte, error) {
@@ -25,5 +27,11 @@ func (value *Link) UnmarshalJSON(data []byte) error {
 }
 
 func (value *Link) Validate(c context.Context) error {
+	if value.OperationID == "" && value.OperationRef == "" {
+		return fmt.Errorf("missing operationId or operationRef on link")
+	}
+	if value.OperationID != "" && value.OperationRef != "" {
+		return fmt.Errorf("operationId '%s' and operationRef '%s' are mutually exclusive", value.OperationID, value.OperationRef)
+	}
 	return nil
 }

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -13,7 +13,7 @@ type Link struct {
 	Href        string                 `json:"href,omitempty" yaml:"href,omitempty"`
 	OperationID string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
 	Parameters  map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Headers     map[string]*Schema     `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Headers     map[string]*HeaderRef  `json:"headers,omitempty" yaml:"headers,omitempty"`
 }
 
 func (value *Link) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Change the type of `Link.Value.Headers` from `map[string]*Schema` to `map[string]*HeaderRef`

Fixes: https://github.com/getkin/kin-openapi/issues/188