### PR TITLE
Fix OpenAPI 3 validation: request body content is required

### DIFF
--- a/openapi3/openapi3_test.go
+++ b/openapi3/openapi3_test.go
@@ -123,6 +123,7 @@ components:
   requestBodies:
     someRequestBody:
       description: Some request body
+      content: {}
   responses:
     someResponse:
       description: Some response
@@ -194,7 +195,8 @@ var specJSON = []byte(`
     },
     "requestBodies": {
       "someRequestBody": {
-        "description": "Some request body"
+        "description": "Some request body",
+        "content": {}
       }
     },
     "responses": {
@@ -253,6 +255,7 @@ func spec() *T {
 	}
 	requestBody := &RequestBody{
 		Description: "Some request body",
+		Content:     NewContent(),
 	}
 	responseDescription := "Some response"
 	response := &Response{

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -29,7 +29,7 @@ type RequestBody struct {
 	ExtensionProps
 	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
-	Content     Content `json:"content,omitempty" yaml:"content,omitempty"`
+	Content     Content `json:"content" yaml:"content"`
 }
 
 func NewRequestBody() *RequestBody {
@@ -98,10 +98,8 @@ func (requestBody *RequestBody) UnmarshalJSON(data []byte) error {
 }
 
 func (value *RequestBody) Validate(ctx context.Context) error {
-	if v := value.Content; v != nil {
-		if err := v.Validate(ctx); err != nil {
-			return err
-		}
+	if value.Content == nil {
+		return fmt.Errorf("content of the request body is required")
 	}
-	return nil
+	return value.Content.Validate(ctx)
 }


### PR DESCRIPTION
According to [request body object  spec section](https://spec.openapis.org/oas/v3.0.3#request-body-object) content field is required. Seems like it would be better to validate this.

P.S.: we use this cool library for strict OpenAPI v3 specs validation in one of our project, that's why I dive into this:)