### PR TITLE
extensible-paths

### DIFF
--- a/routers/gorillamux/router.go
+++ b/routers/gorillamux/router.go
@@ -142,7 +142,7 @@ func orderedPaths(paths map[string]*openapi3.PathItem) []string {
 	ordered := make([]string, 0, len(paths))
 	for c := 0; c <= max; c++ {
 		if ps, ok := vars[c]; ok {
-			sort.Strings(ps)
+			sort.Sort(sort.Reverse(sort.StringSlice(ps)))
 			ordered = append(ordered, ps...)
 		}
 	}

--- a/routers/gorillamux/router.go
+++ b/routers/gorillamux/router.go
@@ -128,7 +128,7 @@ func orderedPaths(paths map[string]*openapi3.PathItem) []string {
 	// https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.3.md#pathsObject
 	// When matching URLs, concrete (non-templated) paths would be matched
 	// before their templated counterparts.
-	// NOTE: sorting by number of variables ASC then by lexicographical
+	// NOTE: sorting by number of variables ASC then by descending lexicographical
 	// order seems to be a good heuristic.
 	vars := make(map[int][]string)
 	max := 0

--- a/routers/gorillamux/router_test.go
+++ b/routers/gorillamux/router_test.go
@@ -59,10 +59,10 @@ func TestRouter(t *testing.T) {
 					&openapi3.ParameterRef{Value: openapi3.NewPathParameter("bookid")},
 				},
 			},
-			"/books/{bookid2}.json": &openapi3.PathItem{
+			"/books/{bookid}.json": &openapi3.PathItem{
 				Post: booksPOST,
 				Parameters: openapi3.Parameters{
-					&openapi3.ParameterRef{Value: openapi3.NewPathParameter("bookid2")},
+					&openapi3.ParameterRef{Value: openapi3.NewPathParameter("bookid")},
 				},
 			},
 			"/partial": &openapi3.PathItem{
@@ -152,7 +152,7 @@ func TestRouter(t *testing.T) {
 		"bookid": "War.and.Peace",
 	})
 	expect(r, http.MethodPost, "/books/War.and.Peace.json", booksPOST, map[string]string{
-		"bookid2": "War.and.Peace",
+		"bookid": "War.and.Peace",
 	})
 	expect(r, http.MethodPost, "/partial", nil, nil)
 


### PR DESCRIPTION
## Summary

The existing path sorting approach is flawed, because calls to `Router.FindRoute()` invariably lead to `routers.ErrMethodNotAllowed` where both `/{X}` and `/{X}:<someSuffix>` are present.  This occurs because `gorillamux` does not preclude `:` inside parameter substitutions and the shorter templated path is evaluated first.  The suggested fix is simply to reverse the lexicographical ordering.  Thus, the longer path is evaluated first.



### Note on unit tests

The prior unit tests leverage lexicographical sorting on the parameter name itself, coupled with opportune parameter name selection, to ensure passing tests.  However, according to https://swagger.io/specification/#patterned-fields:

> Templated paths with the same hierarchy but different templated names MUST NOT exist as they are identical.

This is also exemplified in https://swagger.io/specification/#path-templating-matching 

This implies we should not leverage parameter names in this way.

While I can well imagine future support for "same hierarchy but different templated names" (eg: parameter schema or format different), then in such cases the paths should be evaluated in an ordering that guarantees the core problem does not occur.