### PR TITLE
Remove omitempty from response description

### DIFF
--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -34,7 +34,7 @@ func (responses Responses) Validate(c context.Context) error {
 // Response is specified by OpenAPI/Swagger 3.0 standard.
 type Response struct {
 	ExtensionProps
-	Description string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Description string                `json:"description" yaml:"description"`
 	Headers     map[string]*HeaderRef `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Content     Content               `json:"content,omitempty" yaml:"content,omitempty"`
 	Links       map[string]*LinkRef   `json:"links,omitempty" yaml:"links,omitempty"`


### PR DESCRIPTION
https://github.com/getkin/kin-openapi/issues/185

If the response description field was set empty string and passed into the LoadSwaggerFromData function, the field would be removed when sent due to the omitempty tag. This results in a definition that is invalid. 

Removing the omitempty tag on response description so the field is not dropped with a definition like below

```
{
	"openapi": "3.0.0",
	"info": {
		"version": "1.0.0",
		"title": "Sample API",
		"description": "A sample API to illustrate OpenAPI concepts"
	},

	"paths": {
		"/path1": {
			"get": {
        "responses": {
          "200": {
             "description": ""
          }
       }
    }
  }
 }
}
```

![image](https://user-images.githubusercontent.com/28549164/79863289-6689d780-83cf-11ea-9994-e8f88d4e10c9.png)


I looked for other fields that might have similar issues but I could not find any