### PR TITLE
Prevent a panic in the error encoder

### DIFF
--- a/openapi3filter/fixtures/petstore.json
+++ b/openapi3filter/fixtures/petstore.json
@@ -67,7 +67,21 @@
         ],
         "requestBody": {
           "$ref": "#/components/requestBodies/PetWithRequired"
-        }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "demo",
+                "prod"
+              ]
+            },
+            "in": "header",
+            "name": "x-environment",
+            "description": "Where to send the data for processing"
+          }
+        ]
       },
       "patch": {
         "tags": [
@@ -1136,7 +1150,7 @@
           },
           "name": {
             "type": "string",
-            "example": "doggie",
+            "example": "doggie"
           },
           "photoUrls": {
             "type": "array",
@@ -1196,7 +1210,7 @@
           },
           "name": {
             "type": "string",
-            "example": "doggie",
+            "example": "doggie"
           },
           "photoUrls": {
             "type": "array",

--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -172,7 +172,8 @@ func convertSchemaError(e *RequestError, innerErr *openapi3.SchemaError) *Valida
 		cErr.Detail = fmt.Sprintf("Value '%v' at %s must be one of: %s",
 			innerErr.Value, toJSONPointer(innerErr.JSONPointer()), strings.Join(enums, ", "))
 		value := fmt.Sprintf("%v", innerErr.Value)
-		if (e.Parameter.Explode == nil || *e.Parameter.Explode == true) &&
+		if e.Parameter != nil &&
+			(e.Parameter.Explode == nil || *e.Parameter.Explode == true) &&
 			(e.Parameter.Style == "" || e.Parameter.Style == "form") &&
 			strings.Contains(value, ",") {
 			parts := strings.Split(value, ",")

--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -148,7 +148,7 @@ func convertSchemaError(e *RequestError, innerErr *openapi3.SchemaError) *Valida
 	}
 
 	// Add error source
-	if e.Parameter != nil && e.Parameter.In == "query" {
+	if e.Parameter != nil {
 		// We have a JSONPointer in the query param too so need to
 		// make sure 'Parameter' check takes priority over 'Pointer'
 		cErr.Source = &ValidationErrorSource{


### PR DESCRIPTION
The Parameter can be nil when the enum is set of one of the body fields.