### PR TITLE
Panic with customizer and embedded structs

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -103,6 +103,16 @@ func (g *Generator) generateSchemaRefFor(parents []*jsoninfo.TypeInfo, t reflect
 	return ref, err
 }
 
+func getStructField(t reflect.Type, fieldInfo jsoninfo.FieldInfo) reflect.StructField {
+	var ff reflect.StructField
+	// fieldInfo.Index is an array of indexes starting from the root of the type
+	for i := 0; i < len(fieldInfo.Index); i++ {
+		ff = t.Field(fieldInfo.Index[i])
+		t = ff.Type
+	}
+	return ff
+}
+
 func (g *Generator) generateWithoutSaving(parents []*jsoninfo.TypeInfo, t reflect.Type, name string, tag reflect.StructTag) (*openapi3.SchemaRef, error) {
 	typeInfo := jsoninfo.GetTypeInfo(t)
 	for _, parent := range parents {
@@ -266,7 +276,7 @@ func (g *Generator) generateWithoutSaving(parents []*jsoninfo.TypeInfo, t reflec
 							schema.WithPropertyRef(fieldName, ref)
 						}
 					} else {
-						ff := t.Field(fieldInfo.Index[len(fieldInfo.Index)-1])
+						ff := getStructField(t, fieldInfo)
 						if tag, ok := ff.Tag.Lookup("yaml"); ok && tag != "-" {
 							fieldName, fType = tag, ff.Type
 						}
@@ -276,7 +286,7 @@ func (g *Generator) generateWithoutSaving(parents []*jsoninfo.TypeInfo, t reflec
 				// extract the field tag if we have a customizer
 				var fieldTag reflect.StructTag
 				if g.opts.schemaCustomizer != nil {
-					ff := t.Field(fieldInfo.Index[len(fieldInfo.Index)-1])
+					ff := getStructField(t, fieldInfo)
 					fieldTag = ff.Tag
 				}
 

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -150,13 +150,23 @@ func TestCyclicReferences(t *testing.T) {
 }
 
 func TestSchemaCustomizer(t *testing.T) {
-	type Bla struct {
+	type NestedInnerBla struct {
+		Enum1Field string `json:"enum1" myenumtag:"a,b"`
+	}
+
+	type InnerBla struct {
 		UntaggedStringField string
 		AnonStruct          struct {
 			InnerFieldWithoutTag int
 			InnerFieldWithTag    int `mymintag:"-1" mymaxtag:"50"`
+			NestedInnerBla
 		}
-		EnumField string `json:"another" myenumtag:"a,b"`
+		Enum2Field string `json:"enum2" myenumtag:"c,d"`
+	}
+
+	type Bla struct {
+		InnerBla
+		EnumField3 string `json:"enum3" myenumtag:"e,f"`
 	}
 
 	schemaRef, _, err := NewSchemaRefForValue(&Bla{}, UseAllExportedFields(), SchemaCustomizer(func(name string, ft reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) error {
@@ -196,17 +206,31 @@ func TestSchemaCustomizer(t *testing.T) {
         },
         "InnerFieldWithoutTag": {
           "type": "integer"
-        }
+        },
+				"enum1": {
+					"enum": [
+						"a",
+						"b"
+					],
+					"type": "string"
+				}
       },
       "type": "object"
     },
     "UntaggedStringField": {
       "type": "string"
     },
-    "another": {
+    "enum2": {
       "enum": [
-        "a",
-        "b"
+        "c",
+        "d"
+      ],
+      "type": "string"
+    },
+    "enum3": {
+      "enum": [
+        "e",
+        "f"
       ],
       "type": "string"
     }


### PR DESCRIPTION
When a customizer is used, and there is an embedded struct, it's possible to see a panic as follows:
`panic: reflect: Field index out of bounds` (full stack at bottom of issue)

The root cause was this line of code:
https://github.com/getkin/kin-openapi/blob/9b46ae7fe3f20d6a42482e1ac952137381cc7b1b/openapi3gen/openapi3gen.go#L279

When introduced, that line of code was copied from here:
https://github.com/getkin/kin-openapi/blob/9b46ae7fe3f20d6a42482e1ac952137381cc7b1b/openapi3gen/openapi3gen.go#L269

I believe the bug exists in both places, so have provided a fix to both.

The problem was using the last `Index` array entry from the `jsoninfo.TypeInfo`, and assuming this is the correct index into the `reflect.Type` of the struct. However, in the case of an embedded structure, it will be necessary to traverse into the structure to find the correct object.

An example is provided in the unit test that demonstrates the panic before the fix.

```go
	type InnerBla struct {
		UntaggedStringField string
		AnonStruct          struct {
			InnerFieldWithoutTag int
			InnerFieldWithTag    int `mymintag:"-1" mymaxtag:"50"`
		}
		Enum2Field string `json:"enum2" myenumtag:"c,d"`
	}

	type Bla struct {
		InnerBla
		EnumField3 string `json:"enum3" myenumtag:"e,f"`
	}
```

In the above, when you want to find the tags on `Bla.Enum2Field`, the `Index` array will be `[0,2]`.
- `0` in `Bla` to get to the embedded `InnerBla`
- `2` within `InnerBla`

However, the code was just taking the last entry in the array - which is `2`.
That meant trying to index `2` on `Bla` - but there are only 2 fields, so that's beyond the end of the array.

```
panic: reflect: Field index out of bounds [recovered]
	panic: reflect: Field index out of bounds

goroutine 6 [running]:
testing.tRunner.func1.2(0x473f780, 0x48d5340)
	/usr/local/Cellar/go/1.16.4/libexec/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc0002de480)
	/usr/local/Cellar/go/1.16.4/libexec/src/testing/testing.go:1146 +0x4b6
panic(0x473f780, 0x48d5340)
	/usr/local/Cellar/go/1.16.4/libexec/src/runtime/panic.go:965 +0x1b9
reflect.(*structType).Field(0xc000039e00, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/usr/local/Cellar/go/1.16.4/libexec/src/reflect/type.go:1188 +0x205
reflect.(*rtype).Field(0xc000039e00, 0x6, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/usr/local/Cellar/go/1.16.4/libexec/src/reflect/type.go:923 +0x8c
github.com/getkin/kin-openapi/openapi3gen.(*Generator).generateWithoutSaving(0xc00033c220, 0xc0000ab7e8, 0x1, 0x4, 0x48f5c70, 0xc000039e00, 0x4814fb9, 0x5, 0x0, 0x0, ...)
	/Users/peterbroadhurst/dev/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi3gen/openapi3gen.go:279 +0x54b
github.com/getkin/kin-openapi/openapi3gen.(*Generator).generateSchemaRefFor(0xc00033c220, 0x0, 0x0, 0x0, 0x48f5c70, 0xc00033e200, 0x4814fb9, 0x5, 0x0, 0x0, ...)
	/Users/peterbroadhurst/dev/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi3gen/openapi3gen.go:98 +0x125
github.com/getkin/kin-openapi/openapi3gen.(*Generator).GenerateSchemaRef(...)
	/Users/peterbroadhurst/dev/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi3gen/openapi3gen.go:90
github.com/getkin/kin-openapi/openapi3gen.NewSchemaRefForValue(0xc00033e200, 0xc000340480, 0xc0000abc08, 0x1, 0x1, 0xc00033e200, 0xc000340480, 0x0, 0xc00006fc18)
	/Users/peterbroadhurst/dev/go/pkg/mod/github.com/getkin/kin-openapi@v0.75.0/openapi3gen/openapi3gen.go:58 +0xda
github.com/hyperledger/firefly/internal/oapispec.addInput(0x48ed510, 0xc0000280a0, 0x47a2c40, 0xc000340360, 0x4c3c860, 0x1, 0x1, 0x0, 0xc00032a3c0)
	/Users/peterbroadhurst/dev/photic/firefly/internal/oapispec/openapi3.go:101 +0x1c5
github.com/hyperledger/firefly/internal/oapispec.addRoute(0x48ed510, 0xc0000280a0, 0xc0002792b0, 0x4c46ae0)
	/Users/peterbroadhurst/dev/photic/firefly/internal/oapispec/openapi3.go:198 +0xff4
github.com/hyperledger/firefly/internal/oapispec.SwaggerGen(0x48ed510, 0xc0000280a0, 0x4c3f820, 0x4, 0x4, 0x482a640, 0x1d, 0x615e0cf0)
	/Users/peterbroadhurst/dev/photic/firefly/internal/oapispec/openapi3.go:55 +0x225
github.com/hyperledger/firefly/internal/oapispec.TestOpenAPI3SwaggerGen(0xc0002de480)
	/Users/peterbroadhurst/dev/photic/firefly/internal/oapispec/openapi3_test.go:110 +0x7b
testing.tRunner(0xc0002de480, 0x4853870)
	/usr/local/Cellar/go/1.16.4/libexec/src/testing/testing.go:1193 +0xef
created by testing.(*T).Run
	/usr/local/Cellar/go/1.16.4/libexec/src/testing/testing.go:1238 +0x2b3
```
