### PR TITLE
fix: Allow encoded path parameters with slashes

### DIFF
--- a/routers/gorillamux/router.go
+++ b/routers/gorillamux/router.go
@@ -56,7 +56,7 @@ func NewRouter(doc *openapi3.T) (routers.Router, error) {
 	if len(servers) == 0 {
 		servers = append(servers, srv{})
 	}
-	muxRouter := mux.NewRouter() /*.UseEncodedPath()?*/
+	muxRouter := mux.NewRouter().UseEncodedPath()
 	r := &Router{}
 	for _, path := range orderedPaths(doc.Paths) {
 		pathItem := doc.Paths[path]

--- a/routers/gorillamux/router_test.go
+++ b/routers/gorillamux/router_test.go
@@ -146,7 +146,7 @@ func TestRouter(t *testing.T) {
 	expect(r, http.MethodGet, "/params/a/b/c%2Fd", paramsGET, map[string]string{
 		"x": "a",
 		"y": "b",
-		"z": "c/d",
+		"z": "c%2Fd",
 	})
 	expect(r, http.MethodGet, "/books/War.and.Peace", paramsGET, map[string]string{
 		"bookid": "War.and.Peace",


### PR DESCRIPTION
Fixes #397 