### PR TITLE
Schema customization plug-point

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -239,7 +239,6 @@ func (g *Generator) generateWithoutSaving(parents []*jsoninfo.TypeInfo, t reflec
 			schema.Format = "date-time"
 		} else {
 			for _, fieldInfo := range typeInfo.Fields {
-				var fieldTag reflect.StructTag
 				// Only fields with JSON tag are considered (by default)
 				if !fieldInfo.HasJSONTag && !g.opts.useAllExportedFields {
 					continue
@@ -263,11 +262,17 @@ func (g *Generator) generateWithoutSaving(parents []*jsoninfo.TypeInfo, t reflec
 						}
 					} else {
 						ff := t.Field(fieldInfo.Index[len(fieldInfo.Index)-1])
-						fieldTag = ff.Tag
 						if tag, ok := ff.Tag.Lookup("yaml"); ok && tag != "-" {
 							fieldName, fType = tag, ff.Type
 						}
 					}
+				}
+
+				// extract the field tag if we have a customizer
+				var fieldTag reflect.StructTag
+				if g.opts.schemaCustomizer != nil {
+					ff := t.Field(fieldInfo.Index[len(fieldInfo.Index)-1])
+					fieldTag = ff.Tag
 				}
 
 				ref, err := g.generateSchemaRefFor(parents, fType, fieldName, fieldTag)

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -21,6 +21,11 @@ func (err *CycleError) Error() string { return "detected cycle" }
 // Option allows tweaking SchemaRef generation
 type Option func(*generatorOpt)
 
+// SchemaCustomizerFn is a callback function, allowing
+// the OpenAPI schema definition to be updated with additional
+// properties during the generation process, based on the
+// name of the field, the Go type, and the struct tags.
+// name will be "_root" for the top level object, and tag will be ""
 type SchemaCustomizerFn func(name string, t reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) error
 
 type generatorOpt struct {

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -21,7 +21,7 @@ func (err *CycleError) Error() string { return "detected cycle" }
 // Option allows tweaking SchemaRef generation
 type Option func(*generatorOpt)
 
-type SchemaCustomizerFn func(name string, t reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) *openapi3.Schema
+type SchemaCustomizerFn func(name string, t reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) error
 
 type generatorOpt struct {
 	useAllExportedFields bool
@@ -297,7 +297,9 @@ func (g *Generator) generateWithoutSaving(parents []*jsoninfo.TypeInfo, t reflec
 	}
 
 	if g.opts.schemaCustomizer != nil {
-		schema = g.opts.schemaCustomizer(name, t, tag, schema)
+		if err := g.opts.schemaCustomizer(name, t, tag, schema); err != nil {
+			return nil, err
+		}
 	}
 
 	return openapi3.NewSchemaRef(t.Name(), schema), nil

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -1,7 +1,10 @@
 package openapi3gen
 
 import (
+	"encoding/json"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -143,4 +146,59 @@ func TestCyclicReferences(t *testing.T) {
 	require.NotNil(t, schemaRef.Value.Properties["MapCycle"])
 	require.Equal(t, "object", schemaRef.Value.Properties["MapCycle"].Value.Type)
 	require.Equal(t, "#/components/schemas/ObjectDiff", schemaRef.Value.Properties["MapCycle"].Value.AdditionalProperties.Ref)
+}
+
+func TestSchemaCustomizer(t *testing.T) {
+	type Bla struct {
+		UntaggedStringField string
+		AnonStruct          struct {
+			InnerFieldWithoutTag int
+			InnerFieldWithTag    int `mymintag:"-1" mymaxtag:"50"`
+		}
+		EnumField string `json:"another" myenumtag:"a,b"`
+	}
+
+	schemaRef, _, err := NewSchemaRefForValue(&Bla{}, UseAllExportedFields(), SchemaCustomizer(func(name string, ft reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) *openapi3.Schema {
+		t.Logf("Field=%s,Tag=%s", name, tag)
+		if tag.Get("mymintag") != "" {
+			minVal, _ := strconv.ParseFloat(tag.Get("mymintag"), 64)
+			schema.Min = &minVal
+		}
+		if tag.Get("mymaxtag") != "" {
+			maxVal, _ := strconv.ParseFloat(tag.Get("mymaxtag"), 64)
+			schema.Max = &maxVal
+		}
+		if tag.Get("myenumtag") != "" {
+			for _, s := range strings.Split(tag.Get("myenumtag"), ",") {
+				schema.Enum = append(schema.Enum, s)
+			}
+		}
+		return schema
+	}))
+	require.NoError(t, err)
+	jsonSchema, _ := json.MarshalIndent(schemaRef, "", "  ")
+	require.Equal(t, `{
+  "properties": {
+    "AnonStruct": {
+      "properties": {
+        "InnerFieldWithTag": {
+          "maximum": 50,
+          "minimum": -1,
+          "type": "integer"
+        },
+        "InnerFieldWithoutTag": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "UntaggedStringField": {
+      "type": "string"
+    },
+    "another": {
+      "type": "string"
+    }
+  },
+  "type": "object"
+}`, string(jsonSchema))
 }

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -196,6 +196,10 @@ func TestSchemaCustomizer(t *testing.T) {
       "type": "string"
     },
     "another": {
+      "enum": [
+        "a",
+        "b"
+      ],
       "type": "string"
     }
   },


### PR DESCRIPTION
We would like to support additional descriptions and metadata field-by-field in our project.

Specific examples:
- Adding translated field-level descriptions
- Documenting possible values for an enum field
- Custom min/max values

This PR proposes a minimal change to the `openapi3gen` codebase, to allow projects like ours to have their own extensions using custom struct tags to annotate the Go structs with this extra information.