### PR TITLE
openapi2: add missing schemes field of operation object

### DIFF
--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -151,6 +151,7 @@ type Operation struct {
 	Responses    map[string]*Response   `json:"responses" yaml:"responses"`
 	Consumes     []string               `json:"consumes,omitempty" yaml:"consumes,omitempty"`
 	Produces     []string               `json:"produces,omitempty" yaml:"produces,omitempty"`
+	Schemes      []string               `json:"schemes,omitempty" yaml:"schemes,omitempty"`
 	Security     *SecurityRequirements  `json:"security,omitempty" yaml:"security,omitempty"`
 }
 


### PR DESCRIPTION
closes https://github.com/getkin/kin-openapi/issues/366