### PR TITLE
fix: resolving paths for embedded schema fails if relative doc is not also an OpenAPI spec file

### DIFF
--- a/openapi3/swagger_loader_embedded_schema_test.go
+++ b/openapi3/swagger_loader_embedded_schema_test.go
@@ -1,0 +1,19 @@
+package openapi3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadsRelativeDocWithEmbeddedSchema(t *testing.T) {
+	loader := NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+
+	swagger, err := loader.LoadSwaggerFromFile("testdata/relativeDocsWithEmbeddedSchema/index.yml")
+	require.NoError(t, err)
+
+	vErr := swagger.Validate(context.TODO())
+	require.NoError(t, vErr)
+}

--- a/openapi3/testdata/relativeDocsWithEmbeddedSchema/index.yml
+++ b/openapi3/testdata/relativeDocsWithEmbeddedSchema/index.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.3
+info:
+  title: API Docs
+  description: Test case for relative documents with embedded schemas
+  version: 1.0.0
+paths:
+  /foo:
+    get:
+      summary: Get foo
+      responses:
+        200:
+          description: Foo is foo
+          content:
+            application/json:
+              schema:
+                $ref: schemas.yml#/Foo

--- a/openapi3/testdata/relativeDocsWithEmbeddedSchema/schemas.yml
+++ b/openapi3/testdata/relativeDocsWithEmbeddedSchema/schemas.yml
@@ -1,0 +1,11 @@
+Foo:
+  type: object
+  properties:
+    id:
+      type: string
+      readOnly: true
+    name:
+      type: string
+      minLength: 1
+      maxLength: 150
+  required: [id, name]


### PR DESCRIPTION
The OpenAPI spec states that you can embed any schema from a relative document: https://swagger.io/specification/#reference-object, but this currently only works if the relative document is formatted as an OpenAPI spec file.