### PR TITLE
Internalize references

### DIFF
--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -50,7 +50,7 @@ func isExternalRef(ref string) bool {
 	return ref != "" && !strings.HasPrefix(ref, "#/components/")
 }
 
-func (doc *T) addSchemaToSpec(s *SchemaRef, refNameResolver RefNameResolver) string {
+func (doc *T) addSchemaToSpec(s *SchemaRef, refNameResolver RefNameResolver) {
 	if s == nil || !isExternalRef(s.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -86,7 +86,7 @@ func (doc *T) addSchemaToSpec(s *SchemaRef, refNameResolver RefNameResolver) {
 	return s.Ref
 }
 
-func (doc *T) addParameterToSpec(p *ParameterRef, refNameResolver RefNameResolver) string {
+func (doc *T) addParameterToSpec(p *ParameterRef, refNameResolver RefNameResolver) {
 	if p == nil || !isExternalRef(p.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"path/filepath"
-	"strconv"
 	"strings"
 )
 
@@ -52,48 +51,30 @@ func isExternalRef(ref string) bool {
 
 func (doc *T) addSchemaToSpec(s *SchemaRef, refNameResolver RefNameResolver) {
 	if s == nil || !isExternalRef(s.Ref) {
-		return ""
+		return
 	}
 
 	name := refNameResolver(s.Ref)
-
-	// I just added a more comprehensive check for this being a schema but people should really
-	// make sure their resolver returns unique names
-	val := 1
-	for {
-		// basic check, may need something more exhaustive...
-		if existing, ok := doc.Components.Schemas[name]; ok {
-			if existing.Value.Description != s.Value.Description || s.Value.Type != existing.Value.Type {
-				name = refNameResolver(s.Ref) + strconv.Itoa(val)
-				val++
-				continue
-			}
-			newRef := "#/components/schemas/" + name
-			if newRef == s.Ref {
-				s.Ref = ""
-			} else {
-				s.Ref = newRef
-			}
-			return s.Ref
-		}
-		break
+	if _, ok := doc.Components.Schemas[name]; ok {
+		s.Ref = "#/components/schemas/" + name
+		return
 	}
+
 	if doc.Components.Schemas == nil {
 		doc.Components.Schemas = make(Schemas)
 	}
 	doc.Components.Schemas[name] = s.Value.NewRef()
 	s.Ref = "#/components/schemas/" + name
-	return s.Ref
 }
 
 func (doc *T) addParameterToSpec(p *ParameterRef, refNameResolver RefNameResolver) {
 	if p == nil || !isExternalRef(p.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(p.Ref)
 	if _, ok := doc.Components.Parameters[name]; ok {
 		p.Ref = "#/components/parameters/" + name
-		return p.Ref
+		return
 	}
 
 	if doc.Components.Parameters == nil {
@@ -101,126 +82,121 @@ func (doc *T) addParameterToSpec(p *ParameterRef, refNameResolver RefNameResolve
 	}
 	doc.Components.Parameters[name] = &ParameterRef{Value: p.Value}
 	p.Ref = "#/components/parameters/" + name
-	return p.Ref
 }
 
-func (doc *T) addHeaderToSpec(h *HeaderRef, refNameResolver RefNameResolver) string {
+func (doc *T) addHeaderToSpec(h *HeaderRef, refNameResolver RefNameResolver) {
 	if h == nil || !isExternalRef(h.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(h.Ref)
 	if _, ok := doc.Components.Headers[name]; ok {
 		h.Ref = "#/components/headers/" + name
-		return h.Ref
+		return
 	}
 	if doc.Components.Headers == nil {
 		doc.Components.Headers = make(Headers)
 	}
 	doc.Components.Headers[name] = &HeaderRef{Value: h.Value}
 	h.Ref = "#/components/headers/" + name
-	return h.Ref
 }
 
-func (doc *T) addRequestBodyToSpec(r *RequestBodyRef, refNameResolver RefNameResolver) string {
+func (doc *T) addRequestBodyToSpec(r *RequestBodyRef, refNameResolver RefNameResolver) {
 	if r == nil || !isExternalRef(r.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(r.Ref)
 	if _, ok := doc.Components.RequestBodies[name]; ok {
 		r.Ref = "#/components/requestBodies/" + name
-		return r.Ref
+		return
 	}
 	if doc.Components.RequestBodies == nil {
 		doc.Components.RequestBodies = make(RequestBodies)
 	}
 	doc.Components.RequestBodies[name] = &RequestBodyRef{Value: r.Value}
 	r.Ref = "#/components/requestBodies/" + name
-	return r.Ref
 }
 
 func (doc *T) addResponseToSpec(r *ResponseRef, refNameResolver RefNameResolver) {
 	if r == nil || !isExternalRef(r.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(r.Ref)
 	if _, ok := doc.Components.Responses[name]; ok {
 		r.Ref = "#/components/responses/" + name
-		return r.Ref
+		return
 	}
 	if doc.Components.Responses == nil {
 		doc.Components.Responses = make(Responses)
 	}
 	doc.Components.Responses[name] = &ResponseRef{Value: r.Value}
 	r.Ref = "#/components/responses/" + name
-	return r.Ref
+
 }
 
 func (doc *T) addSecuritySchemeToSpec(ss *SecuritySchemeRef, refNameResolver RefNameResolver) {
 	if ss == nil || !isExternalRef(ss.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(ss.Ref)
 	if _, ok := doc.Components.SecuritySchemes[name]; ok {
 		ss.Ref = "#/components/securitySchemes/" + name
-		return ss.Ref
+		return
 	}
 	if doc.Components.SecuritySchemes == nil {
 		doc.Components.SecuritySchemes = make(SecuritySchemes)
 	}
 	doc.Components.SecuritySchemes[name] = &SecuritySchemeRef{Value: ss.Value}
 	ss.Ref = "#/components/securitySchemes/" + name
-	return ss.Ref
+
 }
 
 func (doc *T) addExampleToSpec(e *ExampleRef, refNameResolver RefNameResolver) {
 	if e == nil || !isExternalRef(e.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(e.Ref)
 	if _, ok := doc.Components.Examples[name]; ok {
 		e.Ref = "#/components/examples/" + name
-		return e.Ref
+		return
 	}
 	if doc.Components.Examples == nil {
 		doc.Components.Examples = make(Examples)
 	}
 	doc.Components.Examples[name] = &ExampleRef{Value: e.Value}
 	e.Ref = "#/components/examples/" + name
-	return e.Ref
+
 }
 
 func (doc *T) addLinkToSpec(l *LinkRef, refNameResolver RefNameResolver) {
 	if l == nil || !isExternalRef(l.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(l.Ref)
 	if _, ok := doc.Components.Links[name]; ok {
 		l.Ref = "#/components/links/" + name
-		return l.Ref
+		return
 	}
 	if doc.Components.Links == nil {
 		doc.Components.Links = make(Links)
 	}
 	doc.Components.Links[name] = &LinkRef{Value: l.Value}
 	l.Ref = "#/components/links/" + name
-	return l.Ref
+
 }
 
 func (doc *T) addCallbackToSpec(c *CallbackRef, refNameResolver RefNameResolver) {
 	if c == nil || !isExternalRef(c.Ref) {
-		return ""
+		return
 	}
 	name := refNameResolver(c.Ref)
 	if _, ok := doc.Components.Callbacks[name]; ok {
 		c.Ref = "#/components/callbacks/" + name
-		return c.Ref
 	}
 	if doc.Components.Callbacks == nil {
 		doc.Components.Callbacks = make(Callbacks)
 	}
 	doc.Components.Callbacks[name] = &CallbackRef{Value: c.Value}
 	c.Ref = "#/components/callbacks/" + name
-	return c.Ref
 }
 
 func (doc *T) derefSchema(s *Schema, refNameResolver RefNameResolver) {
@@ -336,13 +312,17 @@ func (doc *T) derefPaths(paths map[string]*PathItem, refNameResolver RefNameReso
 // to the components section.
 //
 // refNameResolver takes in references to returns a name to store the reference under locally.
+// It MUST return a unique name for each reference type.
 // A default implementation is provided that will suffice for most use cases. See the function
 // documention for more details.
 //
 // Example:
 //
-//   doc.InternalizeRefs(context.Background(), DefaultRefNameResolver)
+//   doc.InternalizeRefs(context.Background(), nil)
 func (doc *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref string) string) {
+	if refNameResolver == nil {
+		refNameResolver = DefaultRefNameResolver
+	}
 
 	// Handle components section
 	names := schemaNames(doc.Components.Schemas)

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -3,14 +3,8 @@ package openapi3
 import (
 	"context"
 	"strconv"
+	"strings"
 )
-
-func isInternalRef(ref string) bool {
-	return ref != "" && ref[0] == '#'
-}
-func isExternalRef(ref string) bool {
-	return ref != "" && ref[0] != '#'
-}
 
 func schemaNames(s Schemas) []string {
 	out := make([]string, 0, len(s))
@@ -32,9 +26,13 @@ func parametersMapNames(s ParametersMap) []string {
 // to the components section.
 //
 // refNameResolver takes in references to returns a name to store the reference under locally.
-//
-// Currently response and request bodies are just inlined rather than moved to the components.
+// Some care should be taken to make sure the resolver does not return duplicate names for different
+// references.
 func (spec *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref string) string) *T {
+	isExternalRef := func(ref string) bool {
+		return ref != "" && !strings.HasPrefix(ref, "#/components/")
+	}
+
 	addSchemaToSpec := func(s *SchemaRef) string {
 		if s == nil || !isExternalRef(s.Ref) {
 			return ""

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -138,7 +138,7 @@ func (doc *T) addRequestBodyToSpec(r *RequestBodyRef, refNameResolver RefNameRes
 	return r.Ref
 }
 
-func (doc *T) addResponseToSpec(r *ResponseRef, refNameResolver RefNameResolver) string {
+func (doc *T) addResponseToSpec(r *ResponseRef, refNameResolver RefNameResolver) {
 	if r == nil || !isExternalRef(r.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -189,7 +189,7 @@ func (doc *T) addExampleToSpec(e *ExampleRef, refNameResolver RefNameResolver) {
 	return e.Ref
 }
 
-func (doc *T) addLinkToSpec(l *LinkRef, refNameResolver RefNameResolver) string {
+func (doc *T) addLinkToSpec(l *LinkRef, refNameResolver RefNameResolver) {
 	if l == nil || !isExternalRef(l.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -206,7 +206,7 @@ func (doc *T) addLinkToSpec(l *LinkRef, refNameResolver RefNameResolver) {
 	return l.Ref
 }
 
-func (doc *T) addCallbackToSpec(c *CallbackRef, refNameResolver RefNameResolver) string {
+func (doc *T) addCallbackToSpec(c *CallbackRef, refNameResolver RefNameResolver) {
 	if c == nil || !isExternalRef(c.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -172,7 +172,7 @@ func (doc *T) addSecuritySchemeToSpec(ss *SecuritySchemeRef, refNameResolver Ref
 	return ss.Ref
 }
 
-func (doc *T) addExampleToSpec(e *ExampleRef, refNameResolver RefNameResolver) string {
+func (doc *T) addExampleToSpec(e *ExampleRef, refNameResolver RefNameResolver) {
 	if e == nil || !isExternalRef(e.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -1,0 +1,160 @@
+package openapi3
+
+import (
+	"context"
+	"strconv"
+)
+
+func isInternalRef(ref string) bool {
+	return ref != "" && ref[0] == '#'
+}
+func isExternalRef(ref string) bool {
+	return ref != "" && ref[0] != '#'
+}
+
+func schemaNames(s Schemas) []string {
+	out := make([]string, 0, len(s))
+	for i := range s {
+		out = append(out, i)
+	}
+	return out
+}
+
+func parametersMapNames(s ParametersMap) []string {
+	out := make([]string, 0, len(s))
+	for i := range s {
+		out = append(out, i)
+	}
+	return out
+}
+
+// InternalizeSpecRefs removes all references to external files from the spec and moves them
+// to the components section.
+//
+// refNameResolver takes in references to returns a name to store the reference under locally.
+//
+// Currently response and request bodies are just inlined rather than moved to the components.
+func (spec *T) InternalizeSpecRefs(ctx context.Context, refNameResolver func(ref string) string) *T {
+	addSchemaToSpec := func(s *SchemaRef) string {
+		name := refNameResolver(s.Ref)
+
+		val := 1
+		for {
+			// basic check, may need something more exhaustive...
+			if existing, ok := spec.Components.Schemas[name]; ok {
+				if existing.Value.Description != s.Value.Description || s.Value.Type != existing.Value.Type {
+					name = refNameResolver(s.Ref) + strconv.Itoa(val)
+					val++
+					continue
+				}
+				s.Ref = "#/components/schemas/" + name
+				return s.Ref
+			}
+			break
+		}
+
+		spec.Components.Schemas[name] = s.Value.NewRef()
+		s.Ref = "#/components/schemas/" + name
+		return s.Ref
+	}
+	tryAddSchemaRef := func(s *SchemaRef) {
+		if s != nil && isExternalRef(s.Ref) {
+			addSchemaToSpec(s)
+		}
+	}
+
+	addParameterToSpec := func(p *ParameterRef) string {
+		name := refNameResolver(p.Ref)
+		if _, ok := spec.Components.Parameters[name]; ok {
+			p.Ref = "#/components/parameters/" + name
+			return p.Ref
+		}
+
+		spec.Components.Parameters[name] = &ParameterRef{Value: p.Value}
+		p.Ref = "#/components/parameters/" + name
+		return p.Ref
+	}
+
+	var derefSchema func(*Schema, []*Schema)
+	derefSchema = func(s *Schema, stack []*Schema) {
+		if len(stack) > 1000 {
+			panic("unresolved circular reference")
+		}
+		for _, p := range stack {
+			if p == s {
+				return
+			}
+		}
+		stack = append(stack, s)
+
+		for _, list := range []SchemaRefs{s.AllOf, s.AnyOf, s.OneOf} {
+			for _, s2 := range list {
+				tryAddSchemaRef(s2)
+				derefSchema(s2.Value, stack)
+			}
+		}
+		for _, s2 := range s.Properties {
+			tryAddSchemaRef(s2)
+			derefSchema(s2.Value, stack)
+		}
+		for _, ref := range []*SchemaRef{s.Not, s.AdditionalProperties, s.Items} {
+			if ref != nil {
+				tryAddSchemaRef(ref)
+				derefSchema(ref.Value, stack)
+			}
+		}
+	}
+
+	derefParameter := func(p *Parameter) {
+		tryAddSchemaRef(p.Schema)
+		if p.Schema.Value != nil {
+			derefSchema(p.Schema.Value, nil)
+		}
+	}
+
+	derefContent := func(c Content) {
+		for _, mediatype := range c {
+			tryAddSchemaRef(mediatype.Schema)
+			if mediatype.Schema != nil {
+				derefSchema(mediatype.Schema.Value, nil)
+			}
+		}
+	}
+
+	// inline all component references
+	names := schemaNames(spec.Components.Schemas)
+	for _, name := range names {
+		schema := spec.Components.Schemas[name]
+		derefSchema(schema.Value, nil)
+	}
+	names = parametersMapNames(spec.Components.Parameters)
+	for _, name := range names {
+		p := spec.Components.Parameters[name]
+		derefParameter(p.Value)
+	}
+
+	for _, ops := range spec.Paths {
+		// inline full operations
+		ops.Ref = ""
+
+		for _, op := range ops.Operations() {
+			if op.RequestBody != nil {
+				op.RequestBody.Ref = ""
+				derefContent(op.RequestBody.Value.Content)
+			}
+			for _, res := range op.Responses {
+				res.Ref = ""
+				derefContent(res.Value.Content)
+			}
+			for _, param := range op.Parameters {
+				// don't inline, add to file refs
+				if isExternalRef(param.Ref) {
+					addParameterToSpec(param)
+				}
+				derefParameter(param.Value)
+			}
+		}
+	}
+
+	return spec
+}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -155,7 +155,7 @@ func (doc *T) addResponseToSpec(r *ResponseRef, refNameResolver RefNameResolver)
 	return r.Ref
 }
 
-func (doc *T) addSecuritySchemeToSpec(ss *SecuritySchemeRef, refNameResolver RefNameResolver) string {
+func (doc *T) addSecuritySchemeToSpec(ss *SecuritySchemeRef, refNameResolver RefNameResolver) {
 	if ss == nil || !isExternalRef(ss.Ref) {
 		return ""
 	}

--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -51,7 +51,12 @@ func (spec *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref str
 					val++
 					continue
 				}
-				s.Ref = "#/components/schemas/" + name
+				newRef := "#/components/schemas/" + name
+				if newRef == s.Ref {
+					s.Ref = ""
+				} else {
+					s.Ref = newRef
+				}
 				return s.Ref
 			}
 			break
@@ -328,6 +333,7 @@ func (spec *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref str
 		schema := spec.Components.Schemas[name]
 		addSchemaToSpec(schema)
 		if schema != nil {
+			schema.Ref = "" // always dereference the top level
 			derefSchema(schema.Value, nil)
 		}
 	}
@@ -336,6 +342,7 @@ func (spec *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref str
 		p := spec.Components.Parameters[name]
 		addParameterToSpec(p)
 		if p != nil && p.Value != nil {
+			p.Ref = "" // always dereference the top level
 			derefParameter(*p.Value)
 		}
 	}
@@ -343,6 +350,7 @@ func (spec *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref str
 	for _, req := range spec.Components.RequestBodies {
 		addRequestBodyToSpec(req)
 		if req != nil && req.Value != nil {
+			req.Ref = "" // always dereference the top level
 			derefRequestBody(*req.Value)
 		}
 	}
@@ -355,6 +363,7 @@ func (spec *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref str
 	for _, cb := range spec.Components.Callbacks {
 		addCallbackToSpec(cb)
 		if cb != nil && cb.Value != nil {
+			cb.Ref = "" // always dereference the top level
 			derefPaths(*cb.Value)
 		}
 	}

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -1,0 +1,76 @@
+package openapi3
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func baseResolver(ref string) string {
+	split := strings.Split(ref, "#")
+	if len(split) == 2 {
+		return filepath.Base(split[1])
+	}
+	ref = split[0]
+	for ext := filepath.Ext(ref); len(ext) > 0; ext = filepath.Ext(ref) {
+		ref = strings.TrimSuffix(ref, ext)
+	}
+	return filepath.Base(ref)
+}
+
+func TestInternalizeRefs(t *testing.T) {
+	var regexpRef = regexp.MustCompile(`"\$ref":`)
+	var regexpRefInternal = regexp.MustCompile(`"\$ref":"\#`)
+
+	tests := []struct {
+		filename string
+	}{
+		{"testdata/testref.openapi.yml"},
+		{"testdata/recursiveRef/openapi.yml"},
+		{"testdata/spec.yaml"},
+		{"testdata/callbacks.yml"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.filename, func(t *testing.T) {
+			// Load in the reference spec from the testdata
+			sl := NewLoader()
+			sl.IsExternalRefsAllowed = true
+			doc, err := sl.LoadFromFile(test.filename)
+			require.NoError(t, err, "loading test file")
+
+			// Internalize the references
+			doc = doc.InternalizeRefs(context.Background(), baseResolver)
+
+			// Validate the internalized spec
+			require.Nil(t, doc.Validate(context.Background()), "validating internalized spec")
+
+			// write it out to the current directory, a different context to where
+			// we read it from which should fail if there are external references
+			data, err := doc.MarshalJSON()
+			require.NoError(t, err, "marshalling interalized spec")
+
+			// run a static check over the file, making sure each occurence of a
+			// reference is followed by a #
+			s, _ := json.MarshalIndent(doc, "", "  ")
+			fmt.Println(string(s))
+			require.Equal(t, len(regexpRef.FindAll(data, -1)), len(regexpRefInternal.FindAll(data, -1)), "checking all references are internal")
+
+			require.NoError(t, os.WriteFile("__internalized.openapi.json", data, 0644), "writing internalized spec to new context")
+
+			doc2, err := sl.LoadFromFile(test.filename)
+			require.NoError(t, err, "reloading spec")
+			require.Nil(t, doc2.Validate(context.Background()), "validating reloaded spec")
+
+			// try delete our artifact
+			require.NoError(t, os.Remove("__internalized.openapi.json"), "removing test artifact")
+		})
+	}
+}

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -25,7 +25,6 @@ func baseResolver(ref string) string {
 func TestInternalizeRefs(t *testing.T) {
 	var regexpRef = regexp.MustCompile(`"\$ref":`)
 	var regexpRefInternal = regexp.MustCompile(`"\$ref":"\#`)
-	_, _ = regexpRef, regexpRefInternal
 
 	tests := []struct {
 		filename string
@@ -53,9 +52,6 @@ func TestInternalizeRefs(t *testing.T) {
 
 			data, err := doc.MarshalJSON()
 			require.NoError(t, err, "marshalling internalized spec")
-
-			// indent, _ := json.MarshalIndent(doc, "", "  ")
-			// t.Logf("%s\n", indent)
 
 			// run a static check over the file, making sure each occurence of a
 			// reference is followed by a #

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -25,12 +25,13 @@ func baseResolver(ref string) string {
 func TestInternalizeRefs(t *testing.T) {
 	var regexpRef = regexp.MustCompile(`"\$ref":`)
 	var regexpRefInternal = regexp.MustCompile(`"\$ref":"\#`)
+	_, _ = regexpRef, regexpRefInternal
 
 	tests := []struct {
 		filename string
 	}{
 		{"testdata/testref.openapi.yml"},
-		// {"testdata/recursiveRef/openapi.yml"},
+		{"testdata/recursiveRef/openapi.yml"},
 		{"testdata/spec.yaml"},
 		{"testdata/callbacks.yml"},
 	}
@@ -52,6 +53,9 @@ func TestInternalizeRefs(t *testing.T) {
 
 			data, err := doc.MarshalJSON()
 			require.NoError(t, err, "marshalling internalized spec")
+
+			// indent, _ := json.MarshalIndent(doc, "", "  ")
+			// t.Logf("%s\n", indent)
 
 			// run a static check over the file, making sure each occurence of a
 			// reference is followed by a #

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -2,25 +2,11 @@ package openapi3
 
 import (
 	"context"
-	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
-
-func baseResolver(ref string) string {
-	split := strings.Split(ref, "#")
-	if len(split) == 2 {
-		return filepath.Base(split[1])
-	}
-	ref = split[0]
-	for ext := filepath.Ext(ref); len(ext) > 0; ext = filepath.Ext(ref) {
-		ref = strings.TrimSuffix(ref, ext)
-	}
-	return filepath.Base(ref)
-}
 
 func TestInternalizeRefs(t *testing.T) {
 	var regexpRef = regexp.MustCompile(`"\$ref":`)
@@ -44,7 +30,7 @@ func TestInternalizeRefs(t *testing.T) {
 			require.NoError(t, err, "loading test file")
 
 			// Internalize the references
-			doc = doc.InternalizeRefs(context.Background(), baseResolver)
+			doc.InternalizeRefs(context.Background(), DefaultRefNameResolver)
 
 			// Validate the internalized spec
 			err = doc.Validate(context.Background())

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -2,8 +2,6 @@ package openapi3
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -32,7 +30,7 @@ func TestInternalizeRefs(t *testing.T) {
 		filename string
 	}{
 		{"testdata/testref.openapi.yml"},
-		{"testdata/recursiveRef/openapi.yml"},
+		// {"testdata/recursiveRef/openapi.yml"},
 		{"testdata/spec.yaml"},
 		{"testdata/callbacks.yml"},
 	}
@@ -61,17 +59,11 @@ func TestInternalizeRefs(t *testing.T) {
 			numInternalRefs := len(regexpRefInternal.FindAll(data, -1))
 			require.Equal(t, numRefs, numInternalRefs, "checking all references are internal")
 
-			// write it out to the current directory, a different context to where
-			// we read it from which should fail if there are external references
-			require.NoError(t, ioutil.WriteFile("__internalized.openapi.json", data, 0644), "writing internalized spec to new context")
-			doc2, err := sl.LoadFromFile(test.filename)
+			// load from data, but with the path set to the current directory
+			doc2, err := sl.LoadFromData(data)
 			require.NoError(t, err, "reloading spec")
 			err = doc2.Validate(context.Background())
 			require.Nil(t, err, "validating reloaded spec")
-
-			// try delete our artifact
-			err = os.Remove("__internalized.openapi.json")
-			require.NoError(t, err, "removing test artifact")
 		})
 	}
 }


### PR DESCRIPTION
I needed this functionality for some tooling I'm building and thought I would make a pull request in-case anyone would find it useful. If so I can create a few tests too.

All this does is either inline or add to the components section all external references, so that when you write the file back out it is self contained and portable. This makes it easier for other tools to process and removes all dependencies.

If there's a better way of doing this let me know and I will update my code!