### PR TITLE
Do not escape regular expressions again (getkin#429)

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1167,7 +1167,7 @@ func (schema *Schema) visitJSONString(settings *schemaValidationSettings, value 
 			Value:       value,
 			Schema:      schema,
 			SchemaField: "pattern",
-			Reason:      fmt.Sprintf("string doesn't match the regular expression %q", schema.Pattern),
+			Reason:      fmt.Sprintf("string doesn't match the regular expression \"%s\"", schema.Pattern),
 		}
 		if !settings.multiError {
 			return err
@@ -1182,7 +1182,7 @@ func (schema *Schema) visitJSONString(settings *schemaValidationSettings, value 
 			switch {
 			case f.regexp != nil && f.callback == nil:
 				if cp := f.regexp; !cp.MatchString(value) {
-					formatErr = fmt.Sprintf("string doesn't match the format %q (regular expression %q)", format, cp.String())
+					formatErr = fmt.Sprintf("string doesn't match the format %q (regular expression \"%s\")", format, cp.String())
 				}
 			case f.regexp == nil && f.callback != nil:
 				if err := f.callback(value); err != nil {


### PR DESCRIPTION
The string representing the regular expression is already escaped, using `%q` escapes it again, resulting in the wrong regex being displayed.

I've changed the code to use `\"%s\"` instead of `%q`.