### PR TITLE
Internalize parameter references in the path as well

### DIFF
--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -286,6 +286,10 @@ func (doc *T) derefPaths(paths map[string]*PathItem, refNameResolver RefNameReso
 		// inline full operations
 		ops.Ref = ""
 
+		for _, param := range ops.Parameters {
+			doc.addParameterToSpec(param, refNameResolver)
+		}
+
 		for _, op := range ops.Operations() {
 			doc.addRequestBodyToSpec(op.RequestBody, refNameResolver)
 			if op.RequestBody != nil && op.RequestBody.Value != nil {

--- a/openapi3/testdata/recursiveRef/parameters/number.yml
+++ b/openapi3/testdata/recursiveRef/parameters/number.yml
@@ -1,0 +1,4 @@
+name: someNumber
+in: query
+schema:
+  type: string

--- a/openapi3/testdata/recursiveRef/paths/foo.yml
+++ b/openapi3/testdata/recursiveRef/paths/foo.yml
@@ -1,3 +1,5 @@
+parameters:
+  - $ref: ../parameters/number.yml
 get:
   responses:
     "200":


### PR DESCRIPTION
We use externalized parameters in our OpenAPI spec. While running `InternalizeSpec` those were not internalized. This is a fix for that bug.