### PR TITLE
Add support for "application/x-yaml"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/go-openapi/jsonpointer v0.19.5
 	github.com/gorilla/mux v1.8.0
 	github.com/stretchr/testify v1.5.1
-	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v2 v2.3.0
 )

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io"
 	"io/ioutil"
 	"mime"
@@ -832,6 +833,8 @@ func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, 
 func init() {
 	RegisterBodyDecoder("text/plain", plainBodyDecoder)
 	RegisterBodyDecoder("application/json", jsonBodyDecoder)
+	RegisterBodyDecoder("application/x-yaml", yamlBodyDecoder)
+	RegisterBodyDecoder("application/yaml", yamlBodyDecoder)
 	RegisterBodyDecoder("application/problem+json", jsonBodyDecoder)
 	RegisterBodyDecoder("application/x-www-form-urlencoded", urlencodedBodyDecoder)
 	RegisterBodyDecoder("multipart/form-data", multipartBodyDecoder)
@@ -849,6 +852,14 @@ func plainBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Schem
 func jsonBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
 	var value interface{}
 	if err := json.NewDecoder(body).Decode(&value); err != nil {
+		return nil, &ParseError{Kind: KindInvalidFormat, Cause: err}
+	}
+	return value, nil
+}
+
+func yamlBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+	var value interface{}
+	if err := yaml.NewDecoder(body).Decode(&value); err != nil {
 		return nil, &ParseError{Kind: KindInvalidFormat, Cause: err}
 	}
 	return value, nil

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -1036,6 +1036,18 @@ func TestDecodeBody(t *testing.T) {
 			want: "foo",
 		},
 		{
+			name: "x-yaml",
+			mime: "application/x-yaml",
+			body: strings.NewReader("foo"),
+			want: "foo",
+		},
+		{
+			name: "yaml",
+			mime: "application/yaml",
+			body: strings.NewReader("foo"),
+			want: "foo",
+		},
+		{
 			name: "urlencoded form",
 			mime: "application/x-www-form-urlencoded",
 			body: strings.NewReader(urlencodedForm.Encode()),


### PR DESCRIPTION
Yaml follows the same flow as json, but with a different unmarshaller.

Added both Contet-Types:

- `application/yaml`
- `application/x-yaml`

Unsure if `text/yaml` should also be added

Reused currently yaml.v2 used by the project