### PR TITLE
Improve error message when path validation fails

### DIFF
--- a/openapi3/example_validation_test.go
+++ b/openapi3/example_validation_test.go
@@ -26,7 +26,7 @@ func TestExamplesSchemaValidation(t *testing.T) {
             param1example:
               value: abcd
    `,
-			errContains: "param1example",
+			errContains: "invalid paths: invalid path /user: invalid operation POST: param1example",
 		},
 		{
 			name: "valid_parameter_examples",
@@ -64,7 +64,7 @@ func TestExamplesSchemaValidation(t *testing.T) {
         email: bad
         password: short
    `,
-			errContains: "BadUser",
+			errContains: "invalid paths: invalid path /user: invalid operation POST: BadUser",
 		},
 		{
 			name: "valid_component_examples",

--- a/openapi3/example_validation_test.go
+++ b/openapi3/example_validation_test.go
@@ -26,7 +26,7 @@ func TestExamplesSchemaValidation(t *testing.T) {
             param1example:
               value: abcd
    `,
-			errContains: "invalid paths: param1example",
+			errContains: "param1example",
 		},
 		{
 			name: "valid_parameter_examples",
@@ -64,7 +64,7 @@ func TestExamplesSchemaValidation(t *testing.T) {
         email: bad
         password: short
    `,
-			errContains: "invalid paths: BadUser",
+			errContains: "BadUser",
 		},
 		{
 			name: "valid_component_examples",

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -91,7 +91,7 @@ func TestResolveSchemaRef(t *testing.T) {
 }
 
 func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
-	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"paths":{"/foo":{"post":{"summary":"Create Foo","requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
 	loader := NewLoader()
 	doc, err := loader.LoadFromData(source)
 	require.NoError(t, err)

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -96,7 +96,7 @@ func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
 	doc, err := loader.LoadFromData(source)
 	require.NoError(t, err)
 	err = doc.Validate(loader.Context)
-	require.EqualError(t, err, `invalid paths: path /foo failed validation for operation POST: found unresolved ref: ""`)
+	require.EqualError(t, err, `invalid paths: path /foo failed validation: validation failed for operation POST: found unresolved ref: ""`)
 }
 
 func TestResolveResponseExampleRef(t *testing.T) {

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -96,7 +96,7 @@ func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
 	doc, err := loader.LoadFromData(source)
 	require.NoError(t, err)
 	err = doc.Validate(loader.Context)
-	require.EqualError(t, err, `invalid paths: path /foo failed validation: validation failed for operation POST: found unresolved ref: ""`)
+	require.EqualError(t, err, `invalid paths: invalid path /foo: invalid operation POST: found unresolved ref: ""`)
 }
 
 func TestResolveResponseExampleRef(t *testing.T) {

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -91,12 +91,12 @@ func TestResolveSchemaRef(t *testing.T) {
 }
 
 func TestResolveSchemaRefWithNullSchemaRef(t *testing.T) {
-	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"paths":{"/foo":{"post":{"requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
+	source := []byte(`{"openapi":"3.0.0","info":{"title":"MyAPI","version":"0.1","description":"An API"},"paths":{"/foo":{"post":{"summary":"Create Foo","requestBody":{"content":{"application/json":{"schema":null}}}}}}}`)
 	loader := NewLoader()
 	doc, err := loader.LoadFromData(source)
 	require.NoError(t, err)
 	err = doc.Validate(loader.Context)
-	require.EqualError(t, err, `invalid paths: found unresolved ref: ""`)
+	require.EqualError(t, err, `invalid paths: path /foo failed validation for operation POST: found unresolved ref: ""`)
 }
 
 func TestResolveResponseExampleRef(t *testing.T) {

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -134,7 +134,7 @@ func (pathItem *PathItem) Validate(ctx context.Context) error {
 	for _, method := range methods {
 		operation := operations[method]
 		if err := operation.Validate(ctx); err != nil {
-			return fmt.Errorf("path %s failed validation for operation %s: %v", path, method, err)
+			return fmt.Errorf("invalid operation %s: %v", method, err)
 		}
 	}
 	return nil

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -134,7 +134,7 @@ func (pathItem *PathItem) Validate(ctx context.Context) error {
 	for _, method := range methods {
 		operation := operations[method]
 		if err := operation.Validate(ctx); err != nil {
-			return fmt.Errorf("path (summary: %s) failed validation for operation %s: %v", pathItem.Summary, method, err)
+			return fmt.Errorf("path %s failed validation for operation %s: %v", path, method, err)
 		}
 	}
 	return nil

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -134,7 +134,7 @@ func (pathItem *PathItem) Validate(ctx context.Context) error {
 	for _, method := range methods {
 		operation := operations[method]
 		if err := operation.Validate(ctx); err != nil {
-			return err
+			return fmt.Errorf("path (summary: %s) failed validation for operation %s: %v", pathItem.Summary, method, err)
 		}
 	}
 	return nil

--- a/openapi3/paths.go
+++ b/openapi3/paths.go
@@ -96,7 +96,7 @@ func (paths Paths) Validate(ctx context.Context) error {
 		}
 
 		if err := pathItem.Validate(ctx); err != nil {
-			return err
+			return fmt.Errorf("invalid path %s: %v", path, err)
 		}
 	}
 

--- a/openapi3/response_issue224_test.go
+++ b/openapi3/response_issue224_test.go
@@ -457,5 +457,5 @@ func TestEmptyResponsesAreInvalid(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, doc.ExternalDocs.Description, "See AsyncAPI example")
 	err = doc.Validate(context.Background())
-	require.Contains(t, err.Error(), `the responses object MUST contain at least one response code`)
+	require.EqualError(t, err, `invalid paths: invalid path /pet: invalid operation POST: the responses object MUST contain at least one response code`)
 }

--- a/openapi3/response_issue224_test.go
+++ b/openapi3/response_issue224_test.go
@@ -457,5 +457,5 @@ func TestEmptyResponsesAreInvalid(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, doc.ExternalDocs.Description, "See AsyncAPI example")
 	err = doc.Validate(context.Background())
-	require.EqualError(t, err, `invalid paths: the responses object MUST contain at least one response code`)
+	require.Contains(t, err.Error(), `the responses object MUST contain at least one response code`)
 }


### PR DESCRIPTION
With the introduction of validation of examples in an OpenAPI spec in #592 there is now a high chance that many will have specs that fail validation. I did! It was hard to debug what was wrong with the spec as the errors were too generic. The change in this PR will hopefully make it easier for folks to debug the problem in their OpenAPI docs.