### PR TITLE
distinguish form data in fromV3RequestBodies

### DIFF
--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -701,6 +701,10 @@ func fromV3RequestBodies(name string, requestBodyRef *openapi3.RequestBodyRef, c
 	//Only select one formData or request body for an individual requestBody as OpenAPI 2 does not support multiples
 	if requestBodyRef.Value != nil {
 		for contentType, mediaType := range requestBodyRef.Value.Content {
+			if consumes == nil {
+				consumes = make(map[string]struct{})
+			}
+			consumes[contentType] = struct{}{}
 			if contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data" {
 				formParameters = FromV3RequestBodyFormData(mediaType)
 				return

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -698,27 +698,26 @@ func fromV3RequestBodies(name string, requestBodyRef *openapi3.RequestBodyRef, c
 		return
 	}
 
-	//Only select one formData or request body for an individual requesstBody as OpenAPI 2 does not support multiples
+	//Only select one formData or request body for an individual requestBody as OpenAPI 2 does not support multiples
 	if requestBodyRef.Value != nil {
 		for contentType, mediaType := range requestBodyRef.Value.Content {
-			if consumes == nil {
-				consumes = make(map[string]struct{})
+			if contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data" {
+				formParameters = FromV3RequestBodyFormData(mediaType)
+				return
 			}
-			consumes[contentType] = struct{}{}
-			if formParams := FromV3RequestBodyFormData(mediaType); len(formParams) != 0 {
-				formParameters = formParams
-			} else {
-				paramName := name
-				if originalName, ok := requestBodyRef.Value.Extensions["x-originalParamName"]; ok {
-					json.Unmarshal(originalName.(json.RawMessage), &paramName)
-				}
 
-				var r *openapi2.Parameter
-				if r, err = FromV3RequestBody(paramName, requestBodyRef, mediaType, components); err != nil {
-					return
-				}
-				bodyOrRefParameters = append(bodyOrRefParameters, r)
+			paramName := name
+			if originalName, ok := requestBodyRef.Value.Extensions["x-originalParamName"]; ok {
+				json.Unmarshal(originalName.(json.RawMessage), &paramName)
 			}
+
+			var r *openapi2.Parameter
+			if r, err = FromV3RequestBody(paramName, requestBodyRef, mediaType, components); err != nil {
+				return
+			}
+
+			bodyOrRefParameters = append(bodyOrRefParameters, r)
+			return
 		}
 	}
 	return

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -707,7 +707,7 @@ func fromV3RequestBodies(name string, requestBodyRef *openapi3.RequestBodyRef, c
 			consumes[contentType] = struct{}{}
 			if contentType == "application/x-www-form-urlencoded" || contentType == "multipart/form-data" {
 				formParameters = FromV3RequestBodyFormData(mediaType)
-				return
+				continue
 			}
 
 			paramName := name
@@ -721,7 +721,6 @@ func fromV3RequestBodies(name string, requestBodyRef *openapi3.RequestBodyRef, c
 			}
 
 			bodyOrRefParameters = append(bodyOrRefParameters, r)
-			return
 		}
 	}
 	return

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -31,6 +31,26 @@ func TestConvOpenAPIV3ToV2(t *testing.T) {
 	require.JSONEq(t, exampleV2, string(data))
 }
 
+func TestConvOpenAPIV3ToV2WithReqBody(t *testing.T) {
+	var doc3 openapi3.T
+	err := json.Unmarshal([]byte(exampleRequestBodyV3), &doc3)
+	require.NoError(t, err)
+	{
+		// Refs need resolving before we can Validate
+		sl := openapi3.NewLoader()
+		err = sl.ResolveRefsIn(&doc3, nil)
+		require.NoError(t, err)
+		err = doc3.Validate(context.Background())
+		require.NoError(t, err)
+	}
+
+	doc2, err := FromV3(&doc3)
+	require.NoError(t, err)
+	data, err := json.Marshal(doc2)
+	require.NoError(t, err)
+	require.JSONEq(t, exampleRequestBodyV2, string(data))
+}
+
 func TestConvOpenAPIV2ToV3(t *testing.T) {
 	var doc2 openapi2.T
 	err := json.Unmarshal([]byte(exampleV2), &doc2)
@@ -764,5 +784,76 @@ const exampleV3 = `
 	],
 	"x-root": "root extension 1",
 	"x-root2": "root extension 2"
+}
+`
+
+const exampleRequestBodyV3 = `{
+	"info": {
+	  "description": "Test Spec",
+	  "title": "Test Spec",
+	  "version": "0.0.0"
+	},
+	"components": {
+		"requestBodies": {
+			"FooBody": {
+				"content": {
+					"application/json": {
+						"schema": {
+							"properties": { "message": { "type": "string" } },
+							"type": "object"
+			  			}
+					}
+		  		},
+		  		"description": "test spec request body.",
+		  		"required": true
+			}
+		}
+	},
+	"paths": {
+		"/foo-path": {
+			"post": {
+				"requestBody": { "$ref": "#/components/requestBodies/FooBody" },
+				"responses": { "202": { "description": "Test spec post." } },
+				"summary": "Test spec path"
+			}
+		}
+	},
+	"servers": [{ "url": "http://localhost/" }],
+	"openapi": "3.0.3"
+}
+`
+
+const exampleRequestBodyV2 = `{
+	"basePath": "/",
+	"consumes": ["application/json"],
+	"host": "localhost",
+	"info": {
+	  "description": "Test Spec",
+	  "title": "Test Spec",
+	  "version": "0.0.0"
+	},
+	"parameters": {
+	  "FooBody": {
+		"description": "test spec request body.",
+		"in": "body",
+		"name": "FooBody",
+		"required": true,
+		"schema": {
+		  "properties": { "message": { "type": "string" } },
+		  "type": "object"
+		}
+	  }
+	},
+	"paths": {
+	  "/foo-path": {
+		"post": {
+		  "parameters": [{ "$ref": "#/parameters/FooBody" }],
+		  "responses": { "202": { "description": "Test spec post." } },
+		  "summary": "Test spec path"
+		}
+	  }
+	},
+	"schemes": ["http"],
+	"swagger": "2.0"
 }
 `

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -828,30 +828,30 @@ const exampleRequestBodyV2 = `{
 	"consumes": ["application/json"],
 	"host": "localhost",
 	"info": {
-	  "description": "Test Spec",
-	  "title": "Test Spec",
-	  "version": "0.0.0"
+		"description": "Test Spec",
+		"title": "Test Spec",
+		"version": "0.0.0"
 	},
 	"parameters": {
-	  "FooBody": {
-		"description": "test spec request body.",
-		"in": "body",
-		"name": "FooBody",
-		"required": true,
-		"schema": {
-		  "properties": { "message": { "type": "string" } },
-		  "type": "object"
+		"FooBody": {
+			"description": "test spec request body.",
+			"in": "body",
+			"name": "FooBody",
+			"required": true,
+			"schema": {
+				"properties": { "message": { "type": "string" } },
+				"type": "object"
+			}
 		}
-	  }
 	},
 	"paths": {
-	  "/foo-path": {
-		"post": {
-		  "parameters": [{ "$ref": "#/parameters/FooBody" }],
-		  "responses": { "202": { "description": "Test spec post." } },
-		  "summary": "Test spec path"
+		"/foo-path": {
+			"post": {
+				"parameters": [{ "$ref": "#/parameters/FooBody" }],
+				"responses": { "202": { "description": "Test spec post." } },
+				"summary": "Test spec path"
+			}
 		}
-	  }
 	},
 	"schemes": ["http"],
 	"swagger": "2.0"

--- a/openapi2conv/openapi2_conv_test.go
+++ b/openapi2conv/openapi2_conv_test.go
@@ -789,9 +789,9 @@ const exampleV3 = `
 
 const exampleRequestBodyV3 = `{
 	"info": {
-	  "description": "Test Spec",
-	  "title": "Test Spec",
-	  "version": "0.0.0"
+		"description": "Test Spec",
+		"title": "Test Spec",
+		"version": "0.0.0"
 	},
 	"components": {
 		"requestBodies": {


### PR DESCRIPTION
This change fixes an issue in `openapi2conv.fromV3RequestBodies` where it didn't distinguish a "formData" parameter from a "body" parameter.

Given the following spec:
```json
{
  "info": {
    "description": "Test Spec",
    "title": "Test Spec",
    "version": "0.0.0"
  },
  "components": {
    "requestBodies": {
      "FooBody": {
        "content": {
          "application/json": {
            "schema": {
              "properties": { "message": { "type": "string" } },
              "type": "object"
            }
          }
        },
        "description": "test spec request body.",
        "required": true
      }
    }
  },
  "paths": {
    "/foo-path": {
      "post": {
        "requestBody": { "$ref": "#/components/requestBodies/FooBody" },
        "responses": { "202": { "description": "Test spec post." } },
        "summary": "Test spec path"
      }
    }
  },
  "servers": [{ "url": "http://localhost/" }],
  "openapi": "3.0.3"
}
```
Would produce the following output:
```json
{
  "basePath": "/",
  "consumes": ["application/json"],
  "host": "localhost",
  "info": {
    "description": "Test Spec",
    "title": "Test Spec",
    "version": "0.0.0"
  },
  "parameters": {
    "message": { "in": "formData", "name": "message", "type": "string" }
  },
  "paths": {
    "/foo-path": {
      "post": {
        "parameters": [{ "$ref": "#/parameters/FooBody" }],
        "responses": { "202": { "description": "Test spec post." } },
        "summary": "Test spec path"
      }
    }
  },
  "schemes": ["http"],
  "swagger": "2.0"
}
```
Note that `"$ref": "#/parameters/FooBody"` does not resolve and parameters contains "formData"

after this change:
```json
{
  "basePath": "/",
  "host": "localhost",
  "info": {
    "description": "Test Spec",
    "title": "Test Spec",
    "version": "0.0.0"
  },
  "parameters": {
    "FooBody": {
      "description": "test spec request body.",
      "in": "body",
      "name": "FooBody",
      "required": true,
      "schema": {
        "properties": { "message": { "type": "string" } },
        "type": "object"
      }
    }
  },
  "paths": {
    "/foo-path": {
      "post": {
        "parameters": [{ "$ref": "#/parameters/FooBody" }],
        "responses": { "202": { "description": "Test spec post." } },
        "summary": "Test spec path"
      }
    }
  },
  "schemes": ["http"],
  "swagger": "2.0"
}
```
Note `"$ref": "#/parameters/FooBody"` resolves to the correct schema.

I also took the liberty to ~~remove the unused `consumes` set and~~ fix a minor typo ✨ 