### PR TITLE
Add repro for issue 615

### DIFF
--- a/openapi3/loader_recursive_ref_test.go
+++ b/openapi3/loader_recursive_ref_test.go
@@ -16,6 +16,15 @@ func TestLoaderSupportsRecursiveReference(t *testing.T) {
 	require.Equal(t, "bar", doc.Paths["/foo"].Get.Responses.Get(200).Value.Content.Get("application/json").Schema.Value.Properties["foo2"].Value.Properties["foo"].Value.Properties["bar"].Value.Example)
 }
 
+func TestIssue615(t *testing.T) {
+	loader := NewLoader()
+	loader.IsExternalRefsAllowed = true
+	_, err := loader.LoadFromFile("testdata/recursiveRef/issue615.yml")
+	// Test currently reproduces the issue 615: failure to load a valid spec
+	// Upon issue resolution, this check should be changed to require.NoError
+	require.Error(t, err)
+}
+
 func TestIssue447(t *testing.T) {
 	loader := NewLoader()
 	doc, err := loader.LoadFromData([]byte(`

--- a/openapi3/testdata/recursiveRef/issue615.yml
+++ b/openapi3/testdata/recursiveRef/issue615.yml
@@ -1,0 +1,60 @@
+openapi: "3.0.3"
+info:
+  title: Deep recursive cyclic refs example
+  version: "1.0"
+paths:
+  /foo:
+    $ref: ./paths/foo.yml
+components:
+  schemas:
+    FilterColumnIncludes:
+      type: object
+      properties:
+        $includes:
+          $ref: '#/components/schemas/FilterPredicate'
+      additionalProperties: false
+      maxProperties: 1
+      minProperties: 1
+    FilterPredicate:
+      oneOf:
+        - $ref: '#/components/schemas/FilterValue'
+        - type: array
+          items:
+            $ref: '#/components/schemas/FilterPredicate'
+          minLength: 1
+        - $ref: '#/components/schemas/FilterPredicateOp'
+        - $ref: '#/components/schemas/FilterPredicateRangeOp'
+    FilterPredicateOp:
+      type: object
+      properties:
+        $any:
+          oneOf:
+            - type: array
+              items:
+                $ref: '#/components/schemas/FilterPredicate'
+        $none:
+          oneOf:
+            - $ref: '#/components/schemas/FilterPredicate'
+            - type: array
+              items:
+                $ref: '#/components/schemas/FilterPredicate'
+      additionalProperties: false
+      maxProperties: 1
+      minProperties: 1
+    FilterPredicateRangeOp:
+      type: object
+      properties:
+        $lt:
+          $ref: '#/components/schemas/FilterRangeValue'
+      additionalProperties: false
+      maxProperties: 2
+      minProperties: 2
+    FilterRangeValue:
+      oneOf:
+        - type: number
+        - type: string
+    FilterValue:
+      oneOf:
+        - type: number
+        - type: string
+        - type: boolean


### PR DESCRIPTION
Adds a spec example that triggers circular ref validation failure for depth 3.
Same example passes if depth is set to 4.