### PR TITLE
Add validation handler and error encoder

### DIFF
--- a/openapi3filter/fixtures/petstore.json
+++ b/openapi3filter/fixtures/petstore.json
@@ -1,0 +1,1200 @@
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    },
+    {
+      "url": "http://petstore.swagger.io/v2"
+    }
+  ],
+  "info": {
+    "description": "This is a sample server Petstore server.  You can find out more about Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).  For this sample, you can use the api key `special-key` to test the authorization filters.",
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders"
+    },
+    {
+      "name": "user",
+      "description": "Operations about user",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "",
+        "operationId": "addPet",
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        }
+      },
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "",
+        "operationId": "updatePet",
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/Pet"
+        }
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "available",
+                  "pending",
+                  "sold"
+                ],
+                "default": "available"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Muliple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": true,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/findByIds": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by IDs",
+        "description": "Muliple IDs can be provided with comma separated strings. Use id1, id2, id3 for testing.",
+        "operationId": "findPetsByIds",
+        "parameters": [
+          {
+            "name": "ids",
+            "in": "query",
+            "description": "IDs to filter by",
+            "required": true,
+            "explode": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/findByKind": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by Kind",
+        "description": "Muliple kinds can be provided with comma separated strings. Use id1, id2, id3 for testing.",
+        "operationId": "findPetsByKind",
+        "parameters": [
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Kinds to filter by",
+            "required": true,
+            "explode": false,
+            "style": "pipeDelimited",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "dog",
+                  "cat",
+                  "turtle",
+                  "bird,with,commas"
+                ]
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "deprecated": true
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "Updated name of the pet",
+                    "type": "string"
+                  },
+                  "status": {
+                    "description": "Updated status of the pet",
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "",
+        "operationId": "placeOrder",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid Order"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          },
+          "description": "order placed for purchasing the pet",
+          "required": true
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value >= 1 and <= 10. Other values will generated exceptions",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of pet that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with positive integer value. Negative or non-integer values will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "minimum": 1
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "description": "Created user object",
+          "required": true
+        }
+      }
+    },
+    "/user/createWithArray": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithArrayInput",
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserArray"
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "",
+        "operationId": "createUsersWithListInput",
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/components/requestBodies/UserArray"
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Updated user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be updated",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid user supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          },
+          "description": "Updated user object",
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean",
+            "default": false
+          }
+        },
+        "xml": {
+          "name": "Order"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "username": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "userStatus": {
+            "type": "integer",
+            "format": "int32",
+            "description": "User Status"
+          }
+        },
+        "xml": {
+          "name": "User"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "name": "tag",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          }
+        },
+        "xml": {
+          "name": "Category"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "Tag"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "Pet": {
+        "type": "object",
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "readOnly": true
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "name": "photoUrl",
+              "wrapped": true
+            },
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "name": "tag",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "Pet"
+        }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        },
+        "description": "Pet object that needs to be added to the store",
+        "required": true
+      },
+      "UserArray": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "description": "List of user object",
+        "required": true
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore.swagger.io/oauth/dialog",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/openapi3filter/validation_error.go
+++ b/openapi3filter/validation_error.go
@@ -1,0 +1,85 @@
+package openapi3filter
+
+import (
+	"bytes"
+	"strconv"
+)
+
+// ValidationError struct provides granular error information
+// useful for communicating issues back to end user and developer.
+// Based on https://jsonapi.org/format/#error-objects
+type ValidationError struct {
+	// A unique identifier for this particular occurrence of the problem.
+	Id string `json:"id,omitempty"`
+	// The HTTP status code applicable to this problem.
+	Status int `json:"status,omitempty"`
+	// An application-specific error code, expressed as a string value.
+	Code string `json:"code,omitempty"`
+	// A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization.
+	Title string `json:"title,omitempty"`
+	// A human-readable explanation specific to this occurrence of the problem.
+	Detail string `json:"detail,omitempty"`
+	// An object containing references to the source of the error
+	Source *ValidationErrorSource `json:"source,omitempty"`
+}
+
+// ValidationErrorSource struct
+type ValidationErrorSource struct {
+	// A JSON Pointer [RFC6901] to the associated entity in the request document [e.g. \"/data\" for a primary data object, or \"/data/attributes/title\" for a specific attribute].
+	Pointer string `json:"pointer,omitempty"`
+	// A string indicating which query parameter caused the error.
+	Parameter string `json:"parameter,omitempty"`
+}
+
+var _ error = &ValidationError{}
+
+// Error implements the error interface.
+func (e *ValidationError) Error() string {
+	b := new(bytes.Buffer)
+	b.WriteString("[")
+	if e.Status != 0 {
+		b.WriteString(strconv.Itoa(e.Status))
+	}
+	b.WriteString("]")
+	b.WriteString("[")
+	if e.Code != "" {
+		b.WriteString(e.Code)
+	}
+	b.WriteString("]")
+	b.WriteString("[")
+	if e.Id != "" {
+		b.WriteString(e.Id)
+	}
+	b.WriteString("]")
+	b.WriteString(" ")
+	if e.Title != "" {
+		b.WriteString(e.Title)
+		b.WriteString(" ")
+	}
+	if e.Detail != "" {
+		b.WriteString("| ")
+		b.WriteString(e.Detail)
+		b.WriteString(" ")
+	}
+	if e.Source != nil {
+		b.WriteString("[source ")
+		if e.Source.Parameter != "" {
+			b.WriteString("parameter=")
+			b.WriteString(e.Source.Parameter)
+		} else if e.Source.Pointer != "" {
+			b.WriteString("pointer=")
+			b.WriteString(e.Source.Pointer)
+		}
+		b.WriteString("]")
+	}
+
+	if b.Len() == 0 {
+		return "no error"
+	}
+	return b.String()
+}
+
+// StatusCode implements the StatusCoder interface for DefaultErrorEncoder
+func (e *ValidationError) StatusCode() int {
+	return e.Status
+}

