### PR TITLE
added a support for absolute paths in $ref

### DIFF
--- a/openapi3/swagger_loader.go
+++ b/openapi3/swagger_loader.go
@@ -240,6 +240,10 @@ func join(basePath *url.URL, relativePath *url.URL) (*url.URL, error) {
 
 func resolvePath(basePath *url.URL, componentPath *url.URL) (*url.URL, error) {
 	if componentPath.Scheme == "" && componentPath.Host == "" {
+		// support absolute paths
+		if componentPath.Path[0] == '/' {
+			return componentPath, nil
+		}
 		return join(basePath, componentPath)
 	}
 	return componentPath, nil


### PR DESCRIPTION
Added a support for absolute paths in external references. 
Before, everything was interpreted as relative paths.

```$ref: /hello/world/spec.json#/components/schemas/HelloWorld``` - this is the absolute path, not the relative