### PR TITLE
fix: ensure conversion won't fail on nil parameter

### DIFF
--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -896,7 +896,9 @@ func FromV3Operation(doc3 *openapi3.T, operation *openapi3.Operation) (*openapi2
 		if err != nil {
 			return nil, err
 		}
-		result.Parameters = append(result.Parameters, r)
+		if r != nil {
+			result.Parameters = append(result.Parameters, r)
+		}
 	}
 	if v := operation.RequestBody; v != nil {
 		// Find parameter name that we can use for the body


### PR DESCRIPTION
when converting a v2 spec to v3, I had an issue on a nil parameter.
this change fixes it by ensuring that nil parameters will be skipped.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x30 pc=0x104382ac4]

goroutine 1 [running]:
github.com/getkin/kin-openapi/openapi2.Parameters.Less(...)
	/Users/vbehar/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi2/openapi2.go:171
sort.insertionSort({0x104600ef8, 0x1400038e4c8}, 0x0, 0x4)
	/opt/homebrew/Cellar/go/1.17/libexec/src/sort/sort.go:40 +0xc8
sort.quickSort({0x104600ef8, 0x1400038e4c8}, 0x0, 0x4, 0x6)
	/opt/homebrew/Cellar/go/1.17/libexec/src/sort/sort.go:222 +0x1cc
sort.Sort({0x104600ef8, 0x1400038e4c8})
	/opt/homebrew/Cellar/go/1.17/libexec/src/sort/sort.go:231 +0x74
github.com/getkin/kin-openapi/openapi2conv.FromV3Operation(0x140002224e0, 0x140000cb860)
	/Users/vbehar/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi2conv/openapi2_conv.go:926 +0x61c
github.com/getkin/kin-openapi/openapi2conv.FromV3(0x140002224e0)
	/Users/vbehar/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi2conv/openapi2_conv.go:586 +0xddc
mypkg/internal/generator.(*Service).LoadOpenAPISpec(0x140003a8030, {0x10448d0ae, 0x1c})
	/Users/vbehar/mypkg/internal/generator/generator.go:104 +0x750
mypkg/internal/generator.CodeGenerator.Run({{0x10448d0ae, 0x1c}, {0x10447eec5, 0x1}, {0x140002c9a20, 0x2, 0x2}})
	/Users/vbehar/mypkg/internal/generator/generator.go:31 +0xd4
main.main()
	/Users/vbehar/mypkg/cmd/code-generator/main.go:24 +0x170
exit status 2
```