--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -1,0 +1,193 @@
+package openapi3filter
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// ValidationErrorEncoder wraps a base ErrorEncoder to handle ValidationErrors
+type ValidationErrorEncoder struct {
+	Encoder ErrorEncoder
+}
+
+// Encode implements the ErrorEncoder interface for encoding ValidationErrors
+func (enc *ValidationErrorEncoder) Encode(ctx context.Context, err error, w http.ResponseWriter) {
+	var cErr *ValidationError
+
+	if e, ok := err.(*RouteError); ok {
+		cErr = convertRouteError(e)
+		enc.Encoder(ctx, cErr, w)
+		return
+	}
+
+	e, ok := err.(*RequestError)
+	if !ok {
+		enc.Encoder(ctx, err, w)
+		return
+	}
+
+	if e.Err == nil {
+		cErr = convertBasicRequestError(e)
+	} else if e.Err == ErrInvalidRequired {
+		cErr = convertErrInvalidRequired(e)
+	} else if innerErr, ok := e.Err.(*ParseError); ok {
+		cErr = convertParseError(e, innerErr)
+	} else if innerErr, ok := e.Err.(*openapi3.SchemaError); ok {
+		cErr = convertSchemaError(e, innerErr)
+	}
+
+	if cErr != nil {
+		enc.Encoder(ctx, cErr, w)
+	} else {
+		enc.Encoder(ctx, err, w)
+	}
+}
+
+func convertRouteError(e *RouteError) *ValidationError {
+	var cErr *ValidationError
+	switch e.Reason {
+	case "Path doesn't support the HTTP method":
+		cErr = &ValidationError{Status: http.StatusMethodNotAllowed, Title: e.Reason}
+	default:
+		cErr = &ValidationError{Status: http.StatusNotFound, Title: e.Reason}
+	}
+	return cErr
+}
+
+func convertBasicRequestError(e *RequestError) *ValidationError {
+	var cErr *ValidationError
+	unsupportedContentType := "header 'Content-Type' has unexpected value: "
+	if strings.HasPrefix(e.Reason, unsupportedContentType) {
+		if strings.HasSuffix(e.Reason, `: ""`) {
+			cErr = &ValidationError{
+				Status: http.StatusUnsupportedMediaType,
+				Title:  "header 'Content-Type' is required",
+			}
+		} else {
+			cErr = &ValidationError{
+				Status: http.StatusUnsupportedMediaType,
+				Title:  "unsupported content type " + strings.TrimPrefix(e.Reason, unsupportedContentType),
+			}
+		}
+	} else {
+		cErr = &ValidationError{
+			Status: http.StatusBadRequest,
+			Title:  e.Error(),
+		}
+	}
+	return cErr
+}
+
+func convertErrInvalidRequired(e *RequestError) *ValidationError {
+	var cErr *ValidationError
+	if e.Reason == ErrInvalidRequired.Error() && e.Parameter != nil {
+		cErr = &ValidationError{
+			Status: http.StatusBadRequest,
+			Title:  fmt.Sprintf("Parameter '%s' in %s is required", e.Parameter.Name, e.Parameter.In),
+		}
+	} else {
+		cErr = &ValidationError{
+			Status: http.StatusBadRequest,
+			Title:  e.Error(),
+		}
+	}
+	return cErr
+}
+
+func convertParseError(e *RequestError, innerErr *ParseError) *ValidationError {
+	var cErr *ValidationError
+	// We treat path params of the wrong type like a 404 instead of a 400
+	if innerErr.Kind == KindInvalidFormat && e.Parameter != nil && e.Parameter.In == "path" {
+		cErr = &ValidationError{
+			Status: http.StatusNotFound,
+			Title:  fmt.Sprintf("Resource not found with '%s' value: %v", e.Parameter.Name, innerErr.Value),
+		}
+	} else if strings.HasPrefix(innerErr.Reason, "unsupported content type") {
+		cErr = &ValidationError{
+			Status: http.StatusUnsupportedMediaType,
+			Title:  innerErr.Reason,
+		}
+	} else if innerErr.RootCause() != nil {
+		if rootErr, ok := innerErr.Cause.(*ParseError); ok &&
+			rootErr.Kind == KindInvalidFormat && e.Parameter.In == "query" {
+			cErr = &ValidationError{
+				Status: http.StatusBadRequest,
+				Title: fmt.Sprintf("Parameter '%s' in %s is invalid: %v is %s",
+					e.Parameter.Name, e.Parameter.In, rootErr.Value, rootErr.Reason),
+			}
+		} else {
+			cErr = &ValidationError{
+				Status: http.StatusBadRequest,
+				Title:  innerErr.Reason,
+			}
+		}
+	}
+	return cErr
+}
+
+var propertyMissingNameRE = regexp.MustCompile(`Property '(?P<name>[^']*)' is missing`)
+
+func convertSchemaError(e *RequestError, innerErr *openapi3.SchemaError) *ValidationError {
+	cErr := &ValidationError{Title: innerErr.Reason}
+
+	// Add http status code
+	if e.Parameter != nil {
+		cErr.Status = http.StatusBadRequest
+	} else if e.RequestBody != nil {
+		cErr.Status = http.StatusUnprocessableEntity
+	}
+
+	// Add error source
+	if e.Parameter != nil && e.Parameter.In == "query" {
+		// We have a JSONPointer in the query param too so need to
+		// make sure 'Parameter' check takes priority over 'Pointer'
+		cErr.Source = &ValidationErrorSource{
+			Parameter: e.Parameter.Name,
+		}
+	} else if innerErr.JSONPointer() != nil {
+		pointer := innerErr.JSONPointer()
+
+		// JSONPointer is rarely what you expect.
+		// 1. for "property is missing" errors, its an empty array
+		// 2. for nested attributes, it leaves off the last element from the JSONPointer
+		matches := propertyMissingNameRE.FindStringSubmatch(innerErr.Reason)
+		if matches != nil && len(matches) > 1 {
+			if len(pointer) == 0 || matches[1] != pointer[0] {
+				pointer = append(pointer, matches[1])
+			}
+		}
+
+		cErr.Source = &ValidationErrorSource{
+			Pointer: toJSONPointer(pointer),
+		}
+	}
+
+	// Add details on allowed values for enums
+	if innerErr.SchemaField == "enum" &&
+		innerErr.Reason == "JSON value is not one of the allowed values" {
+		enums := make([]string, 0, len(innerErr.Schema.Enum))
+		for _, enum := range innerErr.Schema.Enum {
+			enums = append(enums, fmt.Sprintf("%v", enum))
+		}
+		cErr.Detail = fmt.Sprintf("Value '%v' at %s must be one of: %s",
+			innerErr.Value, toJSONPointer(innerErr.JSONPointer()), strings.Join(enums, ", "))
+		value := fmt.Sprintf("%v", innerErr.Value)
+		if (e.Parameter.Explode == nil || *e.Parameter.Explode == true) &&
+			(e.Parameter.Style == "" || e.Parameter.Style == "form") &&
+			strings.Contains(value, ",") {
+			parts := strings.Split(value, ",")
+			cErr.Detail = cErr.Detail+"; "+ fmt.Sprintf("perhaps you intended '?%s=%s'",
+				e.Parameter.Name, strings.Join(parts, "&"+e.Parameter.Name+"="))
+		}
+	}
+	return cErr
+}
+
+func toJSONPointer(reversePath []string) string {
+	return "/" + strings.Join(reversePath, "/")
+}

