### PR TITLE
Reset compiledPattern when updating Pattern

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -448,6 +448,7 @@ func (schema *Schema) WithMaxLengthDecodedBase64(i int64) *Schema {
 
 func (schema *Schema) WithPattern(pattern string) *Schema {
 	schema.Pattern = pattern
+	schema.compiledPattern = nil
 	return schema
 }
 


### PR DESCRIPTION
Updating schema.Pattern should reset schema.compiledPattern so that the next validation will use the new value.
See https://github.com/getkin/kin-openapi/blob/3690b664fe9e5aa8e7e5de77833da7c32d08b6fa/openapi3/schema.go#L1141
