### PR TITLE
Fix #422 added support for error unwrapping for errors with a single sub-error

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1489,6 +1489,8 @@ type SchemaError struct {
 	Origin      error
 }
 
+var _ interface{ Unwrap() error } = SchemaError{}
+
 func markSchemaErrorKey(err error, key string) error {
 	if v, ok := err.(*SchemaError); ok {
 		v.reversePath = append(v.reversePath, key)
@@ -1564,7 +1566,7 @@ func (err *SchemaError) Error() string {
 	return buf.String()
 }
 
-func (err *SchemaError) Unwrap() error {
+func (err SchemaError) Unwrap() error {
 	return err.Origin
 }
 

--- a/openapi3filter/errors.go
+++ b/openapi3filter/errors.go
@@ -17,6 +17,8 @@ type RequestError struct {
 	Err         error
 }
 
+var _ interface{ Unwrap() error } = RequestError{}
+
 func (err *RequestError) Error() string {
 	reason := err.Reason
 	if e := err.Err; e != nil {
@@ -35,7 +37,7 @@ func (err *RequestError) Error() string {
 	}
 }
 
-func (err *RequestError) Unwrap() error {
+func (err RequestError) Unwrap() error {
 	return err.Err
 }
 
@@ -47,6 +49,8 @@ type ResponseError struct {
 	Reason string
 	Err    error
 }
+
+var _ interface{ Unwrap() error } = ResponseError{}
 
 func (err *ResponseError) Error() string {
 	reason := err.Reason
@@ -60,7 +64,7 @@ func (err *ResponseError) Error() string {
 	return reason
 }
 
-func (err *ResponseError) Unwrap() error {
+func (err ResponseError) Unwrap() error {
 	return err.Err
 }
 

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -43,6 +43,8 @@ type ParseError struct {
 	path []interface{}
 }
 
+var _ interface{ Unwrap() error } = ParseError{}
+
 func (e *ParseError) Error() string {
 	var msg []string
 	if p := e.Path(); len(p) > 0 {
@@ -82,7 +84,7 @@ func (e *ParseError) RootCause() error {
 	return e.Cause
 }
 
-func (e *ParseError) Unwrap() error {
+func (e ParseError) Unwrap() error {
 	return e.Cause
 }
 


### PR DESCRIPTION
MultiError and SecurityRequirementsError are trickier - they'd need to be rethought as linked lists of errors. I can do that if you're interested, but I wanted to start with the easy wins.