### PR TITLE
discriminator value should verify the type is string to avoid panic

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -871,11 +871,12 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 					return errors.New("input does not contain the discriminator property")
 				}
 
-				if _, okcheck = discriminatorVal.(string); !okcheck {
+				discriminatorValString, okcheck := discriminatorVal.(string)
+				if !okcheck {
 					return errors.New("descriminator value is not a string")
 				}
 
-				if discriminatorRef, okcheck = schema.Discriminator.Mapping[discriminatorVal.(string)]; len(schema.Discriminator.Mapping) > 0 && !okcheck {
+				if discriminatorRef, okcheck = schema.Discriminator.Mapping[discriminatorValString]; len(schema.Discriminator.Mapping) > 0 && !okcheck {
 					return errors.New("input does not contain a valid discriminator value")
 				}
 			}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -871,8 +871,7 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 					return errors.New("input does not contain the discriminator property")
 				}
 
-				_, okcheck = discriminatorVal.(string)
-				if !okcheck {
+				if _, okcheck = discriminatorVal.(string); !okcheck {
 					return errors.New("descriminator value is not a string")
 				}
 

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -871,6 +871,11 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 					return errors.New("input does not contain the discriminator property")
 				}
 
+				_, okcheck = discriminatorVal.(string)
+				if !okcheck {
+					return errors.New("descriminator value is not a string")
+				}
+
 				if discriminatorRef, okcheck = schema.Discriminator.Mapping[discriminatorVal.(string)]; len(schema.Discriminator.Mapping) > 0 && !okcheck {
 					return errors.New("input does not contain a valid discriminator value")
 				}

--- a/openapi3/schema_oneOf_test.go
+++ b/openapi3/schema_oneOf_test.go
@@ -116,3 +116,21 @@ func TestVisitJSON_OneOf_NoDiscriptor_MissingField(t *testing.T) {
 	})
 	require.EqualError(t, err, "doesn't match schema due to: Error at \"/scratches\": property \"scratches\" is missing\nSchema:\n  {\n    \"properties\": {\n      \"name\": {\n        \"type\": \"string\"\n      },\n      \"scratches\": {\n        \"type\": \"boolean\"\n      }\n    },\n    \"required\": [\n      \"name\",\n      \"scratches\"\n    ],\n    \"type\": \"object\"\n  }\n\nValue:\n  {\n    \"name\": \"snoopy\"\n  }\n Or Error at \"/barks\": property \"barks\" is missing\nSchema:\n  {\n    \"properties\": {\n      \"barks\": {\n        \"type\": \"boolean\"\n      },\n      \"name\": {\n        \"type\": \"string\"\n      }\n    },\n    \"required\": [\n      \"name\",\n      \"barks\"\n    ],\n    \"type\": \"object\"\n  }\n\nValue:\n  {\n    \"name\": \"snoopy\"\n  }\n")
 }
+
+func TestVisitJSON_OneOf_BadDescriminatorType(t *testing.T) {
+	s, err := NewLoader().LoadFromData(oneofSpec)
+	require.NoError(t, err)
+	err = s.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+		"name":      "snoopy",
+		"scratches": true,
+		"$type":     1,
+	})
+	require.EqualError(t, err, "descriminator value is not a string")
+
+	err = s.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+		"name":  "snoopy",
+		"barks": true,
+		"$type": nil,
+	})
+	require.EqualError(t, err, "descriminator value is not a string")
+}


### PR DESCRIPTION
With out this check, the request with body like `{"discriminator": null}` or `{"discriminator": 1}` will simply get panic 
```
interface conversion: interface {} is nil, not string
```