### PR TITLE
Have Header Object follow the structure of the Parameter Object

### DIFF
--- a/openapi3/openapi3_test.go
+++ b/openapi3/openapi3_test.go
@@ -130,7 +130,8 @@ components:
     someSchema:
       description: Some schema
   headers:
-    otherHeader: {}
+    otherHeader:
+      schema: {type: string}
     someHeader:
       "$ref": "#/components/headers/otherHeader"
   examples:
@@ -207,7 +208,11 @@ var specJSON = []byte(`
       }
     },
     "headers": {
-      "otherHeader": {},
+      "otherHeader": {
+        "schema": {
+          "type": "string"
+      	}
+      },
       "someHeader": {
         "$ref": "#/components/headers/otherHeader"
       }
@@ -317,7 +322,7 @@ func spec() *T {
 					Ref: "#/components/headers/otherHeader",
 				},
 				"otherHeader": {
-					Value: &Header{},
+					Value: &Header{Parameter{Schema: &SchemaRef{Value: NewStringSchema()}}},
 				},
 			},
 			Examples: map[string]*ExampleRef{

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -83,6 +83,7 @@ func (value Parameters) Validate(ctx context.Context) error {
 }
 
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.0.md#parameterObject
 type Parameter struct {
 	ExtensionProps
 	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
@@ -167,42 +168,42 @@ func (parameter *Parameter) UnmarshalJSON(data []byte) error {
 	return jsoninfo.UnmarshalStrictStruct(data, parameter)
 }
 
-func (parameter Parameter) JSONLookup(token string) (interface{}, error) {
+func (value Parameter) JSONLookup(token string) (interface{}, error) {
 	switch token {
 	case "schema":
-		if parameter.Schema != nil {
-			if parameter.Schema.Ref != "" {
-				return &Ref{Ref: parameter.Schema.Ref}, nil
+		if value.Schema != nil {
+			if value.Schema.Ref != "" {
+				return &Ref{Ref: value.Schema.Ref}, nil
 			}
-			return parameter.Schema.Value, nil
+			return value.Schema.Value, nil
 		}
 	case "name":
-		return parameter.Name, nil
+		return value.Name, nil
 	case "in":
-		return parameter.In, nil
+		return value.In, nil
 	case "description":
-		return parameter.Description, nil
+		return value.Description, nil
 	case "style":
-		return parameter.Style, nil
+		return value.Style, nil
 	case "explode":
-		return parameter.Explode, nil
+		return value.Explode, nil
 	case "allowEmptyValue":
-		return parameter.AllowEmptyValue, nil
+		return value.AllowEmptyValue, nil
 	case "allowReserved":
-		return parameter.AllowReserved, nil
+		return value.AllowReserved, nil
 	case "deprecated":
-		return parameter.Deprecated, nil
+		return value.Deprecated, nil
 	case "required":
-		return parameter.Required, nil
+		return value.Required, nil
 	case "example":
-		return parameter.Example, nil
+		return value.Example, nil
 	case "examples":
-		return parameter.Examples, nil
+		return value.Examples, nil
 	case "content":
-		return parameter.Content, nil
+		return value.Content, nil
 	}
 
-	v, _, err := jsonpointer.GetForToken(parameter.ExtensionProps, token)
+	v, _, err := jsonpointer.GetForToken(value.ExtensionProps, token)
 	return v, err
 }
 
@@ -294,6 +295,7 @@ func (value *Parameter) Validate(ctx context.Context) error {
 			return fmt.Errorf("parameter %q schema is invalid: %v", value.Name, err)
 		}
 	}
+
 	if content := value.Content; content != nil {
 		if err := content.Validate(ctx); err != nil {
 			return fmt.Errorf("parameter %q content is invalid: %v", value.Name, err)


### PR DESCRIPTION
Fixes #46

@pruser @danielvladco can you confirm this meets your needs? I'm asking specifically about the awkward way to construct a `Header.Value`:
```go
			Headers: map[string]*HeaderRef{
				"someHeader": {
					Ref: "#/components/headers/otherHeader",
				},
				"otherHeader": {
					Value: &Header{Parameter{Schema: &SchemaRef{Value: NewStringSchema()}}},
				},
			},
```