### PR TITLE
Fix openapi3 validation: path param must be required

### DIFF
--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -412,6 +412,7 @@ paths:
       parameters:
         - name: id,
           in: path
+          required: true
           schema:
             type: string
       responses:

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -252,6 +252,10 @@ func (value *Parameter) Validate(ctx context.Context) error {
 		return fmt.Errorf("parameter can't have 'in' value %q", value.In)
 	}
 
+	if in == ParameterInPath && !value.Required {
+		return fmt.Errorf("path parameter %q must be required", value.Name)
+	}
+
 	// Validate a parameter's serialization method.
 	sm, err := value.SerializationMethod()
 	if err != nil {

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -908,6 +908,7 @@ func TestDecodeParameter(t *testing.T) {
 					path := "/test"
 					if tc.path != "" {
 						path += "/{" + tc.param.Name + "}"
+						tc.param.Required = true
 					}
 
 					info := &openapi3.Info{

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -62,9 +62,10 @@ func TestFilter(t *testing.T) {
 					Parameters: openapi3.Parameters{
 						{
 							Value: &openapi3.Parameter{
-								In:     "path",
-								Name:   "pathArg",
-								Schema: openapi3.NewStringSchema().WithMaxLength(2).NewRef(),
+								In:       "path",
+								Name:     "pathArg",
+								Schema:   openapi3.NewStringSchema().WithMaxLength(2).NewRef(),
+								Required: true,
 							},
 						},
 						{


### PR DESCRIPTION
Hi,

Looks like path parameter always should be marked as `required: true` explicitly according OpenAPI 3.0 spec.
Quote from the [section](https://spec.openapis.org/oas/v3.0.3#fixed-fields-9) about `required` field of the parameter object:
> Determines whether this parameter is mandatory. If the [parameter location](https://spec.openapis.org/oas/v3.0.3#parameterIn) is "path", this property is REQUIRED and its value MUST be true. Otherwise, the property MAY be included and its default value is false.

So, perhaps it would be better to check this on validation.