### PR TITLE
Add extensions in missing resources

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -237,9 +237,18 @@ func (response *Response) UnmarshalJSON(data []byte) error {
 }
 
 type Header struct {
+	openapi3.ExtensionProps
 	Ref         string `json:"$ref,omitempty"`
 	Description string `json:"description,omitempty"`
 	Type        string `json:"type,omitempty"`
+}
+
+func (header *Header) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(header)
+}
+
+func (header *Header) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, header)
 }
 
 type SecurityRequirements []map[string][]string

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -45,12 +45,12 @@ type Server struct {
 	Variables   map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
 }
 
-func (value *Server) MarshalJSON() ([]byte, error) {
-	return jsoninfo.MarshalStrictStruct(value)
+func (server *Server) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(server)
 }
 
-func (value *Server) UnmarshalJSON(data []byte) error {
-	return jsoninfo.UnmarshalStrictStruct(data, value)
+func (server *Server) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, server)
 }
 
 func (server Server) ParameterNames() ([]string, error) {
@@ -138,9 +138,18 @@ func (server *Server) Validate(c context.Context) (err error) {
 
 // ServerVariable is specified by OpenAPI/Swagger standard version 3.0.
 type ServerVariable struct {
+	ExtensionProps
 	Enum        []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Default     interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
 	Description string        `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+func (serverVariable *ServerVariable) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(serverVariable)
+}
+
+func (serverVariable *ServerVariable) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, serverVariable)
 }
 
 func (serverVariable *ServerVariable) Validate(c context.Context) error {

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -1,5 +1,7 @@
 package openapi3
 
+import "github.com/getkin/kin-openapi/jsoninfo"
+
 // Tags is specified by OpenAPI/Swagger 3.0 standard.
 type Tags []*Tag
 
@@ -14,7 +16,16 @@ func (tags Tags) Get(name string) *Tag {
 
 // Tag is specified by OpenAPI/Swagger 3.0 standard.
 type Tag struct {
+	ExtensionProps
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
 	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+}
+
+func (t *Tag) MarshalJSON() ([]byte, error) {
+	return jsoninfo.MarshalStrictStruct(t)
+}
+
+func (t *Tag) UnmarshalJSON(data []byte) error {
+	return jsoninfo.UnmarshalStrictStruct(data, t)
 }


### PR DESCRIPTION
Regarding https://github.com/getkin/kin-openapi/issues/299 still having some resources mismatching the documentation.

Adding them 🙂 