### PR TITLE
conversion: fileUpload: handle parameters other than formData

### DIFF
--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -164,6 +164,12 @@ const exampleV2 = `
         "responses": {},
         "parameters": [
           {
+            "in": "path",
+            "name":"id",
+            "type": "integer",
+            "description": "File Id"
+          },
+          {
             "in": "formData",
             "name": "fileUpload",
             "type": "file",
@@ -460,7 +466,17 @@ const exampleV3 = `
               }
             }
           }
-        }
+        },
+        "parameters": [
+          {
+            "in": "path",
+            "name":"id",
+            "description": "File Id",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
       },
       "put": {
         "description": "example put",


### PR DESCRIPTION
This change enables using all possible parameters for file upload.
Previously, only `in: formData` was handled. Now, other parameters
are suported e.g.: `in: path`.
If at least one parameter has `in: formData`, it is considered to
be handled for file upload.