### PR TITLE
fix: yaml marshal output

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.yml text eol=lf

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -12,7 +12,7 @@ import (
 // Components is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#componentsObject
 type Components struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Schemas         Schemas         `json:"schemas,omitempty" yaml:"schemas,omitempty"`
 	Parameters      ParametersMap   `json:"parameters,omitempty" yaml:"parameters,omitempty"`

--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -9,7 +9,7 @@ import (
 // Discriminator is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminatorObject
 type Discriminator struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	PropertyName string            `json:"propertyName" yaml:"propertyName"`
 	Mapping      map[string]string `json:"mapping,omitempty" yaml:"mapping,omitempty"`

--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -11,7 +11,7 @@ import (
 // Encoding is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encodingObject
 type Encoding struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	ContentType   string  `json:"contentType,omitempty" yaml:"contentType,omitempty"`
 	Headers       Headers `json:"headers,omitempty" yaml:"headers,omitempty"`

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -30,7 +30,7 @@ func (e Examples) JSONLookup(token string) (interface{}, error) {
 // Example is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#exampleObject
 type Example struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Summary       string      `json:"summary,omitempty" yaml:"summary,omitempty"`
 	Description   string      `json:"description,omitempty" yaml:"description,omitempty"`

--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -12,7 +12,7 @@ import (
 // ExternalDocs is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#external-documentation-object
 type ExternalDocs struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -10,7 +10,7 @@ import (
 // Info is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#infoObject
 type Info struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Title          string   `json:"title" yaml:"title"` // Required
 	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
@@ -58,7 +58,7 @@ func (info *Info) Validate(ctx context.Context) error {
 // Contact is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#contactObject
 type Contact struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
 	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -83,7 +83,7 @@ func (contact *Contact) Validate(ctx context.Context) error {
 // License is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#licenseObject
 type License struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Name string `json:"name" yaml:"name"` // Required
 	URL  string `json:"url,omitempty" yaml:"url,omitempty"`

--- a/openapi3/issue241_test.go
+++ b/openapi3/issue241_test.go
@@ -1,0 +1,28 @@
+package openapi3_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestIssue241(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/issue241.yml")
+	require.NoError(t, err)
+
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
+	spec, err := loader.LoadFromData(data)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	err = enc.Encode(spec)
+	require.NoError(t, err)
+	require.Equal(t, string(data), buf.String())
+}

--- a/openapi3/issue241_test.go
+++ b/openapi3/issue241_test.go
@@ -5,9 +5,10 @@ import (
 	"io/ioutil"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 func TestIssue241(t *testing.T) {

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -30,7 +30,7 @@ var _ jsonpointer.JSONPointable = (*Links)(nil)
 // Link is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#linkObject
 type Link struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
 	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -14,7 +14,7 @@ import (
 // MediaType is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#mediaTypeObject
 type MediaType struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Schema   *SchemaRef           `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Example  interface{}          `json:"example,omitempty" yaml:"example,omitempty"`

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -11,7 +11,7 @@ import (
 // T is the root of an OpenAPI v3 document
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oasObject
 type T struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	OpenAPI      string               `json:"openapi" yaml:"openapi"` // Required
 	Components   Components           `json:"components,omitempty" yaml:"components,omitempty"`

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -14,7 +14,7 @@ import (
 // Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object
 type Operation struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	// Optional tags for documentation.
 	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -90,7 +90,7 @@ func (parameters Parameters) Validate(ctx context.Context) error {
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameterObject
 type Parameter struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
 	In              string      `json:"in,omitempty" yaml:"in,omitempty"`

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -12,7 +12,7 @@ import (
 // PathItem is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#pathItemObject
 type PathItem struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Ref         string     `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 	Summary     string     `json:"summary,omitempty" yaml:"summary,omitempty"`

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -23,6 +23,11 @@ type CallbackRef struct {
 
 var _ jsonpointer.JSONPointable = (*CallbackRef)(nil)
 
+// MarshalYAML returns the YAML encoding of CallbackRef.
+func (value *CallbackRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
+
 // MarshalJSON returns the JSON encoding of CallbackRef.
 func (value *CallbackRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -59,6 +64,11 @@ type ExampleRef struct {
 }
 
 var _ jsonpointer.JSONPointable = (*ExampleRef)(nil)
+
+// MarshalYAML returns the YAML encoding of ExampleRef.
+func (value *ExampleRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
 
 // MarshalJSON returns the JSON encoding of ExampleRef.
 func (value *ExampleRef) MarshalJSON() ([]byte, error) {
@@ -97,6 +107,11 @@ type HeaderRef struct {
 
 var _ jsonpointer.JSONPointable = (*HeaderRef)(nil)
 
+// MarshalYAML returns the YAML encoding of HeaderRef.
+func (value *HeaderRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
+
 // MarshalJSON returns the JSON encoding of HeaderRef.
 func (value *HeaderRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -132,6 +147,11 @@ type LinkRef struct {
 	Value *Link
 }
 
+// MarshalYAML returns the YAML encoding of LinkRef.
+func (value *LinkRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
+
 // MarshalJSON returns the JSON encoding of LinkRef.
 func (value *LinkRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -158,6 +178,11 @@ type ParameterRef struct {
 }
 
 var _ jsonpointer.JSONPointable = (*ParameterRef)(nil)
+
+// MarshalYAML returns the YAML encoding of ParameterRef.
+func (value *ParameterRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
 
 // MarshalJSON returns the JSON encoding of ParameterRef.
 func (value *ParameterRef) MarshalJSON() ([]byte, error) {
@@ -196,6 +221,11 @@ type ResponseRef struct {
 
 var _ jsonpointer.JSONPointable = (*ResponseRef)(nil)
 
+// MarshalYAML returns the YAML encoding of ResponseRef.
+func (value *ResponseRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
+
 // MarshalJSON returns the JSON encoding of ResponseRef.
 func (value *ResponseRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -232,6 +262,11 @@ type RequestBodyRef struct {
 }
 
 var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
+
+// MarshalYAML returns the YAML encoding of RequestBodyRef.
+func (value *RequestBodyRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
 
 // MarshalJSON returns the JSON encoding of RequestBodyRef.
 func (value *RequestBodyRef) MarshalJSON() ([]byte, error) {
@@ -277,6 +312,11 @@ func NewSchemaRef(ref string, value *Schema) *SchemaRef {
 	}
 }
 
+// MarshalYAML returns the YAML encoding of SchemaRef.
+func (value *SchemaRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
+
 // MarshalJSON returns the JSON encoding of SchemaRef.
 func (value *SchemaRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -314,6 +354,11 @@ type SecuritySchemeRef struct {
 
 var _ jsonpointer.JSONPointable = (*SecuritySchemeRef)(nil)
 
+// MarshalYAML returns the YAML encoding of SecuritySchemeRef.
+func (value *SecuritySchemeRef) MarshalYAML() (interface{}, error) {
+	return marshalRefYAML(value.Ref, value.Value)
+}
+
 // MarshalJSON returns the JSON encoding of SecuritySchemeRef.
 func (value *SecuritySchemeRef) MarshalJSON() ([]byte, error) {
 	return jsoninfo.MarshalRef(value.Ref, value.Value)
@@ -340,4 +385,12 @@ func (value SecuritySchemeRef) JSONLookup(token string) (interface{}, error) {
 
 	ptr, _, err := jsonpointer.GetForToken(value.Value, token)
 	return ptr, err
+}
+
+// marshalRefYAML returns the YAML encoding of ref values.
+func marshalRefYAML(value string, otherwise interface{}) (interface{}, error) {
+	if value != "" {
+		return &Ref{Ref: value}, nil
+	}
+	return otherwise, nil
 }

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -30,7 +30,7 @@ func (r RequestBodies) JSONLookup(token string) (interface{}, error) {
 // RequestBody is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#requestBodyObject
 type RequestBody struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -68,7 +68,7 @@ func (responses Responses) JSONLookup(token string) (interface{}, error) {
 // Response is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responseObject
 type Response struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	Headers     Headers `json:"headers,omitempty" yaml:"headers,omitempty"`

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -113,7 +113,7 @@ func (s SchemaRefs) JSONLookup(token string) (interface{}, error) {
 // Schema is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#schemaObject
 type Schema struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	OneOf        SchemaRefs    `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
 	AnyOf        SchemaRefs    `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -30,7 +30,7 @@ var _ jsonpointer.JSONPointable = (*SecuritySchemes)(nil)
 // SecurityScheme is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#securitySchemeObject
 type SecurityScheme struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Type             string      `json:"type,omitempty" yaml:"type,omitempty"`
 	Description      string      `json:"description,omitempty" yaml:"description,omitempty"`
@@ -176,7 +176,7 @@ func (ss *SecurityScheme) Validate(ctx context.Context) error {
 // OAuthFlows is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oauthFlowsObject
 type OAuthFlows struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Implicit          *OAuthFlow `json:"implicit,omitempty" yaml:"implicit,omitempty"`
 	Password          *OAuthFlow `json:"password,omitempty" yaml:"password,omitempty"`
@@ -223,7 +223,7 @@ func (flows *OAuthFlows) Validate(ctx context.Context) error {
 // OAuthFlow is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oauthFlowObject
 type OAuthFlow struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -50,7 +50,7 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string) 
 // Server is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#serverObject
 type Server struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	URL         string                     `json:"url" yaml:"url"`
 	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
@@ -197,7 +197,7 @@ func (server *Server) Validate(ctx context.Context) (err error) {
 // ServerVariable is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object
 type ServerVariable struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Default     string   `json:"default,omitempty" yaml:"default,omitempty"`

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -32,7 +32,7 @@ func (tags Tags) Validate(ctx context.Context) error {
 // Tag is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#tagObject
 type Tag struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`

--- a/openapi3/testdata/issue241.yml
+++ b/openapi3/testdata/issue241.yml
@@ -1,0 +1,15 @@
+openapi: 3.0.3
+components:
+  schemas:
+    FooBar:
+      type: object
+      properties:
+        type_url:
+          type: string
+        value:
+          type: string
+          format: byte
+info:
+  title: sample
+  version: version not set
+paths: {}

--- a/openapi3/xml.go
+++ b/openapi3/xml.go
@@ -9,7 +9,7 @@ import (
 // XML is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xmlObject
 type XML struct {
-	ExtensionProps
+	ExtensionProps `json:"-" yaml:"-"`
 
 	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`


### PR DESCRIPTION
Fix the output when encoding the YAML by:
* Excluding ExtensionProps, the Extensions were already excluded resulting in empty extensionProps only.
* Add custom marshaler to all ref types so it doesn't output both values in the same way the JSON marshaler does.

Fixes #241