### PR TITLE
only encode defaults for supported content type

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -272,8 +272,9 @@ func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, req
 			Err:         err,
 		}
 	}
-
-	if defaultsSet {
+	// only encode defaults for existing encoders
+	_, ok := bodyEncoders[mediaType]
+	if defaultsSet && ok {
 		var err error
 		if data, err = encodeBody(value, mediaType); err != nil {
 			return &RequestError{


### PR DESCRIPTION
there is a problem with openapi spec when the following are true:
- content type is multipart/form-data 
- defaults are specified

