### PR TITLE
Add support for embedded struct pointers

### DIFF
--- a/jsoninfo/field_info.go
+++ b/jsoninfo/field_info.go
@@ -21,6 +21,9 @@ type FieldInfo struct {
 }
 
 func AppendFields(fields []FieldInfo, parentIndex []int, t reflect.Type) []FieldInfo {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
 	// For each field
 	numField := t.NumField()
 iteration:

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -85,6 +85,36 @@ func TestEmbeddedStructs(t *testing.T) {
 	require.Equal(t, true, ok)
 }
 
+func TestEmbeddedPointerStructs(t *testing.T) {
+	type EmbeddedStruct struct {
+		ID string
+	}
+
+	type ContainerStruct struct {
+		Name string
+		*EmbeddedStruct
+	}
+
+	instance := &ContainerStruct{
+		Name: "Container",
+		EmbeddedStruct: &EmbeddedStruct{
+			ID: "Embedded",
+		},
+	}
+
+	generator := NewGenerator(UseAllExportedFields())
+
+	schemaRef, err := generator.GenerateSchemaRef(reflect.TypeOf(instance))
+	require.NoError(t, err)
+
+	var ok bool
+	_, ok = schemaRef.Value.Properties["Name"]
+	require.Equal(t, true, ok)
+
+	_, ok = schemaRef.Value.Properties["ID"]
+	require.Equal(t, true, ok)
+}
+
 func TestCyclicReferences(t *testing.T) {
 	type ObjectDiff struct {
 		FieldCycle *ObjectDiff


### PR DESCRIPTION
This PR adds a guard clause so that if an embedded struct is an embedded struct _pointer_, `field_info.AppendFields` will set `t` to the underlying element. 

- Unit test added
- All tests passing