### PR TITLE
Define const schema types

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -17,13 +17,12 @@ import (
 )
 
 const (
-	TypeArray     = "array"
-	TypeBoolean   = "boolean"
-	TypeInteger   = "integer"
-	TypeNumber    = "number"
-	TypeObject    = "object"
-	TypeString    = "string"
-	TypeUndefined = ""
+	TypeArray   = "array"
+	TypeBoolean = "boolean"
+	TypeInteger = "integer"
+	TypeNumber  = "number"
+	TypeObject  = "object"
+	TypeString  = "string"
 )
 
 var (
@@ -646,7 +645,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) (err error)
 
 	schemaType := schema.Type
 	switch schemaType {
-	case TypeUndefined:
+	case "":
 	case TypeBoolean:
 	case TypeNumber:
 		if format := schema.Format; len(format) > 0 {


### PR DESCRIPTION
This PR defines data types as const strings.
This will help to have less errors when comparing types.

Types are defined in [OpenAPI spec](https://spec.openapis.org/oas/latest.html#data-types) and [JSON schema spec](https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-00#section-6.1.1).