### PR TITLE
Structures improvement

### DIFF
--- a/jsoninfo/field_info.go
+++ b/jsoninfo/field_info.go
@@ -9,15 +9,15 @@ import (
 
 // FieldInfo contains information about JSON serialization of a field.
 type FieldInfo struct {
-	MultipleFields     bool // Whether multiple Go fields share this JSON name
-	HasJSONTag         bool
-	TypeIsMarshaller   bool
+	Type               reflect.Type
+	JSONName           string
+	Index              []int
 	TypeIsUnmarshaller bool
 	JSONOmitEmpty      bool
 	JSONString         bool
-	Index              []int
-	Type               reflect.Type
-	JSONName           string
+	MultipleFields     bool
+	HasJSONTag         bool
+	TypeIsMarshaller   bool
 }
 
 func AppendFields(fields []FieldInfo, parentIndex []int, t reflect.Type) []FieldInfo {

--- a/jsoninfo/unmarshal.go
+++ b/jsoninfo/unmarshal.go
@@ -18,8 +18,8 @@ func UnmarshalStrictStruct(data []byte, value StrictStruct) error {
 }
 
 type ObjectDecoder struct {
-	Data            []byte
 	remainingFields map[string]json.RawMessage
+	Data            []byte
 }
 
 func NewObjectDecoder(data []byte) (*ObjectDecoder, error) {

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -146,17 +146,17 @@ func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
 
 type Operation struct {
 	openapi3.ExtensionProps
-	Summary      string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	ExternalDocs *openapi3.ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-	Tags         []string               `json:"tags,omitempty" yaml:"tags,omitempty"`
-	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Parameters   Parameters             `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	Responses    map[string]*Response   `json:"responses" yaml:"responses"`
+	ExternalDocs *openapi3.ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	Security     *SecurityRequirements  `json:"security,omitempty" yaml:"security,omitempty"`
+	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
+	Summary      string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
+	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Tags         []string               `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Parameters   Parameters             `json:"parameters,omitempty" yaml:"parameters,omitempty"`
 	Consumes     []string               `json:"consumes,omitempty" yaml:"consumes,omitempty"`
 	Produces     []string               `json:"produces,omitempty" yaml:"produces,omitempty"`
 	Schemes      []string               `json:"schemes,omitempty" yaml:"schemes,omitempty"`
-	Security     *SecurityRequirements  `json:"security,omitempty" yaml:"security,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Operation.
@@ -186,31 +186,31 @@ func (ps Parameters) Less(i, j int) bool {
 }
 
 type Parameter struct {
+	Default    interface{}         `json:"default,omitempty" yaml:"default,omitempty"`
+	MaxItems   *uint64             `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	MaxLength  *uint64             `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	Maximum    *float64            `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	Minimum    *float64            `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	MultipleOf *float64            `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Items      *openapi3.SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
+	Schema     *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
 	openapi3.ExtensionProps
-	Ref              string              `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	In               string              `json:"in,omitempty" yaml:"in,omitempty"`
-	Name             string              `json:"name,omitempty" yaml:"name,omitempty"`
-	Description      string              `json:"description,omitempty" yaml:"description,omitempty"`
-	CollectionFormat string              `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
-	Type             string              `json:"type,omitempty" yaml:"type,omitempty"`
-	Format           string              `json:"format,omitempty" yaml:"format,omitempty"`
-	Pattern          string              `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-	AllowEmptyValue  bool                `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
-	Required         bool                `json:"required,omitempty" yaml:"required,omitempty"`
-	UniqueItems      bool                `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-	ExclusiveMin     bool                `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-	ExclusiveMax     bool                `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-	Schema           *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Items            *openapi3.SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
-	Enum             []interface{}       `json:"enum,omitempty" yaml:"enum,omitempty"`
-	MultipleOf       *float64            `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
-	Minimum          *float64            `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	Maximum          *float64            `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	MaxLength        *uint64             `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	MaxItems         *uint64             `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-	MinLength        uint64              `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	MinItems         uint64              `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	Default          interface{}         `json:"default,omitempty" yaml:"default,omitempty"`
+	In               string        `json:"in,omitempty" yaml:"in,omitempty"`
+	CollectionFormat string        `json:"collectionFormat,omitempty" yaml:"collectionFormat,omitempty"`
+	Pattern          string        `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Ref              string        `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Format           string        `json:"format,omitempty" yaml:"format,omitempty"`
+	Type             string        `json:"type,omitempty" yaml:"type,omitempty"`
+	Description      string        `json:"description,omitempty" yaml:"description,omitempty"`
+	Name             string        `json:"name,omitempty" yaml:"name,omitempty"`
+	Enum             []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
+	MinItems         uint64        `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	MinLength        uint64        `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	AllowEmptyValue  bool          `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	ExclusiveMax     bool          `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	UniqueItems      bool          `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	Required         bool          `json:"required,omitempty" yaml:"required,omitempty"`
+	ExclusiveMin     bool          `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Parameter.
@@ -225,11 +225,11 @@ func (parameter *Parameter) UnmarshalJSON(data []byte) error {
 
 type Response struct {
 	openapi3.ExtensionProps
-	Ref         string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
 	Schema      *openapi3.SchemaRef    `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Headers     map[string]*Header     `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Examples    map[string]interface{} `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Ref         string                 `json:"$ref,omitempty" yaml:"$ref,omitempty"`
+	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Response.

--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -10,9 +10,8 @@ import (
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminatorObject
 type Discriminator struct {
 	ExtensionProps
-
-	PropertyName string            `json:"propertyName" yaml:"propertyName"`
 	Mapping      map[string]string `json:"mapping,omitempty" yaml:"mapping,omitempty"`
+	PropertyName string            `json:"propertyName" yaml:"propertyName"`
 }
 
 // MarshalJSON returns the JSON encoding of Discriminator.

--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -11,11 +11,10 @@ import (
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encodingObject
 type Encoding struct {
 	ExtensionProps
-
-	ContentType   string  `json:"contentType,omitempty" yaml:"contentType,omitempty"`
 	Headers       Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Style         string  `json:"style,omitempty" yaml:"style,omitempty"`
 	Explode       *bool   `json:"explode,omitempty" yaml:"explode,omitempty"`
+	ContentType   string  `json:"contentType,omitempty" yaml:"contentType,omitempty"`
+	Style         string  `json:"style,omitempty" yaml:"style,omitempty"`
 	AllowReserved bool    `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 }
 

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -29,14 +29,13 @@ var _ jsonpointer.JSONPointable = (*Links)(nil)
 // Link is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#linkObject
 type Link struct {
+	RequestBody interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Parameters  map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Server      *Server                `json:"server,omitempty" yaml:"server,omitempty"`
 	ExtensionProps
-
-	OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
-	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Server       *Server                `json:"server,omitempty" yaml:"server,omitempty"`
-	RequestBody  interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	OperationRef string `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
+	OperationID  string `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Description  string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Link.

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -25,28 +25,20 @@ func failedToResolveRefFragmentPart(value, what string) error {
 
 // Loader helps deserialize an OpenAPIv3 document
 type Loader struct {
-	// IsExternalRefsAllowed enables visiting other files
-	IsExternalRefsAllowed bool
-
-	// ReadFromURIFunc allows overriding the any file/URL reading func
-	ReadFromURIFunc ReadFromURIFunc
-
-	Context context.Context
-
-	rootDir string
-
-	visitedPathItemRefs map[string]struct{}
-
-	visitedDocuments map[string]*T
-
+	Context               context.Context
+	visitedSecurityScheme map[*SecurityScheme]struct{}
+	ReadFromURIFunc       ReadFromURIFunc
+	visitedSchema         map[*Schema]struct{}
+	visitedPathItemRefs   map[string]struct{}
+	visitedDocuments      map[string]*T
 	visitedExample        map[*Example]struct{}
 	visitedHeader         map[*Header]struct{}
 	visitedLink           map[*Link]struct{}
 	visitedParameter      map[*Parameter]struct{}
 	visitedRequestBody    map[*RequestBody]struct{}
 	visitedResponse       map[*Response]struct{}
-	visitedSchema         map[*Schema]struct{}
-	visitedSecurityScheme map[*SecurityScheme]struct{}
+	rootDir               string
+	IsExternalRefsAllowed bool
 }
 
 // NewLoader returns an empty Loader

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -11,16 +11,15 @@ import (
 // T is the root of an OpenAPI v3 document
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasObject
 type T struct {
+	Components Components `json:"components,omitempty" yaml:"components,omitempty"`
 	ExtensionProps
-
-	OpenAPI      string               `json:"openapi" yaml:"openapi"` // Required
-	Components   Components           `json:"components,omitempty" yaml:"components,omitempty"`
-	Info         *Info                `json:"info" yaml:"info"`   // Required
-	Paths        Paths                `json:"paths" yaml:"paths"` // Required
+	Info         *Info                `json:"info" yaml:"info"`
+	Paths        Paths                `json:"paths" yaml:"paths"`
+	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	OpenAPI      string               `json:"openapi" yaml:"openapi"`
 	Security     SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
 	Servers      Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Tags         Tags                 `json:"tags,omitempty" yaml:"tags,omitempty"`
-	ExternalDocs *ExternalDocs        `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of T.

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -13,41 +13,19 @@ import (
 // Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object
 type Operation struct {
+	RequestBody *RequestBodyRef       `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	Servers     *Servers              `json:"servers,omitempty" yaml:"servers,omitempty"`
+	Security    *SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
+	Callbacks   Callbacks             `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
+	Responses   Responses             `json:"responses" yaml:"responses"`
 	ExtensionProps
-
-	// Optional tags for documentation.
-	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
-
-	// Optional short summary.
-	Summary string `json:"summary,omitempty" yaml:"summary,omitempty"`
-
-	// Optional description. Should use CommonMark syntax.
-	Description string `json:"description,omitempty" yaml:"description,omitempty"`
-
-	// Optional operation ID.
-	OperationID string `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-
-	// Optional parameters.
-	Parameters Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-
-	// Optional body parameter.
-	RequestBody *RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
-
-	// Responses.
-	Responses Responses `json:"responses" yaml:"responses"` // Required
-
-	// Optional callbacks
-	Callbacks Callbacks `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
-
-	Deprecated bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-
-	// Optional security requirements that overrides top-level security.
-	Security *SecurityRequirements `json:"security,omitempty" yaml:"security,omitempty"`
-
-	// Optional servers that overrides top-level servers.
-	Servers *Servers `json:"servers,omitempty" yaml:"servers,omitempty"`
-
 	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	OperationID  string        `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
+	Summary      string        `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Tags         []string      `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Parameters   Parameters    `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Deprecated   bool          `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 }
 
 var _ jsonpointer.JSONPointable = (*Operation)(nil)

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -88,21 +88,20 @@ func (parameters Parameters) Validate(ctx context.Context) error {
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
 type Parameter struct {
+	Example  interface{} `json:"example,omitempty" yaml:"example,omitempty"`
+	Explode  *bool       `json:"explode,omitempty" yaml:"explode,omitempty"`
+	Examples Examples    `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Schema   *SchemaRef  `json:"schema,omitempty" yaml:"schema,omitempty"`
 	ExtensionProps
-
-	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
-	In              string      `json:"in,omitempty" yaml:"in,omitempty"`
-	Description     string      `json:"description,omitempty" yaml:"description,omitempty"`
-	Style           string      `json:"style,omitempty" yaml:"style,omitempty"`
-	Explode         *bool       `json:"explode,omitempty" yaml:"explode,omitempty"`
-	AllowEmptyValue bool        `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
-	AllowReserved   bool        `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
-	Deprecated      bool        `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Required        bool        `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema          *SchemaRef  `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example         interface{} `json:"example,omitempty" yaml:"example,omitempty"`
-	Examples        Examples    `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Content         Content     `json:"content,omitempty" yaml:"content,omitempty"`
+	Content         Content `json:"content,omitempty" yaml:"content,omitempty"`
+	Name            string  `json:"name,omitempty" yaml:"name,omitempty"`
+	Style           string  `json:"style,omitempty" yaml:"style,omitempty"`
+	Description     string  `json:"description,omitempty" yaml:"description,omitempty"`
+	In              string  `json:"in,omitempty" yaml:"in,omitempty"`
+	Deprecated      bool    `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Required        bool    `json:"required,omitempty" yaml:"required,omitempty"`
+	AllowEmptyValue bool    `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool    `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
 }
 
 var _ jsonpointer.JSONPointable = (*Parameter)(nil)

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -16,8 +16,8 @@ type Ref struct {
 // CallbackRef represents either a Callback or a $ref to a Callback.
 // When serializing and both fields are set, Ref is preferred over Value.
 type CallbackRef struct {
-	Ref   string
 	Value *Callback
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*CallbackRef)(nil)
@@ -53,8 +53,8 @@ func (value CallbackRef) JSONLookup(token string) (interface{}, error) {
 // ExampleRef represents either a Example or a $ref to a Example.
 // When serializing and both fields are set, Ref is preferred over Value.
 type ExampleRef struct {
-	Ref   string
 	Value *Example
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*ExampleRef)(nil)
@@ -90,8 +90,8 @@ func (value ExampleRef) JSONLookup(token string) (interface{}, error) {
 // HeaderRef represents either a Header or a $ref to a Header.
 // When serializing and both fields are set, Ref is preferred over Value.
 type HeaderRef struct {
-	Ref   string
 	Value *Header
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*HeaderRef)(nil)
@@ -127,8 +127,8 @@ func (value HeaderRef) JSONLookup(token string) (interface{}, error) {
 // LinkRef represents either a Link or a $ref to a Link.
 // When serializing and both fields are set, Ref is preferred over Value.
 type LinkRef struct {
-	Ref   string
 	Value *Link
+	Ref   string
 }
 
 // MarshalJSON returns the JSON encoding of LinkRef.
@@ -152,8 +152,8 @@ func (value *LinkRef) Validate(ctx context.Context) error {
 // ParameterRef represents either a Parameter or a $ref to a Parameter.
 // When serializing and both fields are set, Ref is preferred over Value.
 type ParameterRef struct {
-	Ref   string
 	Value *Parameter
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*ParameterRef)(nil)
@@ -189,8 +189,8 @@ func (value ParameterRef) JSONLookup(token string) (interface{}, error) {
 // ResponseRef represents either a Response or a $ref to a Response.
 // When serializing and both fields are set, Ref is preferred over Value.
 type ResponseRef struct {
-	Ref   string
 	Value *Response
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*ResponseRef)(nil)
@@ -226,8 +226,8 @@ func (value ResponseRef) JSONLookup(token string) (interface{}, error) {
 // RequestBodyRef represents either a RequestBody or a $ref to a RequestBody.
 // When serializing and both fields are set, Ref is preferred over Value.
 type RequestBodyRef struct {
-	Ref   string
 	Value *RequestBody
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
@@ -263,8 +263,8 @@ func (value RequestBodyRef) JSONLookup(token string) (interface{}, error) {
 // SchemaRef represents either a Schema or a $ref to a Schema.
 // When serializing and both fields are set, Ref is preferred over Value.
 type SchemaRef struct {
-	Ref   string
 	Value *Schema
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*SchemaRef)(nil)
@@ -307,8 +307,8 @@ func (value SchemaRef) JSONLookup(token string) (interface{}, error) {
 // SecuritySchemeRef represents either a SecurityScheme or a $ref to a SecurityScheme.
 // When serializing and both fields are set, Ref is preferred over Value.
 type SecuritySchemeRef struct {
-	Ref   string
 	Value *SecurityScheme
+	Ref   string
 }
 
 var _ jsonpointer.JSONPointable = (*SecuritySchemeRef)(nil)

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -30,10 +30,9 @@ func (r RequestBodies) JSONLookup(token string) (interface{}, error) {
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#requestBodyObject
 type RequestBody struct {
 	ExtensionProps
-
+	Content     Content `json:"content" yaml:"content"`
 	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
-	Content     Content `json:"content" yaml:"content"`
 }
 
 func NewRequestBody() *RequestBody {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -106,58 +106,45 @@ func (s SchemaRefs) JSONLookup(token string) (interface{}, error) {
 // Schema is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject
 type Schema struct {
+	Default interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+	Example interface{} `json:"example,omitempty" yaml:"example,omitempty"`
 	ExtensionProps
-
-	OneOf        SchemaRefs    `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
-	AnyOf        SchemaRefs    `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
-	AllOf        SchemaRefs    `json:"allOf,omitempty" yaml:"allOf,omitempty"`
-	Not          *SchemaRef    `json:"not,omitempty" yaml:"not,omitempty"`
-	Type         string        `json:"type,omitempty" yaml:"type,omitempty"`
-	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
-	Format       string        `json:"format,omitempty" yaml:"format,omitempty"`
-	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	Enum         []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-	Default      interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-	Example      interface{}   `json:"example,omitempty" yaml:"example,omitempty"`
-	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
-
-	// Array-related, here for struct compactness
-	UniqueItems bool `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
-	// Number-related, here for struct compactness
-	ExclusiveMin bool `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
-	ExclusiveMax bool `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
-	// Properties
-	Nullable        bool `json:"nullable,omitempty" yaml:"nullable,omitempty"`
-	ReadOnly        bool `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
-	WriteOnly       bool `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
-	AllowEmptyValue bool `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
-	Deprecated      bool `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	XML             *XML `json:"xml,omitempty" yaml:"xml,omitempty"`
-
-	// Number
-	Min        *float64 `json:"minimum,omitempty" yaml:"minimum,omitempty"`
-	Max        *float64 `json:"maximum,omitempty" yaml:"maximum,omitempty"`
-	MultipleOf *float64 `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
-
-	// String
-	MinLength       uint64  `json:"minLength,omitempty" yaml:"minLength,omitempty"`
-	MaxLength       *uint64 `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
-	Pattern         string  `json:"pattern,omitempty" yaml:"pattern,omitempty"`
-	compiledPattern *regexp.Regexp
-
-	// Array
-	MinItems uint64     `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	MaxItems *uint64    `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
-	Items    *SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
-
-	// Object
-	Required                    []string       `json:"required,omitempty" yaml:"required,omitempty"`
-	Properties                  Schemas        `json:"properties,omitempty" yaml:"properties,omitempty"`
-	MinProps                    uint64         `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
-	MaxProps                    *uint64        `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
-	AdditionalPropertiesAllowed *bool          `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"` // In this order...
-	AdditionalProperties        *SchemaRef     `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"` // ...for multijson
+	MaxProps                    *uint64    `json:"maxProperties,omitempty" yaml:"maxProperties,omitempty"`
+	Not                         *SchemaRef `json:"not,omitempty" yaml:"not,omitempty"`
+	Properties                  Schemas    `json:"properties,omitempty" yaml:"properties,omitempty"`
+	Items                       *SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
+	MaxItems                    *uint64    `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
+	compiledPattern             *regexp.Regexp
+	MaxLength                   *uint64        `json:"maxLength,omitempty" yaml:"maxLength,omitempty"`
+	AdditionalPropertiesAllowed *bool          `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"`
+	AdditionalProperties        *SchemaRef     `multijson:"additionalProperties,omitempty" json:"-" yaml:"-"`
+	ExternalDocs                *ExternalDocs  `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
+	MultipleOf                  *float64       `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
+	Max                         *float64       `json:"maximum,omitempty" yaml:"maximum,omitempty"`
+	Min                         *float64       `json:"minimum,omitempty" yaml:"minimum,omitempty"`
+	XML                         *XML           `json:"xml,omitempty" yaml:"xml,omitempty"`
 	Discriminator               *Discriminator `json:"discriminator,omitempty" yaml:"discriminator,omitempty"`
+	Type                        string         `json:"type,omitempty" yaml:"type,omitempty"`
+	Description                 string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Pattern                     string         `json:"pattern,omitempty" yaml:"pattern,omitempty"`
+	Title                       string         `json:"title,omitempty" yaml:"title,omitempty"`
+	Format                      string         `json:"format,omitempty" yaml:"format,omitempty"`
+	AllOf                       SchemaRefs     `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	Enum                        []interface{}  `json:"enum,omitempty" yaml:"enum,omitempty"`
+	AnyOf                       SchemaRefs     `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	OneOf                       SchemaRefs     `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	Required                    []string       `json:"required,omitempty" yaml:"required,omitempty"`
+	MinProps                    uint64         `json:"minProperties,omitempty" yaml:"minProperties,omitempty"`
+	MinLength                   uint64         `json:"minLength,omitempty" yaml:"minLength,omitempty"`
+	MinItems                    uint64         `json:"minItems,omitempty" yaml:"minItems,omitempty"`
+	WriteOnly                   bool           `json:"writeOnly,omitempty" yaml:"writeOnly,omitempty"`
+	UniqueItems                 bool           `json:"uniqueItems,omitempty" yaml:"uniqueItems,omitempty"`
+	ExclusiveMin                bool           `json:"exclusiveMinimum,omitempty" yaml:"exclusiveMinimum,omitempty"`
+	ExclusiveMax                bool           `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
+	Nullable                    bool           `json:"nullable,omitempty" yaml:"nullable,omitempty"`
+	Deprecated                  bool           `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	ReadOnly                    bool           `json:"readOnly,omitempty" yaml:"readOnly,omitempty"`
+	AllowEmptyValue             bool           `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 }
 
 var _ jsonpointer.JSONPointable = (*Schema)(nil)
@@ -1520,11 +1507,11 @@ func (schema *Schema) compilePattern() (err error) {
 
 type SchemaError struct {
 	Value       interface{}
-	reversePath []string
+	Origin      error
 	Schema      *Schema
 	SchemaField string
 	Reason      string
-	Origin      error
+	reversePath []string
 }
 
 var _ interface{ Unwrap() error } = SchemaError{}

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -223,11 +223,10 @@ func (flows *OAuthFlows) Validate(ctx context.Context) error {
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oauthFlowObject
 type OAuthFlow struct {
 	ExtensionProps
-
+	Scopes           map[string]string `json:"scopes" yaml:"scopes"`
 	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
 	RefreshURL       string            `json:"refreshUrl,omitempty" yaml:"refreshUrl,omitempty"`
-	Scopes           map[string]string `json:"scopes" yaml:"scopes"`
 }
 
 // MarshalJSON returns the JSON encoding of OAuthFlow.

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -42,10 +42,9 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string) 
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverObject
 type Server struct {
 	ExtensionProps
-
+	Variables   map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
 	URL         string                     `json:"url" yaml:"url"`
 	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
-	Variables   map[string]*ServerVariable `json:"variables,omitempty" yaml:"variables,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Server.
@@ -156,10 +155,9 @@ func (server *Server) Validate(ctx context.Context) (err error) {
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object
 type ServerVariable struct {
 	ExtensionProps
-
-	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Default     string   `json:"default,omitempty" yaml:"default,omitempty"`
 	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of ServerVariable.

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -33,10 +33,9 @@ func (tags Tags) Validate(ctx context.Context) error {
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#tagObject
 type Tag struct {
 	ExtensionProps
-
+	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Tag.

--- a/openapi3filter/errors.go
+++ b/openapi3filter/errors.go
@@ -10,11 +10,11 @@ var _ error = &RequestError{}
 
 // RequestError is returned by ValidateRequest when request does not match OpenAPI spec
 type RequestError struct {
+	Err         error
 	Input       *RequestValidationInput
 	Parameter   *openapi3.Parameter
 	RequestBody *openapi3.RequestBody
 	Reason      string
-	Err         error
 }
 
 var _ interface{ Unwrap() error } = RequestError{}
@@ -45,9 +45,9 @@ var _ error = &ResponseError{}
 
 // ResponseError is returned by ValidateResponse when response does not match OpenAPI spec
 type ResponseError struct {
+	Err    error
 	Input  *ResponseValidationInput
 	Reason string
-	Err    error
 }
 
 var _ interface{ Unwrap() error } = ResponseError{}

--- a/openapi3filter/middleware.go
+++ b/openapi3filter/middleware.go
@@ -171,10 +171,10 @@ type responseWrapper interface {
 
 type warnResponseWrapper struct {
 	w             http.ResponseWriter
-	headerWritten bool
-	status        int
-	body          bytes.Buffer
 	tee           io.Writer
+	body          bytes.Buffer
+	status        int
+	headerWritten bool
 }
 
 func newWarnResponseWrapper(w http.ResponseWriter) *warnResponseWrapper {
@@ -232,9 +232,9 @@ func (wr *warnResponseWrapper) bodyContents() []byte {
 
 type strictResponseWrapper struct {
 	w             http.ResponseWriter
-	headerWritten bool
-	status        int
 	body          bytes.Buffer
+	status        int
+	headerWritten bool
 }
 
 // Write implements http.ResponseWriter.

--- a/openapi3filter/options.go
+++ b/openapi3filter/options.go
@@ -7,18 +7,9 @@ var DefaultOptions = &Options{}
 
 // Options used by ValidateRequest and ValidateResponse
 type Options struct {
-	// Set ExcludeRequestBody so ValidateRequest skips request body validation
-	ExcludeRequestBody bool
-
-	// Set ExcludeResponseBody so ValidateResponse skips response body validation
-	ExcludeResponseBody bool
-
-	// Set IncludeResponseStatus so ValidateResponse fails on response
-	// status not defined in OpenAPI spec
+	AuthenticationFunc    AuthenticationFunc
+	ExcludeRequestBody    bool
+	ExcludeResponseBody   bool
 	IncludeResponseStatus bool
-
-	MultiError bool
-
-	// See NoopAuthenticationFunc
-	AuthenticationFunc AuthenticationFunc
+	MultiError            bool
 }

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -35,12 +35,11 @@ const (
 
 // ParseError describes errors which happens while parse operation's parameters, requestBody, or response.
 type ParseError struct {
-	Kind   ParseErrorKind
 	Value  interface{}
-	Reason string
 	Cause  error
-
-	path []interface{}
+	Reason string
+	path   []interface{}
+	Kind   ParseErrorKind
 }
 
 var _ interface{ Unwrap() error } = ParseError{}

--- a/openapi3filter/validate_response_input.go
+++ b/openapi3filter/validate_response_input.go
@@ -8,11 +8,11 @@ import (
 )
 
 type ResponseValidationInput struct {
-	RequestValidationInput *RequestValidationInput
-	Status                 int
-	Header                 http.Header
 	Body                   io.ReadCloser
+	RequestValidationInput *RequestValidationInput
+	Header                 http.Header
 	Options                *Options
+	Status                 int
 }
 
 func (input *ResponseValidationInput) SetBodyBytes(value []byte) *ResponseValidationInput {

--- a/openapi3filter/validation_error.go
+++ b/openapi3filter/validation_error.go
@@ -9,18 +9,12 @@ import (
 // useful for communicating issues back to end user and developer.
 // Based on https://jsonapi.org/format/#error-objects
 type ValidationError struct {
-	// A unique identifier for this particular occurrence of the problem.
-	Id string `json:"id,omitempty" yaml:"id,omitempty"`
-	// The HTTP status code applicable to this problem.
-	Status int `json:"status,omitempty" yaml:"status,omitempty"`
-	// An application-specific error code, expressed as a string value.
-	Code string `json:"code,omitempty" yaml:"code,omitempty"`
-	// A short, human-readable summary of the problem. It **SHOULD NOT** change from occurrence to occurrence of the problem, except for purposes of localization.
-	Title string `json:"title,omitempty" yaml:"title,omitempty"`
-	// A human-readable explanation specific to this occurrence of the problem.
-	Detail string `json:"detail,omitempty" yaml:"detail,omitempty"`
-	// An object containing references to the source of the error
 	Source *ValidationErrorSource `json:"source,omitempty" yaml:"source,omitempty"`
+	Id     string                 `json:"id,omitempty" yaml:"id,omitempty"`
+	Code   string                 `json:"code,omitempty" yaml:"code,omitempty"`
+	Title  string                 `json:"title,omitempty" yaml:"title,omitempty"`
+	Detail string                 `json:"detail,omitempty" yaml:"detail,omitempty"`
+	Status int                    `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // ValidationErrorSource struct

--- a/openapi3filter/validation_handler.go
+++ b/openapi3filter/validation_handler.go
@@ -17,10 +17,10 @@ var _ AuthenticationFunc = NoopAuthenticationFunc
 
 type ValidationHandler struct {
 	Handler            http.Handler
-	AuthenticationFunc AuthenticationFunc
-	File               string
-	ErrorEncoder       ErrorEncoder
 	router             routers.Router
+	AuthenticationFunc AuthenticationFunc
+	ErrorEncoder       ErrorEncoder
+	File               string
 }
 
 func (h *ValidationHandler) Load() error {

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -37,9 +37,9 @@ type Option func(*generatorOpt)
 type SchemaCustomizerFn func(name string, t reflect.Type, tag reflect.StructTag, schema *openapi3.Schema) error
 
 type generatorOpt struct {
+	schemaCustomizer     SchemaCustomizerFn
 	useAllExportedFields bool
 	throwErrorOnCycle    bool
-	schemaCustomizer     SchemaCustomizerFn
 }
 
 // UseAllExportedFields changes the default behavior of only

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -18,26 +18,21 @@ import (
 func ExampleGenerator_SchemaRefs() {
 	type SomeOtherType string
 	type SomeStruct struct {
-		Bool    bool                      `json:"bool"`
-		Int     int                       `json:"int"`
-		Int64   int64                     `json:"int64"`
-		Float64 float64                   `json:"float64"`
-		String  string                    `json:"string"`
-		Bytes   []byte                    `json:"bytes"`
-		JSON    json.RawMessage           `json:"json"`
-		Time    time.Time                 `json:"time"`
-		Slice   []SomeOtherType           `json:"slice"`
-		Map     map[string]*SomeOtherType `json:"map"`
-
-		Struct struct {
+		Time        time.Time                 `json:"time"`
+		Ptr         *SomeOtherType            `json:"ptr"`
+		Map         map[string]*SomeOtherType `json:"map"`
+		EmptyStruct struct{ Y string }        `json:"structWithoutFields"`
+		Struct      struct {
 			X string `json:"x"`
 		} `json:"struct"`
-
-		EmptyStruct struct {
-			Y string
-		} `json:"structWithoutFields"`
-
-		Ptr *SomeOtherType `json:"ptr"`
+		String  string          `json:"string"`
+		JSON    json.RawMessage `json:"json"`
+		Bytes   []byte          `json:"bytes"`
+		Slice   []SomeOtherType `json:"slice"`
+		Float64 float64         `json:"float64"`
+		Int64   int64           `json:"int64"`
+		Int     int             `json:"int"`
+		Bool    bool            `json:"bool"`
 	}
 
 	g := openapi3gen.NewGenerator()
@@ -270,8 +265,8 @@ func TestEmbeddedPointerStructs(t *testing.T) {
 	}
 
 	type ContainerStruct struct {
-		Name string
 		*EmbeddedStruct
+		Name string
 	}
 
 	instance := &ContainerStruct{
@@ -301,8 +296,8 @@ func TestEmbeddedPointerStructsWithSchemaCustomizer(t *testing.T) {
 	}
 
 	type ContainerStruct struct {
-		Name string
 		*EmbeddedStruct
+		Name string
 	}
 
 	instance := &ContainerStruct{
@@ -333,8 +328,8 @@ func TestEmbeddedPointerStructsWithSchemaCustomizer(t *testing.T) {
 func TestCyclicReferences(t *testing.T) {
 	type ObjectDiff struct {
 		FieldCycle *ObjectDiff
-		SliceCycle []*ObjectDiff
 		MapCycle   map[*ObjectDiff]*ObjectDiff
+		SliceCycle []*ObjectDiff
 	}
 
 	instance := &ObjectDiff{
@@ -368,9 +363,9 @@ func ExampleSchemaCustomizer() {
 	type InnerBla struct {
 		UntaggedStringField string
 		AnonStruct          struct {
+			NestedInnerBla
 			InnerFieldWithoutTag int
 			InnerFieldWithTag    int `mymintag:"-1" mymaxtag:"50"`
-			NestedInnerBla
 		}
 		Enum2Field string `json:"enum2" myenumtag:"c,d"`
 	}

--- a/openapi3gen/simple_test.go
+++ b/openapi3gen/simple_test.go
@@ -10,26 +10,21 @@ import (
 
 type (
 	SomeStruct struct {
-		Bool    bool                      `json:"bool"`
-		Int     int                       `json:"int"`
-		Int64   int64                     `json:"int64"`
-		Float64 float64                   `json:"float64"`
-		String  string                    `json:"string"`
-		Bytes   []byte                    `json:"bytes"`
-		JSON    json.RawMessage           `json:"json"`
-		Time    time.Time                 `json:"time"`
-		Slice   []SomeOtherType           `json:"slice"`
-		Map     map[string]*SomeOtherType `json:"map"`
-
-		Struct struct {
+		Time        time.Time                 `json:"time"`
+		Ptr         *SomeOtherType            `json:"ptr"`
+		Map         map[string]*SomeOtherType `json:"map"`
+		EmptyStruct struct{ Y string }        `json:"structWithoutFields"`
+		Struct      struct {
 			X string `json:"x"`
 		} `json:"struct"`
-
-		EmptyStruct struct {
-			Y string
-		} `json:"structWithoutFields"`
-
-		Ptr *SomeOtherType `json:"ptr"`
+		String  string          `json:"string"`
+		JSON    json.RawMessage `json:"json"`
+		Bytes   []byte          `json:"bytes"`
+		Slice   []SomeOtherType `json:"slice"`
+		Float64 float64         `json:"float64"`
+		Int64   int64           `json:"int64"`
+		Int     int             `json:"int"`
+		Bool    bool            `json:"bool"`
 	}
 
 	SomeOtherType string

--- a/routers/types.go
+++ b/routers/types.go
@@ -22,10 +22,10 @@ type Router interface {
 type Route struct {
 	Spec      *openapi3.T
 	Server    *openapi3.Server
-	Path      string
 	PathItem  *openapi3.PathItem
-	Method    string
 	Operation *openapi3.Operation
+	Path      string
+	Method    string
 }
 
 // ErrPathNotFound is returned when no route match is found


### PR DESCRIPTION
In this PR I've used the `fieldalignment` tool to improve the structure size in memory.

Here is the output:
```sh
$> fieldalignment -fix ./jsoninfo
./jsoninfo/field_info.go:11:16: struct with 56 pointer bytes could be 40
./jsoninfo/unmarshal.go:20:20: struct with 32 pointer bytes could be 16
./jsoninfo/marshal_test.go:12:13: struct with 88 pointer bytes could be 56
./jsoninfo/marshal_test.go:23:22: struct with 88 pointer bytes could be 56
./jsoninfo/marshal_test.go:70:14: struct with 40 pointer bytes could be 32

$> fieldalignment -fix ./openapi2
./openapi2/openapi2.go:147:16: struct with 200 pointer bytes could be 184
./openapi2/openapi2.go:188:16: struct with 256 pointer bytes could be 216
./openapi2/openapi2.go:226:15: struct with 64 pointer bytes could be 56

$> fieldalignment -fix ./openapi2conv

$> fieldalignment -fix ./openapi3
./openapi3/discriminator.go:11:20: struct with 32 pointer bytes could be 24
./openapi3/encoding.go:12:15: struct with 56 pointer bytes could be 48
./openapi3/link.go:31:11: struct with 88 pointer bytes could be 80
./openapi3/loader.go:27:13: struct with 128 pointer bytes could be 112
./openapi3/openapi3.go:13:8: struct with 200 pointer bytes could be 184
./openapi3/operation.go:15:16: struct with 160 pointer bytes could be 136
./openapi3/parameter.go:90:16: struct with 128 pointer bytes could be 112
./openapi3/refs.go:18:18: struct with 24 pointer bytes could be 16
./openapi3/refs.go:55:17: struct with 24 pointer bytes could be 16
./openapi3/refs.go:92:16: struct with 24 pointer bytes could be 16
./openapi3/refs.go:129:14: struct with 24 pointer bytes could be 16
./openapi3/refs.go:154:19: struct with 24 pointer bytes could be 16
./openapi3/refs.go:191:18: struct with 24 pointer bytes could be 16
./openapi3/refs.go:228:21: struct with 24 pointer bytes could be 16
./openapi3/refs.go:265:16: struct with 24 pointer bytes could be 16
./openapi3/refs.go:309:24: struct with 24 pointer bytes could be 16
./openapi3/request_body.go:31:18: struct with 40 pointer bytes could be 24
./openapi3/schema.go:108:13: struct with 392 pointer bytes could be 344
./openapi3/schema.go:1521:18: struct with 96 pointer bytes could be 80
./openapi3/security_scheme.go:224:16: struct with 64 pointer bytes could be 56
./openapi3/server.go:43:13: struct with 48 pointer bytes could be 40
./openapi3/server.go:157:21: struct with 56 pointer bytes could be 48
./openapi3/tag.go:34:10: struct with 48 pointer bytes could be 40
./openapi3/content_test.go:24:13: struct with 48 pointer bytes could be 40
./openapi3/encoding_test.go:64:17: struct with 32 pointer bytes could be 24
./openapi3/loader_relative_refs_test.go:11:23: struct with 40 pointer bytes could be 32
./openapi3/loader_relative_refs_test.go:17:39: struct with 48 pointer bytes could be 40
./openapi3/operation_test.go:48:13: struct with 40 pointer bytes could be 32
./openapi3/server_test.go:64:13: struct with 40 pointer bytes could be 32

$> fieldalignment -fix ./openapi3filter
./openapi3filter/errors.go:12:19: struct with 56 pointer bytes could be 48
./openapi3filter/errors.go:47:20: struct with 40 pointer bytes could be 32
./openapi3filter/middleware.go:172:26: struct with 88 pointer bytes could be 40
./openapi3filter/middleware.go:233:28: struct with 40 pointer bytes could be 24
./openapi3filter/options.go:9:14: struct with 16 pointer bytes could be 8
./openapi3filter/req_resp_decoder.go:37:17: struct with 64 pointer bytes could be 56
./openapi3filter/validate_response_input.go:10:30: struct with 48 pointer bytes could be 40
./openapi3filter/validation_error.go:11:22: struct with 80 pointer bytes could be 64
./openapi3filter/validation_handler.go:18:24: struct with 64 pointer bytes could be 56
./openapi3filter/req_resp_decoder_test.go:70:16: struct with 128 pointer bytes could be 112
./openapi3filter/req_resp_decoder_test.go:1130:17: struct with 96 pointer bytes could be 88
./openapi3filter/validate_request_test.go:103:13: struct with 72 pointer bytes could be 64
./openapi3filter/validation_error_test.go:29:23: struct with 40 pointer bytes could be 32
./openapi3filter/validation_error_test.go:37:21: struct with 280 pointer bytes could be 256
./openapi3filter/validation_error_test.go:594:23: struct with 56 pointer bytes could be 48
./openapi3filter/validation_test.go:22:21: struct with 64 pointer bytes could be 56
./openapi3filter/validation_test.go:29:22: struct with 40 pointer bytes could be 24
./openapi3filter/validation_test.go:35:28: struct with 24 pointer bytes could be 16
./openapi3filter/validation_test.go:386:17: struct with 72 pointer bytes could be 64
./openapi3filter/validation_test.go:504:10: struct with 32 pointer bytes could be 24
./openapi3filter/middleware_test.go:179:20: struct with 16 pointer bytes could be 8
./openapi3filter/middleware_test.go:183:13: struct with 192 pointer bytes could be 184

$> fieldalignment -fix ./openapi3gen
./openapi3gen/openapi3gen.go:39:19: struct with 16 pointer bytes could be 8
./openapi3gen/openapi3gen_test.go:20:18: struct with 192 pointer bytes could be 144
./openapi3gen/openapi3gen_test.go:272:23: struct with 24 pointer bytes could be 16
./openapi3gen/openapi3gen_test.go:303:23: struct with 24 pointer bytes could be 16
./openapi3gen/openapi3gen_test.go:334:18: struct with 40 pointer bytes could be 24
./openapi3gen/openapi3gen_test.go:370:23: struct with 24 pointer bytes could be 8
./openapi3gen/simple_test.go:12:13: struct with 192 pointer bytes could be 144

$> fieldalignment -fix ./routers
./routers/types.go:22:12: struct with 64 pointer bytes could be 56
```