### PR TITLE
openapi2_conv: include ExternalDocs prop when converting to v3

### DIFF
--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -21,6 +21,7 @@ func ToV3Swagger(swagger *openapi2.Swagger) (*openapi3.Swagger, error) {
 		Components:     openapi3.Components{},
 		Tags:           swagger.Tags,
 		ExtensionProps: swagger.ExtensionProps,
+		ExternalDocs:   swagger.ExternalDocs,
 	}
 	host := swagger.Host
 	if len(host) > 0 {
@@ -362,6 +363,7 @@ func FromV3Swagger(swagger *openapi3.Swagger) (*openapi2.Swagger, error) {
 		Responses:      resultResponses,
 		Tags:           swagger.Tags,
 		ExtensionProps: swagger.ExtensionProps,
+		ExternalDocs:   swagger.ExternalDocs,
 	}
 
 	isHTTPS := false

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -41,6 +41,10 @@ const exampleV2 = `
   "schemes": ["https"],
   "host": "test.example.com",
   "basePath": "/v2",
+  "externalDocs": {
+    "url": "https://example/doc/",
+    "description": "Example Documentation"
+  },
   "tags": [
     {
       "name": "Example",
@@ -229,6 +233,10 @@ const exampleV3 = `
   "x-root2": "root extension 2",
   "openapi": "3.0.2",
   "info": {"title":"MyAPI","version":"0.1","x-info":"info extension"},
+  "externalDocs": {
+    "url": "https://example/doc/",
+    "description": "Example Documentation"
+  },
   "components": {
     "responses": {
       "ForbiddenError": {


### PR DESCRIPTION
`ToV3Swagger` func should include `ExternalDocs` prop. Without this, it is required to set it explicitly, e.g.:

```
v3, err := openapi2conv.ToV3Swagger(&v2)		
v3.ExternalDocs = v2.ExternalDocs

```