### PR TITLE
Fix broken link in openapi3/doc.go

### DIFF
--- a/openapi3/doc.go
+++ b/openapi3/doc.go
@@ -1,5 +1,5 @@
 // Package openapi3 parses and writes OpenAPI 3 specifications.
 //
 // The OpenAPI 3.0 specification can be found at:
-//   https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.md
+//   https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md
 package openapi3


### PR DESCRIPTION
Fix broken link in `openapi3/doc.go`