### PR TITLE
issue/500

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -133,6 +133,9 @@ func getStructField(t reflect.Type, fieldInfo jsoninfo.FieldInfo) reflect.Struct
 	for i := 0; i < len(fieldInfo.Index); i++ {
 		ff = t.Field(fieldInfo.Index[i])
 		t = ff.Type
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
 	}
 	return ff
 }

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -133,7 +133,7 @@ func getStructField(t reflect.Type, fieldInfo jsoninfo.FieldInfo) reflect.Struct
 	for i := 0; i < len(fieldInfo.Index); i++ {
 		ff = t.Field(fieldInfo.Index[i])
 		t = ff.Type
-		if t.Kind() == reflect.Ptr {
+		for t.Kind() == reflect.Ptr {
 			t = t.Elem()
 		}
 	}


### PR DESCRIPTION
Fixes #500 by updating [getStructField](https://github.com/nicheinc/kin-openapi/blob/issue/500/openapi3gen/openapi3gen.go#L130-L141) to handle embedded pointer types, which were previously causing panics (but only when a schema customizer was being used). The solution involved adding these [three lines](https://github.com/nicheinc/kin-openapi/blob/issue/500/openapi3gen/openapi3gen.go#L136-L138), to mirror the logic happening [here](https://github.com/getkin/kin-openapi/blob/5352767564ece15c85c3d0a1ea1143d1f4206b04/jsoninfo/field_info.go#L24-L26).

Also includes a new unit test that should help prevent regressions (I verified that the unit test triggered the panic before these changes).

Please let me know if you have any questions!