### PR TITLE
Do not clear refs on recursive type references

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -57,7 +57,9 @@ func NewSchemaRefForValue(value interface{}, opts ...Option) (*openapi3.SchemaRe
 	g := NewGenerator(opts...)
 	ref, err := g.GenerateSchemaRef(reflect.TypeOf(value))
 	for ref := range g.SchemaRefs {
-		ref.Ref = ""
+		if !strings.HasPrefix(ref.Ref, "#/") {
+			ref.Ref = ""
+		}
 	}
 	return ref, g.SchemaRefs, err
 }


### PR DESCRIPTION
Proposed UT and fix for #447 

A reference was being added carefully in the recursion checker while building the struct on this line (note this _also_ includes the `schema` being passed into the `value` of the `$ref` - we leave both):
https://github.com/getkin/kin-openapi/blob/0db2d4c3583875f4fe65b47ccb51662a20ed32a9/openapi3gen/openapi3gen.go#L344

However, it was then being stripped out in this code:
https://github.com/getkin/kin-openapi/blob/0db2d4c3583875f4fe65b47ccb51662a20ed32a9/openapi3gen/openapi3gen.go#L58-L61

As the original `$ref.value` was still there (see note above), this meant the infinite loop occurred on JSON serialization.

