### PR TITLE
Don't validate readonly field for write requests

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -554,7 +554,7 @@ func (schema *Schema) IsEmpty(settings *schemaValidationSettings) bool {
 
 	if schema.Type != "" || schema.Format != "" || len(schema.Enum) != 0 ||
 		schema.UniqueItems || schema.ExclusiveMin || schema.ExclusiveMax ||
-		schema.Nullable || schema.AllowEmptyValue ||
+		schema.Nullable || schema.ReadOnly || schema.WriteOnly || schema.AllowEmptyValue ||
 		schema.Min != nil || schema.Max != nil || schema.MultipleOf != nil ||
 		schema.MinLength != 0 || schema.MaxLength != nil || schema.Pattern != "" ||
 		schema.MinItems != 0 || schema.MaxItems != nil ||

--- a/openapi3/schema_validation_settings.go
+++ b/openapi3/schema_validation_settings.go
@@ -4,9 +4,10 @@ package openapi3
 type SchemaValidationOption func(*schemaValidationSettings)
 
 type schemaValidationSettings struct {
-	failfast     bool
-	multiError   bool
-	asreq, asrep bool // exclusive (XOR) fields
+	failfast        bool
+	multiError      bool
+	asreq, asrep    bool // exclusive (XOR) fields
+	writeEp, readEp bool
 }
 
 // FailFast returns schema validation errors quicker.
@@ -21,8 +22,17 @@ func MultiErrors() SchemaValidationOption {
 func VisitAsRequest() SchemaValidationOption {
 	return func(s *schemaValidationSettings) { s.asreq, s.asrep = true, false }
 }
+
 func VisitAsResponse() SchemaValidationOption {
 	return func(s *schemaValidationSettings) { s.asreq, s.asrep = false, true }
+}
+
+func ReadEndpoint() SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.writeEp, s.readEp = false, true }
+}
+
+func WriteEndpoint() SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.readEp, s.writeEp = false, true }
 }
 
 func newSchemaValidationSettings(opts ...SchemaValidationOption) *schemaValidationSettings {

--- a/openapi3filter/options.go
+++ b/openapi3filter/options.go
@@ -21,4 +21,7 @@ type Options struct {
 
 	// See NoopAuthenticationFunc
 	AuthenticationFunc AuthenticationFunc
+
+	// See EndpointType
+	EndpointType EndpointType
 }

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -245,6 +245,12 @@ func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, req
 	if options.MultiError {
 		opts = append(opts, openapi3.MultiErrors())
 	}
+	if options.EndpointType == ReadEndpoint {
+		opts = append(opts, openapi3.ReadEndpoint())
+	}
+	if options.EndpointType == WriteEndpoint {
+		opts = append(opts, openapi3.WriteEndpoint())
+	}
 
 	// Validate JSON with the schema
 	if err := contentType.Schema.Value.VisitJSON(value, opts...); err != nil {

--- a/openapi3filter/validate_writeonly_test.go
+++ b/openapi3filter/validate_writeonly_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
+func TestValidatingWriteRequestBodyWithWriteOnlyProperty(t *testing.T) {
 	const spec = `{
   "openapi": "3.0.3",
   "info": {
@@ -24,8 +24,8 @@ func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
   },
   "paths": {
     "/accounts": {
-      "get": {
-        "description": "Get an account",
+      "post": {
+        "description": "Create a new account",
         "requestBody": {
           "required": true,
           "content": {
@@ -40,7 +40,7 @@ func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
                     "pattern": "[0-9a-v]+$",
                     "minLength": 20,
                     "maxLength": 20,
-                    "readOnly": true
+                    "writeOnly": true
                   }
                 }
               }
@@ -76,7 +76,7 @@ func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
 	b, err := json.Marshal(Request{ID: "bt6kdc3d0cvp6u8u3ft0"})
 	require.NoError(t, err)
 
-	httpReq, err := http.NewRequest(http.MethodGet, "/accounts", bytes.NewReader(b))
+	httpReq, err := http.NewRequest(http.MethodPost, "/accounts", bytes.NewReader(b))
 	require.NoError(t, err)
 	httpReq.Header.Add(headerCT, "application/json")
 
@@ -87,7 +87,7 @@ func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
 		Request:    httpReq,
 		PathParams: pathParams,
 		Route:      route,
-		Options:    &Options{EndpointType: ReadEndpoint},
+		Options:    &Options{EndpointType: WriteEndpoint},
 	})
 	require.NoError(t, err)
 
@@ -95,7 +95,7 @@ func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
 	b, err = json.Marshal(Request{ID: "0cvp6u8u3ft0"})
 	require.NoError(t, err)
 
-	httpReq, err = http.NewRequest(http.MethodGet, "/accounts", bytes.NewReader(b))
+	httpReq, err = http.NewRequest(http.MethodPost, "/accounts", bytes.NewReader(b))
 	require.NoError(t, err)
 	httpReq.Header.Add(headerCT, "application/json")
 
@@ -103,12 +103,12 @@ func TestValidatingReadRequestBodyWithReadOnlyProperty(t *testing.T) {
 		Request:    httpReq,
 		PathParams: pathParams,
 		Route:      route,
-		Options:    &Options{EndpointType: ReadEndpoint},
+		Options:    &Options{EndpointType: WriteEndpoint},
 	})
 	require.Error(t, err)
 }
 
-func TestValidatingIfReadOrWriteEndpointIsNotKnownDefaultValidatesProperty(t *testing.T) {
+func TestValidatingReadRequestOnRequiredWriteOnlyProperty(t *testing.T) {
 	const spec = `{
   "openapi": "3.0.3",
   "info": {
@@ -121,7 +121,7 @@ func TestValidatingIfReadOrWriteEndpointIsNotKnownDefaultValidatesProperty(t *te
   },
   "paths": {
     "/accounts": {
-      "post": {
+      "get": {
         "description": "Get an account",
         "requestBody": {
           "required": true,
@@ -137,7 +137,7 @@ func TestValidatingIfReadOrWriteEndpointIsNotKnownDefaultValidatesProperty(t *te
                     "pattern": "[0-9a-v]+$",
                     "minLength": 20,
                     "maxLength": 20,
-                    "readOnly": true
+                    "writeOnly": true
                   }
                 }
               }
@@ -170,91 +170,11 @@ func TestValidatingIfReadOrWriteEndpointIsNotKnownDefaultValidatesProperty(t *te
 	router, err := legacyrouter.NewRouter(doc)
 	require.NoError(t, err)
 
-	b, err := json.Marshal(Request{ID: ""})
-	require.NoError(t, err)
-
-	httpReq, err := http.NewRequest(http.MethodPost, "/accounts", bytes.NewReader(b))
-	require.NoError(t, err)
-	httpReq.Header.Add(headerCT, "application/json")
-
-	route, pathParams, err := router.FindRoute(httpReq)
-	require.NoError(t, err)
-
-	err = ValidateRequest(sl.Context, &RequestValidationInput{
-		Request:    httpReq,
-		PathParams: pathParams,
-		Route:      route,
-	})
-	require.Error(t, err)
-}
-
-func TestValidatingWriteRequestOnRequiredReadOnlyProperty(t *testing.T) {
-	const spec = `{
-  "openapi": "3.0.3",
-  "info": {
-    "version": "1.0.0",
-    "title": "title",
-    "description": "desc",
-    "contact": {
-      "email": "email"
-    }
-  },
-  "paths": {
-    "/accounts": {
-      "post": {
-        "description": "Create a new account",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "required": ["_id"],
-                "properties": {
-                  "_id": {
-                    "type": "string",
-                    "description": "Unique identifier for this object.",
-                    "pattern": "[0-9a-v]+$",
-                    "minLength": 20,
-                    "maxLength": 20,
-                    "readOnly": true
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Successfully created an account"
-          },
-          "400": {
-            "description": "The server could not understand the request due to invalid syntax",
-          }
-        }
-      }
-    }
-  }
-}
-`
-
-	type Request struct {
-		ID string `json:"_id"`
-	}
-
-	sl := openapi3.NewLoader()
-	doc, err := sl.LoadFromData([]byte(spec))
-	require.NoError(t, err)
-	err = doc.Validate(sl.Context)
-	require.NoError(t, err)
-	router, err := legacyrouter.NewRouter(doc)
-	require.NoError(t, err)
-
 	// Set no id because id is a required readonly field, but this is a write request
 	b, err := json.Marshal(Request{ID: ""})
 	require.NoError(t, err)
 
-	httpReq, err := http.NewRequest(http.MethodPost, "/accounts", bytes.NewReader(b))
+	httpReq, err := http.NewRequest(http.MethodGet, "/accounts", bytes.NewReader(b))
 	require.NoError(t, err)
 	httpReq.Header.Add(headerCT, "application/json")
 
@@ -265,7 +185,7 @@ func TestValidatingWriteRequestOnRequiredReadOnlyProperty(t *testing.T) {
 		Request:    httpReq,
 		PathParams: pathParams,
 		Route:      route,
-		Options:    &Options{EndpointType: WriteEndpoint},
+		Options:    &Options{EndpointType: ReadEndpoint},
 	})
 	require.NoError(t, err)
 }

--- a/openapi3filter/validation_handler.go
+++ b/openapi3filter/validation_handler.go
@@ -15,6 +15,15 @@ func NoopAuthenticationFunc(context.Context, *AuthenticationInput) error { retur
 
 var _ AuthenticationFunc = NoopAuthenticationFunc
 
+// EndpointType Represents what type of endpoint we'll be running validation on
+type EndpointType int32
+
+const (
+	None EndpointType = iota
+	WriteEndpoint
+	ReadEndpoint
+)
+
 type ValidationHandler struct {
 	Handler            http.Handler
 	AuthenticationFunc AuthenticationFunc


### PR DESCRIPTION
## What

Don't validate readonly field for write requests

## Why

In my work, we were using the same struct for many of our openapi endpoints, and one of those struct fields was `readOnly`. We were getting validation errors whenever we tried to make a post request with that struct because we weren't filling in the field.

For example, we were using the common struct:

```
Account:
  id: readonly
```
For all our endpoints.

When we tried to create an account, we wouldn't fill in the ID, but we were still getting validation errors. The issue is because in the library there's no way (to my knowledge) to give the validator context on whether the endpoint is a read endpoint or a write endpoint. The behavior should be if the endpoint is a write endpoint, then we shouldn't validate a readonly field.

cc @codyaray who knows more about this than me. 