--- a/openapi3filter/validation_error_test.go
+++ b/openapi3filter/validation_error_test.go
@@ -1,0 +1,570 @@
+package openapi3filter
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func newPetstoreRequest(t *testing.T, method, path string, body io.Reader) *http.Request {
+	host := "petstore.swagger.io"
+	pathPrefix := "v2"
+	r, err := http.NewRequest(method, fmt.Sprintf("http://%s/%s%s", host, pathPrefix, path), body)
+	require.NoError(t, err)
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set("Authorization", "Bearer magicstring")
+	r.Host = host
+	return r
+}
+
+type validationFields struct {
+	Handler      http.Handler
+	SwaggerFile  string
+	ErrorEncoder ErrorEncoder
+}
+type validationArgs struct {
+	r *http.Request
+}
+type validationTest struct {
+	name                string
+	fields              validationFields
+	args                validationArgs
+	wantErr             bool
+	wantErrBody         string
+	wantErrReason       string
+	wantErrSchemaReason string
+	wantErrSchemaPath   string
+	wantErrSchemaValue  interface{}
+	wantErrParam        string
+	wantErrParamIn      string
+	wantErrParseKind    ParseErrorKind
+	wantErrParseValue   interface{}
+	wantErrParseReason  string
+	wantErrResponse     *ValidationError
+}
+
+func getValidationTests(t *testing.T) []*validationTest {
+	badHost, _ := http.NewRequest(http.MethodGet, "http://unknown-host.com/v2/pet", nil)
+	badPath := newPetstoreRequest(t, http.MethodGet, "/watdis", nil)
+	badMethod := newPetstoreRequest(t, http.MethodTrace, "/pet", nil)
+
+	missingBody1 := newPetstoreRequest(t, http.MethodPost, "/pet", nil)
+	missingBody2 := newPetstoreRequest(t, http.MethodPost, "/pet", bytes.NewBufferString(``))
+
+	noContentType := newPetstoreRequest(t, http.MethodPost, "/pet", bytes.NewBufferString(`{}`))
+	noContentType.Header.Del("Content-Type")
+
+	noContentTypeNeeded := newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?status=sold", nil)
+	noContentTypeNeeded.Header.Del("Content-Type")
+
+	unknownContentType := newPetstoreRequest(t, http.MethodPost, "/pet", bytes.NewBufferString(`{}`))
+	unknownContentType.Header.Set("Content-Type", "application/xml")
+
+	unsupportedContentType := newPetstoreRequest(t, http.MethodPost, "/pet", bytes.NewBufferString(`{}`))
+	unsupportedContentType.Header.Set("Content-Type", "text/plain")
+
+	return []*validationTest{
+		//
+		// Basics
+		//
+
+		{
+			name: "error - unknown host",
+			args: validationArgs{
+				r: badHost,
+			},
+			wantErrReason:   "Does not match any server",
+			wantErrResponse: &ValidationError{Status: http.StatusNotFound, Title: "Does not match any server"},
+		},
+		{
+			name: "error - unknown path",
+			args: validationArgs{
+				r: badPath,
+			},
+			wantErrReason:   "Path was not found",
+			wantErrResponse: &ValidationError{Status: http.StatusNotFound, Title: "Path was not found"},
+		},
+		{
+			name: "error - unknown method",
+			args: validationArgs{
+				r: badMethod,
+			},
+			wantErrReason: "Path doesn't support the HTTP method",
+			// TODO: By HTTP spec, this should have an Allow header with what is allowed
+			// but kin-openapi doesn't provide us the requested method or path, so impossible to provide details
+			wantErrResponse: &ValidationError{Status: http.StatusMethodNotAllowed,
+				Title: "Path doesn't support the HTTP method"},
+		},
+		{
+			name: "error - missing body on POST",
+			args: validationArgs{
+				r: missingBody1,
+			},
+			wantErrBody: "Request body has an error: must have a value",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "Request body has an error: must have a value"},
+		},
+		{
+			name: "error - empty body on POST",
+			args: validationArgs{
+				r: missingBody2,
+			},
+			wantErrBody: "Request body has an error: must have a value",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "Request body has an error: must have a value"},
+		},
+
+		//
+		// Content-Type
+		//
+
+		{
+			name: "error - missing content-type on POST",
+			args: validationArgs{
+				r: noContentType,
+			},
+			wantErrReason: "header 'Content-Type' has unexpected value: \"\"",
+			wantErrResponse: &ValidationError{Status: http.StatusUnsupportedMediaType,
+				Title: "header 'Content-Type' is required"},
+		},
+		{
+			name: "error - unknown content-type on POST",
+			args: validationArgs{
+				r: unknownContentType,
+			},
+			wantErrReason:      "failed to decode request body",
+			wantErrParseKind:   KindUnsupportedFormat,
+			wantErrParseReason: "unsupported content type \"application/xml\"",
+			wantErrResponse: &ValidationError{Status: http.StatusUnsupportedMediaType,
+				Title: "unsupported content type \"application/xml\""},
+		},
+		{
+			name: "error - unsupported content-type on POST",
+			args: validationArgs{
+				r: unsupportedContentType,
+			},
+			wantErrReason: "header 'Content-Type' has unexpected value: \"text/plain\"",
+			wantErrResponse: &ValidationError{Status: http.StatusUnsupportedMediaType,
+				Title: "unsupported content type \"text/plain\""},
+		},
+		{
+			name: "success - no content-type header required on GET",
+			args: validationArgs{
+				r: noContentTypeNeeded,
+			},
+		},
+
+		//
+		// Query strings
+		//
+
+		{
+			name: "error - missing required query string parameter",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus", nil),
+			},
+			wantErrParam:   "status",
+			wantErrParamIn: "query",
+			wantErrReason:  "must have a value",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "Parameter 'status' in query is required"},
+		},
+		{
+			name: "error - wrong query string parameter type",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByIds?ids=1,notAnInt", nil),
+			},
+			wantErrParam:   "ids",
+			wantErrParamIn: "query",
+			// This is a nested ParseError. The outer error is a KindOther with no details.
+			// So we'd need to look at the inner one which is a KindInvalidFormat. So just check the error body.
+			wantErrBody: "Parameter 'ids' in query has an error: path 1: value notAnInt: an invalid integer: " +
+				"strconv.ParseFloat: parsing \"notAnInt\": invalid syntax",
+			// TODO: Should we treat query params of the wrong type like a 404 instead of a 400?
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "Parameter 'ids' in query is invalid: notAnInt is an invalid integer"},
+		},
+		{
+			name: "success - ignores unknown query string parameter",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?wat=isdis", nil),
+			},
+		},
+		{
+			name: "success - normal case, query strings",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?status=available", nil),
+			},
+		},
+		{
+			name: "success - normal case, query strings, array",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?status=available&status=sold", nil),
+			},
+		},
+		{
+			name: "error - invalid query string array serialization",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?status=available,sold", nil),
+			},
+			wantErrParam:        "status",
+			wantErrParamIn:      "query",
+			wantErrSchemaReason: "JSON value is not one of the allowed values",
+			wantErrSchemaPath:   "/0",
+			wantErrSchemaValue:  "available,sold",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "JSON value is not one of the allowed values",
+				Detail: "Value 'available,sold' at /0 must be one of: available, pending, sold; " +
+					// TODO: do we really want to use this heuristic to guess
+					//  that they're using the wrong serialization?
+					"perhaps you intended '?status=available&status=sold'",
+				Source: &ValidationErrorSource{Parameter: "status"}},
+		},
+		{
+			name: "error - invalid enum value for query string parameter",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?status=sold&status=watdis", nil),
+			},
+			wantErrParam:        "status",
+			wantErrParamIn:      "query",
+			wantErrSchemaReason: "JSON value is not one of the allowed values",
+			wantErrSchemaPath:   "/1",
+			wantErrSchemaValue:  "watdis",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "JSON value is not one of the allowed values",
+				Detail: "Value 'watdis' at /1 must be one of: available, pending, sold",
+				Source:  &ValidationErrorSource{Parameter: "status"}},
+		},
+		{
+			name: "error - invalid enum value, allowing commas (without 'perhaps you intended' recommendation)",
+			args: validationArgs{
+				// fish,with,commas isn't an enum value
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByKind?kind=dog|fish,with,commas", nil),
+			},
+			wantErrParam:        "kind",
+			wantErrParamIn:      "query",
+			wantErrSchemaReason: "JSON value is not one of the allowed values",
+			wantErrSchemaPath:   "/1",
+			wantErrSchemaValue:  "fish,with,commas",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "JSON value is not one of the allowed values",
+				Detail: "Value 'fish,with,commas' at /1 must be one of: dog, cat, turtle, bird,with,commas",
+					// No 'perhaps you intended' because its the right serialization format
+				Source: &ValidationErrorSource{Parameter: "kind"}},
+		},
+		{
+			name: "success - valid enum value, allowing commas",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/findByKind?kind=dog|bird,with,commas", nil),
+			},
+		},
+
+		//
+		// Request bodies
+		//
+
+		{
+			name: "error - missing required object attribute",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet", bytes.NewBufferString(`{"name":"Bahama"}`)),
+			},
+			wantErrReason:       "doesn't match the schema",
+			wantErrSchemaReason: "Property 'photoUrls' is missing",
+			wantErrSchemaValue:  map[string]string{"name": "Bahama"},
+			wantErrSchemaPath:   "/",
+			wantErrResponse: &ValidationError{Status: http.StatusUnprocessableEntity,
+				Title: "Property 'photoUrls' is missing",
+				Source:  &ValidationErrorSource{Pointer: "/photoUrls"}},
+		},
+		{
+			name: "error - missing required nested object attribute",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet",
+					bytes.NewBufferString(`{"name":"Bahama","photoUrls":[],"category":{}}`)),
+			},
+			wantErrReason:       "doesn't match the schema",
+			wantErrSchemaReason: "Property 'name' is missing",
+			wantErrSchemaValue:  map[string]string{},
+			wantErrSchemaPath:   "/category",
+			wantErrResponse: &ValidationError{Status: http.StatusUnprocessableEntity,
+				Title: "Property 'name' is missing",
+				Source:  &ValidationErrorSource{Pointer: "/category/name"}},
+		},
+		{
+			name: "error - missing required deeply nested object attribute",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet",
+					bytes.NewBufferString(`{"name":"Bahama","photoUrls":[],"category":{"tags": [{}]}}`)),
+			},
+			wantErrReason:       "doesn't match the schema",
+			wantErrSchemaReason: "Property 'name' is missing",
+			wantErrSchemaValue:  map[string]string{},
+			wantErrSchemaPath:   "/category/tags/0",
+			wantErrResponse: &ValidationError{Status: http.StatusUnprocessableEntity,
+				Title: "Property 'name' is missing",
+				Source:  &ValidationErrorSource{Pointer: "/category/tags/0/name"}},
+		},
+		{
+			// TODO: Add support for validating readonly properties to upstream validator.
+			name: "error - readonly object attribute",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet",
+					bytes.NewBufferString(`{"id":213,"name":"Bahama","photoUrls":[]}}`)),
+			},
+			//wantErr: true,
+		},
+		{
+			name: "error - wrong attribute type",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet",
+					bytes.NewBufferString(`{"name":"Bahama","photoUrls":"http://cat"}`)),
+			},
+			wantErrReason:       "doesn't match the schema",
+			wantErrSchemaReason: "Field must be set to array or not be present",
+			wantErrSchemaPath:   "/photoUrls",
+			wantErrSchemaValue:  "string",
+			// TODO: this shouldn't say "or not be present", but this requires recursively resolving
+			//  innerErr.JSONPointer() against e.RequestBody.Content["application/json"].Schema.Value (.Required, .Properties)
+			wantErrResponse: &ValidationError{Status: http.StatusUnprocessableEntity,
+				Title: "Field must be set to array or not be present",
+				Source:  &ValidationErrorSource{Pointer: "/photoUrls"}},
+		},
+		{
+			name: "success - ignores unknown object attribute",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet",
+					bytes.NewBufferString(`{"wat":"isdis","name":"Bahama","photoUrls":[]}`)),
+			},
+		},
+		{
+			name: "success - normal case, POST",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodPost, "/pet",
+					bytes.NewBufferString(`{"name":"Bahama","photoUrls":[]}`)),
+			},
+		},
+
+		//
+		// Path params
+		//
+
+		{
+			name: "error - missing path param",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/", nil),
+			},
+			wantErrParam:   "petId",
+			wantErrParamIn: "path",
+			wantErrReason:  "must have a value",
+			wantErrResponse: &ValidationError{Status: http.StatusBadRequest,
+				Title: "Parameter 'petId' in path is required"},
+		},
+		{
+			name: "error - wrong path param type",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/NotAnInt", nil),
+			},
+			wantErrParam:       "petId",
+			wantErrParamIn:     "path",
+			wantErrParseKind:   KindInvalidFormat,
+			wantErrParseValue:  "NotAnInt",
+			wantErrParseReason: "an invalid integer",
+			wantErrResponse: &ValidationError{Status: http.StatusNotFound,
+				Title: "Resource not found with 'petId' value: NotAnInt"},
+		},
+		{
+			name: "success - normal case, with path params",
+			args: validationArgs{
+				r: newPetstoreRequest(t, http.MethodGet, "/pet/23", nil),
+			},
+		},
+	}
+}
+
+func TestValidationHandler_validateRequest(t *testing.T) {
+	tests := getValidationTests(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := require.New(t)
+
+			h, err := buildValidationHandler(tt)
+			req.NoError(err)
+
+			err = h.validateRequest(tt.args.r)
+			req.Equal(tt.wantErr, err != nil)
+
+			if err != nil {
+				if tt.wantErrBody != "" {
+					req.Equal(tt.wantErrBody, err.Error())
+				}
+
+				if e, ok := err.(*RouteError); ok {
+					req.Equal(tt.wantErrReason, e.Reason)
+					return
+				}
+
+				e, ok := err.(*RequestError)
+				req.True(ok, "error = %v, not a RequestError -- %#v", err, err)
+
+				req.Equal(tt.wantErrReason, e.Reason)
+
+				if e.Parameter != nil {
+					req.Equal(tt.wantErrParam, e.Parameter.Name)
+					req.Equal(tt.wantErrParamIn, e.Parameter.In)
+				} else {
+					req.False(tt.wantErrParam != "" || tt.wantErrParamIn != "",
+						"error = %v, no Parameter -- %#v", e, e)
+				}
+
+				if innerErr, ok := e.Err.(*openapi3.SchemaError); ok {
+					req.Equal(tt.wantErrSchemaReason, innerErr.Reason)
+					pointer := toJSONPointer(innerErr.JSONPointer())
+					req.Equal(tt.wantErrSchemaPath, pointer)
+					req.Equal(fmt.Sprintf("%v", tt.wantErrSchemaValue), fmt.Sprintf("%v", innerErr.Value))
+				} else {
+					req.False(tt.wantErrSchemaReason != "" || tt.wantErrSchemaPath != "",
+						"error = %v, not a SchemaError -- %#v", e.Err, e.Err)
+				}
+
+				if innerErr, ok := e.Err.(*ParseError); ok {
+					req.Equal(tt.wantErrParseKind, innerErr.Kind)
+					req.Equal(tt.wantErrParseValue, innerErr.Value)
+					req.Equal(tt.wantErrParseReason, innerErr.Reason)
+				} else {
+					req.False(tt.wantErrParseValue != nil || tt.wantErrParseReason != "",
+						"error = %v, not a ParseError -- %#v", e.Err, e.Err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidationErrorEncoder(t *testing.T) {
+	tests := getValidationTests(t)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockEncoder := &mockErrorEncoder{}
+			encoder := &ValidationErrorEncoder{Encoder: mockEncoder.Encode}
+
+			req := require.New(t)
+
+			h, err := buildValidationHandler(tt)
+			req.NoError(err)
+
+			err = h.validateRequest(tt.args.r)
+			req.Equal(tt.wantErr, err != nil)
+
+			if err != nil {
+				encoder.Encode(tt.args.r.Context(), err, httptest.NewRecorder())
+				if tt.wantErrResponse != mockEncoder.Err {
+					req.Equal(tt.wantErrResponse, mockEncoder.Err)
+				}
+			}
+		})
+	}
+}
+
+func buildValidationHandler(tt *validationTest) (*ValidationHandler, error) {
+	if tt.fields.SwaggerFile == "" {
+		tt.fields.SwaggerFile = "fixtures/petstore.json"
+	}
+	h := &ValidationHandler{
+		Handler:      tt.fields.Handler,
+		SwaggerFile:  tt.fields.SwaggerFile,
+		ErrorEncoder: tt.fields.ErrorEncoder,
+	}
+	tt.wantErr = tt.wantErr ||
+		(tt.wantErrBody != "") ||
+		(tt.wantErrReason != "") ||
+		(tt.wantErrSchemaReason != "") ||
+		(tt.wantErrSchemaPath != "") ||
+		(tt.wantErrParseValue != nil) ||
+		(tt.wantErrParseReason != "")
+	err := h.Load()
+	return h, err
+}
+
+type testHandler struct {
+	Called bool
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.Called = true
+}
+
+type mockErrorEncoder struct {
+	Called bool
+	Ctx    context.Context
+	Err    error
+	W      http.ResponseWriter
+}
+
+func (e *mockErrorEncoder) Encode(ctx context.Context, err error, w http.ResponseWriter) {
+	e.Called = true
+	e.Ctx = ctx
+	e.Err = err
+	e.W = w
+}
+
+func runTest(t *testing.T, handler http.Handler, encoder ErrorEncoder, req *http.Request) *http.Response {
+	h := &ValidationHandler{
+		Handler:      handler,
+		ErrorEncoder: encoder,
+		SwaggerFile:  "fixtures/petstore.json",
+	}
+	err := h.Load()
+	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w.Result()
+}
+
+func TestValidationHandler_ServeHTTP(t *testing.T) {
+	t.Run("errors on invalid requests", func(t *testing.T) {
+		httpCtx := context.WithValue(context.Background(), "pig", "tails")
+		r, err := http.NewRequest(http.MethodGet, "http://unknown-host.com/v2/pet", nil)
+		require.NoError(t, err)
+		r = r.WithContext(httpCtx)
+
+		handler := &testHandler{}
+		encoder := &mockErrorEncoder{}
+		runTest(t, handler, encoder.Encode, r)
+
+		require.False(t, handler.Called)
+		require.True(t, encoder.Called)
+		require.Equal(t, httpCtx, encoder.Ctx)
+		require.NotNil(t, encoder.Err)
+	})
+
+	t.Run("passes valid requests through", func(t *testing.T) {
+		r := newPetstoreRequest(t, http.MethodGet, "/pet/findByStatus?status=sold", nil)
+
+		handler := &testHandler{}
+		encoder := &mockErrorEncoder{}
+		runTest(t, handler, encoder.Encode, r)
+
+		require.True(t, handler.Called)
+		require.False(t, encoder.Called)
+	})
+
+	t.Run("uses error encoder", func(t *testing.T) {
+		r := newPetstoreRequest(t, http.MethodPost, "/pet", bytes.NewBufferString(`{"name":"Bahama","photoUrls":"http://cat"}`))
+
+		handler := &testHandler{}
+		encoder := &ValidationErrorEncoder{Encoder: (ErrorEncoder)(DefaultErrorEncoder)}
+		resp := runTest(t, handler, encoder.Encode, r)
+
+		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+		require.Equal(t, "[422][][] Field must be set to array or not be present [source pointer=/photoUrls]", string(body))
+	})
+}

--- a/openapi3filter/validation_handler.go
+++ b/openapi3filter/validation_handler.go
@@ -1,0 +1,78 @@
+package openapi3filter
+
+import (
+	"context"
+	"net/http"
+)
+
+type AuthenticationFunc func(context.Context, *AuthenticationInput) error
+
+func NoopAuthenticationFunc(context.Context, *AuthenticationInput) error { return nil }
+
+var _ AuthenticationFunc = NoopAuthenticationFunc
+
+type ValidationHandler struct {
+	Handler            http.Handler
+	AuthenticationFunc AuthenticationFunc
+	SwaggerFile        string
+	ErrorEncoder       ErrorEncoder
+	router             *Router
+}
+
+func (h *ValidationHandler) Load() error {
+	h.router = NewRouter()
+
+	err := h.router.AddSwaggerFromFile(h.SwaggerFile)
+	if err != nil {
+		return err
+	}
+
+	// set defaults
+	if h.Handler == nil {
+		h.Handler = http.DefaultServeMux
+	}
+	if h.AuthenticationFunc == nil {
+		h.AuthenticationFunc = NoopAuthenticationFunc
+	}
+	if h.ErrorEncoder == nil {
+		h.ErrorEncoder = DefaultErrorEncoder
+	}
+
+	return nil
+}
+
+func (h *ValidationHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	err := h.validateRequest(r)
+	if err != nil {
+		h.ErrorEncoder(r.Context(), err, w)
+		return
+	}
+	// TODO: validateResponse
+	h.Handler.ServeHTTP(w, r)
+}
+
+func (h *ValidationHandler) validateRequest(r *http.Request) error {
+	// Find route
+	route, pathParams, err := h.router.FindRoute(r.Method, r.URL)
+	if err != nil {
+		return err
+	}
+
+	options := &Options{
+		AuthenticationFunc: h.AuthenticationFunc,
+	}
+
+	// Validate request
+	requestValidationInput := &RequestValidationInput{
+		Request:    r,
+		PathParams: pathParams,
+		Route:      route,
+		Options:    options,
+	}
+	err = ValidateRequest(r.Context(), requestValidationInput)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/openapi3filter/validation_kit.go
+++ b/openapi3filter/validation_kit.go
@@ -1,0 +1,85 @@
+package openapi3filter
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+///////////////////////////////////////////////////////////////////////////////////
+// We didn't want to tie kin-openapi too tightly with go-kit.
+// This file contains the ErrorEncoder and DefaultErrorEncoder function
+// borrowed from this project.
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2015 Peter Bourgon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////
+
+// ErrorEncoder is responsible for encoding an error to the ResponseWriter.
+// Users are encouraged to use custom ErrorEncoders to encode HTTP errors to
+// their clients, and will likely want to pass and check for their own error
+// types. See the example shipping/handling service.
+type ErrorEncoder func(ctx context.Context, err error, w http.ResponseWriter)
+
+// StatusCoder is checked by DefaultErrorEncoder. If an error value implements
+// StatusCoder, the StatusCode will be used when encoding the error. By default,
+// StatusInternalServerError (500) is used.
+type StatusCoder interface {
+	StatusCode() int
+}
+
+// Headerer is checked by DefaultErrorEncoder. If an error value implements
+// Headerer, the provided headers will be applied to the response writer, after
+// the Content-Type is set.
+type Headerer interface {
+	Headers() http.Header
+}
+
+// DefaultErrorEncoder writes the error to the ResponseWriter, by default a
+// content type of text/plain, a body of the plain text of the error, and a
+// status code of 500. If the error implements Headerer, the provided headers
+// will be applied to the response. If the error implements json.Marshaler, and
+// the marshaling succeeds, a content type of application/json and the JSON
+// encoded form of the error will be used. If the error implements StatusCoder,
+// the provided StatusCode will be used instead of 500.
+func DefaultErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
+	contentType, body := "text/plain; charset=utf-8", []byte(err.Error())
+	if marshaler, ok := err.(json.Marshaler); ok {
+		if jsonBody, marshalErr := marshaler.MarshalJSON(); marshalErr == nil {
+			contentType, body = "application/json; charset=utf-8", jsonBody
+		}
+	}
+	w.Header().Set("Content-Type", contentType)
+	if headerer, ok := err.(Headerer); ok {
+		for k, values := range headerer.Headers() {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+	}
+	code := http.StatusInternalServerError
+	if sc, ok := err.(StatusCoder); ok {
+		code = sc.StatusCode()
+	}
+	w.WriteHeader(code)
+	w.Write(body)
+}


### PR DESCRIPTION
Implement https://github.com/getkin/kin-openapi/issues/194 and https://github.com/getkin/kin-openapi/issues/195

This is what I had to add on top of kin-openapi in order to provide openapi validation errors in my API service. More discussion at https://github.com/getkin/kin-openapi/issues/194#issuecomment-605488953