### PR TITLE
Prevent infinite loop while loading openapi spec with recursive references

### DIFF
--- a/openapi3/swagger_loader_recursive_ref_test.go
+++ b/openapi3/swagger_loader_recursive_ref_test.go
@@ -1,0 +1,17 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoaderSupportsRecursiveReference(t *testing.T) {
+	loader := NewSwaggerLoader()
+	loader.IsExternalRefsAllowed = true
+	doc, err := loader.LoadSwaggerFromFile("testdata/recursiveRef/openapi.yml")
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.NoError(t, doc.Validate(loader.Context))
+	require.Equal(t, "bar", doc.Paths["/foo"].Get.Responses.Get(200).Value.Content.Get("application/json").Schema.Value.Properties["foo"].Value.Properties["bar"].Value.Items.Value.Example)
+}

--- a/openapi3/testdata/recursiveRef/components/Bar.yml
+++ b/openapi3/testdata/recursiveRef/components/Bar.yml
@@ -1,0 +1,2 @@
+type: string
+example: bar

--- a/openapi3/testdata/recursiveRef/components/Foo.yml
+++ b/openapi3/testdata/recursiveRef/components/Foo.yml
@@ -1,0 +1,6 @@
+type: object
+properties:
+  bar:
+    type: array
+    items:
+      $ref: ../openapi.yml#/components/schemas/Bar

--- a/openapi3/testdata/recursiveRef/openapi.yml
+++ b/openapi3/testdata/recursiveRef/openapi.yml
@@ -1,0 +1,13 @@
+openapi: "3.0.3"
+info:
+  title: Recursive refs example
+  version: "1.0"
+paths:
+  /foo:
+    $ref: ./paths/foo.yml
+components:
+  schemas:
+    Foo:
+      $ref: ./components/Foo.yml
+    Bar:
+      $ref: ./components/Bar.yml

--- a/openapi3/testdata/recursiveRef/paths/foo.yml
+++ b/openapi3/testdata/recursiveRef/paths/foo.yml
@@ -1,0 +1,11 @@
+get:
+  responses:
+    "200":
+      description: OK
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              foo:
+                $ref: ../openapi.yml#/components/schemas/Foo


### PR DESCRIPTION
Try to fix https://github.com/getkin/kin-openapi/issues/309