### PR TITLE
ClientCredentials conversion to OpenAPI v2

### DIFF
--- a/openapi2conv/issue187_test.go
+++ b/openapi2conv/issue187_test.go
@@ -167,3 +167,27 @@ paths:
 	err = doc3.Validate(context.Background())
 	require.NoError(t, err)
 }
+
+func TestPR449(t *testing.T) {
+	spec := `
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: title
+
+securityDefinitions:
+  OAuth2Application:
+    type: "oauth2"
+    flow: "application"
+    tokenUrl: "example.com/oauth2/token"
+`
+	doc3, err := v2v3YAML([]byte(spec))
+	require.NoError(t, err)
+	require.NotNil(t, doc3.Components.SecuritySchemes["OAuth2Application"].Value.Flows.ClientCredentials)
+	_, err = yaml.Marshal(doc3)
+	require.NoError(t, err)
+
+	doc2, err := FromV3(doc3)
+	require.NoError(t, err)
+	require.Equal(t, doc2.SecurityDefinitions["OAuth2Application"].Flow, "application")
+}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -525,6 +525,8 @@ func ToV3SecurityScheme(securityScheme *openapi2.SecurityScheme) (*openapi3.Secu
 			flows.AuthorizationCode = flow
 		case "password":
 			flows.Password = flow
+		case "application":
+			flows.ClientCredentials = flow
 		default:
 			return nil, fmt.Errorf("unsupported flow %q", securityScheme.Flow)
 		}
@@ -1076,6 +1078,8 @@ func FromV3SecurityScheme(doc3 *openapi3.T, ref *openapi3.SecuritySchemeRef) (*o
 				result.Flow = "accessCode"
 			} else if flow = flows.Password; flow != nil {
 				result.Flow = "password"
+			} else if flow = flows.ClientCredentials; flow != nil {
+				result.Flow = "application"
 			} else {
 				return nil, nil
 			}


### PR DESCRIPTION
 ClientCredentials was called application in OpenAPI v2 so this needs to be converted.

Specification:
https://swagger.io/specification/#oauth-flows-object