### PR TITLE
new: add detetion for undescribed request parameters

### DIFF
--- a/openapi3filter/options.go
+++ b/openapi3filter/options.go
@@ -11,7 +11,8 @@ type Options struct {
 	ExcludeResponseBody   bool
 	IncludeResponseStatus bool
 
-	MultiError bool
+	MultiError             bool
+	FailOnUnknownParameter bool
 
 	// See NoopAuthenticationFunc
 	AuthenticationFunc AuthenticationFunc


### PR DESCRIPTION
Added the ability, when checking a request, to find parameters that are not described in the schema. 