### PR TITLE
swagger2 formData & request body refs

### DIFF
--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -94,6 +94,24 @@ const exampleV2 = `
       "name": "banana",
       "required": true,
       "type": "string"
+    },
+    "put_body": {
+      "in": "body",
+      "name": "banana",
+      "required": true,
+      "schema": {
+        "type": "string"
+      },
+      "x-originalParamName":"banana"
+    },
+    "post_form_ref": {
+      "required": true,
+      "description": "param description",
+      "in": "formData",
+      "name": "fileUpload2",
+      "type": "file",
+      "x-formData-name":"fileUpload2",
+      "x-mimetype": "text/plain"
     }
   },
   "paths": {
@@ -214,6 +232,7 @@ const exampleV2 = `
             "schema": {
               "allOf": [{"$ref": "#/definitions/Item"}]
             },
+            "x-originalParamName":"body",
             "x-requestBody": "requestbody extension 1"
           }
         ],
@@ -238,13 +257,18 @@ const exampleV2 = `
             "in": "formData",
             "name": "fileUpload",
             "type": "file",
+            "x-formData-name":"fileUpload", 
             "x-mimetype": "text/plain"
           },
           {
             "description": "Description of file contents",
             "in": "formData",
             "name": "note",
-            "type": "integer"
+            "type": "integer",
+            "x-formData-name":"note" 
+          },
+          {
+            "$ref": "#/parameters/post_form_ref"
           }
         ],
         "responses": {
@@ -255,6 +279,11 @@ const exampleV2 = `
       },
       "put": {
         "description": "example put",
+        "parameters": [
+          { 
+            "$ref": "#/parameters/put_body"
+          }
+        ],
         "responses": {
           "default": {
             "description": "default response"
@@ -309,6 +338,19 @@ const exampleV3 = `
         }
       }
     },
+    "requestBodies": {
+      "put_body": {
+        "content":{ 
+          "application/json": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "required": true,
+        "x-originalParamName":"banana"
+      }
+    },
     "responses": {
       "ForbiddenError": {
         "content": {
@@ -349,6 +391,14 @@ const exampleV3 = `
       "ItemExtension": {
         "type": "boolean",
         "description": "It could be anything."
+      },
+      "post_form_ref": {
+        "description": "param description",
+        "format": "binary",
+        "required": ["fileUpload2"],
+        "type": "string",
+        "x-formData-name": "fileUpload2",
+        "x-mimetype":"text/plain"
       }
     }
   },
@@ -491,6 +541,7 @@ const exampleV3 = `
               }
             }
           },
+          "x-originalParamName":"body",
           "x-requestBody": "requestbody extension 1"
         },
         "responses": {
@@ -520,13 +571,19 @@ const exampleV3 = `
                     "description": "param description",
                     "type": "string",
                     "format": "binary",
+                    "x-formData-name":"fileUpload",
                     "x-mimetype": "text/plain"
                   },
                   "note": {
                     "description": "Description of file contents",
-                    "type": "integer"
+                    "type": "integer",
+                    "x-formData-name": "note"
+                  }, 
+                  "fileUpload2": {
+                    "$ref": "#/components/schemas/post_form_ref"
                   }
                 },
+                "required": ["fileUpload2"],
                 "type": "object"
               }
             }
@@ -540,6 +597,9 @@ const exampleV3 = `
       },
       "put": {
         "description": "example put",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/put_body"
+        },
         "responses": {
           "default": {
             "description": "default response"


### PR DESCRIPTION
Issue: 
FormData and standard request bodies defined at root level in a swagger 2 definition would fail the conversion as references could not be resolved as they aren't converted correctly.

V2ToV3 changes
- Changed Parameters `in: formData` to convert to schema refs rather than a request body at levels other than the operation level (because it made it easier to be used in references)
- When converting refs, appropriate conversion from `parameters/` to `components/parameters`, `components/requestBodies` or `components/schemas`
- Added `x-formData-name` and `x-originalName` to the conversions for testing purposes (mostly) so that the original names for parameters are used (e.g. the parameter name which is usually lost on conversion at that level).

V3ToV2 changes
- Converting root level schemas to parameters if they have `type: string format: binary` & updating relevant references (restores original names where possible with extension names)
- Converting root level request bodies components to root level parameters

