### PR TITLE
Add deprecated field in Schema

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -78,6 +78,7 @@ type Schema struct {
 	WriteOnly       bool        `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
 	AllowEmptyValue bool        `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 	XML             interface{} `json:"xml,omitempty" yaml:"xml,omitempty"`
+	Deprecated      bool        `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 
 	// Number
 	Min        *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`


### PR DESCRIPTION
Change-Id: If750ff340ae29cf24a6ad870071502c9327485ca

As the spec described, there is a deprecated field in schema.
https://swagger.io/docs/specification/data-models/keywords/