### PR TITLE
fix panic when multipart form contains extra parts not present in schema

### DIFF
--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -928,8 +928,15 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 		valueSchema, exists = schema.Value.Properties[name]
 		if !exists {
 			anyProperties := schema.Value.AdditionalPropertiesAllowed
-			if anyProperties != nil && *anyProperties {
-				continue
+			if anyProperties != nil {
+				switch *anyProperties {
+				case true:
+					//additionalProperties: true
+					continue
+				default:
+					//additionalProperties: false
+					return nil, &ParseError{Kind: KindOther, Cause: fmt.Errorf("part %s: undefined", name)}
+				}
 			}
 			if schema.Value.AdditionalProperties == nil {
 				return nil, &ParseError{Kind: KindOther, Cause: fmt.Errorf("part %s: undefined", name)}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -953,7 +953,10 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 		values[name] = append(values[name], value)
 	}
 
-	allTheProperties := schema.Value.Properties
+	allTheProperties := make(map[string]*openapi3.SchemaRef)
+	for k, v := range schema.Value.Properties {
+		allTheProperties[k] = v
+	}
 	if schema.Value.AdditionalProperties != nil {
 		for k, v := range schema.Value.AdditionalProperties.Value.Properties {
 			allTheProperties[k] = v

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -923,7 +923,11 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 		subEncFn := func(string) *openapi3.Encoding { return enc }
 		// If the property's schema has type "array" it is means that the form contains a few parts with the same name.
 		// Every such part has a type that is defined by an items schema in the property's schema.
-		valueSchema := schema.Value.Properties[name]
+		valueSchema, exists := schema.Value.Properties[name]
+		if !exists {
+			// ignore extra properties
+			continue
+		}
 		if valueSchema.Value.Type == "array" {
 			valueSchema = valueSchema.Value.Items
 		}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -925,8 +925,11 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 		// Every such part has a type that is defined by an items schema in the property's schema.
 		valueSchema, exists := schema.Value.Properties[name]
 		if !exists {
-			// ignore extra properties
-			continue
+			additionalProperties := schema.Value.AdditionalPropertiesAllowed
+			if additionalProperties != nil && *additionalProperties {
+				continue
+			}
+			return nil, &ParseError{Kind: KindOther, Cause: fmt.Errorf("part %s: undefined", name)}
 		}
 		if valueSchema.Value.Type == "array" {
 			valueSchema = valueSchema.Value.Items

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -980,6 +980,12 @@ func TestDecodeBody(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	multipartFormExtraPart, multipartFormMimeExtraPart, err := newTestMultipartForm([]*testFormPart{
+		{name: "a", contentType: "text/plain", data: strings.NewReader("a1")},
+		{name: "x", contentType: "text/plain", data: strings.NewReader("x1")},
+	})
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name     string
 		mime     string
@@ -1059,6 +1065,14 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("d", openapi3.NewObjectSchema().WithProperty("d1", openapi3.NewStringSchema())).
 				WithProperty("f", openapi3.NewStringSchema().WithFormat("binary")),
 			want: map[string]interface{}{"a": "a1", "b": float64(10), "c": []interface{}{"c1", "c2"}, "d": map[string]interface{}{"d1": "d1"}, "f": "foo"},
+		},
+		{
+			name: "multipartExtraPart",
+			mime: multipartFormMimeExtraPart,
+			body: multipartFormExtraPart,
+			schema: openapi3.NewObjectSchema().
+				WithProperty("a", openapi3.NewStringSchema()),
+			want: map[string]interface{}{"a": "a1"},
 		},
 		{
 			name: "file",

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -986,6 +986,13 @@ func TestDecodeBody(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	multipartAdditionalProps, multipartMimeAdditionalProps, err := newTestMultipartForm([]*testFormPart{
+		{name: "a", contentType: "text/plain", data: strings.NewReader("a1")},
+		{name: "x", contentType: "text/plain", data: strings.NewReader("x1")},
+		{name: "y", contentType: "application/json", data: bytes.NewReader(d)},
+	})
+	require.NoError(t, err)
+
 	testCases := []struct {
 		name     string
 		mime     string
@@ -1071,6 +1078,16 @@ func TestDecodeBody(t *testing.T) {
 			mime: multipartFormMimeExtraPart,
 			body: multipartFormExtraPart,
 			schema: openapi3.NewObjectSchema().
+				WithProperty("a", openapi3.NewStringSchema()),
+			want:    map[string]interface{}{"a": "a1"},
+			wantErr: &ParseError{Kind: KindOther},
+		},
+		{
+			name: "multipartAdditionalProperties",
+			mime: multipartMimeAdditionalProps,
+			body: multipartAdditionalProps,
+			schema: openapi3.NewObjectSchema().
+				WithAnyAdditionalProperties().
 				WithProperty("a", openapi3.NewStringSchema()),
 			want: map[string]interface{}{"a": "a1"},
 		},


### PR DESCRIPTION
Validating a request body with content 'multipart/form-data' that contained parts not defined in the schema caused Panic, 
fixed by ignoring the undefined properties