### PR TITLE
conversion: conversion for file upload from v2 to v3 and vice versa

### DIFF
--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -161,7 +161,22 @@ const exampleV2 = `
       },
       "post": {
         "description": "example post",
-        "responses": {}
+        "responses": {},
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "fileUpload",
+            "type": "file",
+            "description": "param description",
+            "x-mimetype": "text/plain"
+          },
+          {
+            "in": "formData",
+            "name":"note",
+            "type": "integer",
+            "description": "Description of file contents"
+          }
+        ]
       },
       "put": {
         "description": "example put",
@@ -424,7 +439,28 @@ const exampleV3 = `
       },
       "post": {
         "description": "example post",
-        "responses": {}
+        "responses": {},
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "fileUpload": {
+                    "description": "param description",
+                    "format": "binary",
+                    "type": "string",
+                    "x-mimetype": "text/plain"
+                  },
+                  "note":{
+                    "type": "integer",
+                    "description": "Description of file contents"
+                  }
+                },
+                "type": "object"
+              }
+            }
+          }
+        }
       },
       "put": {
         "description": "example put",

--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -23,6 +23,18 @@ func NewContentWithJSONSchemaRef(schema *SchemaRef) Content {
 	}
 }
 
+func NewContentWithFormDataSchema(schema *Schema) Content {
+	return Content{
+		"multipart/form-data": NewMediaType().WithSchema(schema),
+	}
+}
+
+func NewContentWithFormDataSchemaRef(schema *SchemaRef) Content {
+	return Content{
+		"multipart/form-data": NewMediaType().WithSchemaRef(schema),
+	}
+}
+
 func (content Content) Get(mime string) *MediaType {
 	// If the mime is empty then short-circuit to the wildcard.
 	// We do this here so that we catch only the specific case of

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -43,6 +43,16 @@ func (requestBody *RequestBody) WithJSONSchema(value *Schema) *RequestBody {
 	return requestBody
 }
 
+func (requestBody *RequestBody) WithFormDataSchemaRef(value *SchemaRef) *RequestBody {
+	requestBody.Content = NewContentWithFormDataSchemaRef(value)
+	return requestBody
+}
+
+func (requestBody *RequestBody) WithFormDataSchema(value *Schema) *RequestBody {
+	requestBody.Content = NewContentWithFormDataSchema(value)
+	return requestBody
+}
+
 func (requestBody *RequestBody) GetMediaType(mediaType string) *MediaType {
 	m := requestBody.Content
 	if m == nil {


### PR DESCRIPTION
This change enables converting spec for file upload with POST from v2 to v3 and vice versa
according to https://swagger.io/docs/specification/2-0/file-upload/ specification.
Added support for `multipart/form-data`.
Added `in: formData` case for file upload.
Updated unit tests related sections.