### PR TITLE
Fix ExampleValidator test for 32-bit architectures

### DIFF
--- a/openapi3filter/middleware_test.go
+++ b/openapi3filter/middleware_test.go
@@ -420,7 +420,7 @@ paths:
 	// requests.
 	squareHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		xParam := path.Base(r.URL.Path)
-		x, err := strconv.Atoi(xParam)
+		x, err := strconv.ParseInt(xParam, 10, 64)
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
Fix an integer overflow in ExampleValidator on 32-bit architectures (where `65536 * 65536` with `int` returns `0`)
by using int64 for square calculations.

Tested with `GOARCH=386 go test ./...`

See Debian Bug report log "autopkgtest regression on armhf and i386" at https://bugs.debian.org/1007733

Many thanks!