### PR TITLE
WIP: Skip adding index in error for enum validation

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1308,7 +1308,10 @@ func (schema *Schema) visitJSONArray(settings *schemaValidationSettings, value [
 		}
 		for i, item := range value {
 			if err := itemSchema.visitJSON(settings, item); err != nil {
-				err = markSchemaErrorIndex(err, i)
+				// No need to mark index in error if validate the value with enum array
+				if len(itemSchema.Enum) == 0 {
+					err = markSchemaErrorIndex(err, i)
+				}
 				if !settings.multiError {
 					return err
 				}


### PR DESCRIPTION
Enum value validation has confused error messages like below where `Error at "0"` is like hardcoded because it is validating with enum values, which is unnecessary and confusing. So this PR suggests removing this. error will be `value is not one of the allowed values`
```
Error at \"/0\": value is not one of the allowed values
```