### PR TITLE
fix panic slice out of range error #652

### DIFF
--- a/openapi3/issue652_test.go
+++ b/openapi3/issue652_test.go
@@ -3,8 +3,9 @@ package openapi3_test
 import (
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 func TestIssue652(t *testing.T) {

--- a/openapi3/issue652_test.go
+++ b/openapi3/issue652_test.go
@@ -1,0 +1,20 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue652(t *testing.T) {
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
+
+	// Test checks that no slice bounds out of range error occurs while loading
+	// from file that contains reference to file in the parent directory.
+	require.NotPanics(t, func() {
+		_, err := loader.LoadFromFile("testdata/issue652/nested/schema.yml")
+		require.NoError(t, err)
+	})
+}

--- a/openapi3/issue652_test.go
+++ b/openapi3/issue652_test.go
@@ -3,6 +3,7 @@ package openapi3_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -15,7 +16,14 @@ func TestIssue652(t *testing.T) {
 	// Test checks that no slice bounds out of range error occurs while loading
 	// from file that contains reference to file in the parent directory.
 	require.NotPanics(t, func() {
-		_, err := loader.LoadFromFile("testdata/issue652/nested/schema.yml")
+		const schemaName = "ReferenceToParentDirectory"
+
+		spec, err := loader.LoadFromFile("testdata/issue652/nested/schema.yml")
 		require.NoError(t, err)
+		require.Contains(t, spec.Components.Schemas, schemaName)
+
+		schema := spec.Components.Schemas[schemaName]
+		assert.Equal(t, schema.Ref, "../definitions.yml#/components/schemas/TestSchema")
+		assert.Equal(t, schema.Value.Type, "string")
 	})
 }

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -742,7 +742,10 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 				return err
 			}
 			component.Value = resolved.Value
-			foundPath := loader.getResolvedRefPath(ref, &resolved, documentPath, componentPath)
+			foundPath, rerr := loader.getResolvedRefPath(ref, &resolved, documentPath, componentPath)
+			if rerr != nil {
+				return fmt.Errorf("failed to resolve file for reference %q: %w", ref, rerr)
+			}
 			documentPath = loader.documentPathForRecursiveRef(documentPath, foundPath)
 		}
 	}
@@ -790,23 +793,28 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 	return nil
 }
 
-func (loader *Loader) getResolvedRefPath(ref string, resolved *SchemaRef, cur, found *url.URL) string {
+func (loader *Loader) getResolvedRefPath(ref string, resolved *SchemaRef, cur, found *url.URL) (string, error) {
 	if referencedFilename := strings.Split(ref, "#")[0]; referencedFilename == "" {
 		if cur != nil {
 			if loader.rootDir != "" && strings.HasPrefix(cur.Path, loader.rootDir) {
-				return cur.Path[len(loader.rootDir)+1:]
+				return cur.Path[len(loader.rootDir)+1:], nil
 			}
 
-			return path.Base(cur.Path)
+			return path.Base(cur.Path), nil
 		}
-		return ""
+		return "", nil
 	}
 	// ref. to external file
 	if resolved.Ref != "" {
-		return resolved.Ref
+		return resolved.Ref, nil
 	}
+
+	if loader.rootDir == "" {
+		return path.Dir(found.Path), nil
+	}
+
 	// found dest spec. file
-	return path.Dir(found.Path)[len(loader.rootDir):]
+	return filepath.Rel(loader.rootDir, found.Path)
 }
 
 func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecuritySchemeRef, documentPath *url.URL) (err error) {

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -744,7 +744,7 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 			component.Value = resolved.Value
 			foundPath, rerr := loader.getResolvedRefPath(ref, &resolved, documentPath, componentPath)
 			if rerr != nil {
-				return fmt.Errorf("failed to resolve file for reference %q: %w", ref, rerr)
+				return fmt.Errorf("failed to resolve file from reference %q: %w", ref, rerr)
 			}
 			documentPath = loader.documentPathForRecursiveRef(documentPath, foundPath)
 		}

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -810,7 +810,7 @@ func (loader *Loader) getResolvedRefPath(ref string, resolved *SchemaRef, cur, f
 	}
 
 	if loader.rootDir == "" {
-		return path.Dir(found.Path), nil
+		return found.Path, nil
 	}
 
 	// found dest spec. file

--- a/openapi3/testdata/issue652/definitions.yml
+++ b/openapi3/testdata/issue652/definitions.yml
@@ -1,0 +1,4 @@
+components:
+    schemas:
+        TestSchema:
+            type: string

--- a/openapi3/testdata/issue652/nested/schema.yml
+++ b/openapi3/testdata/issue652/nested/schema.yml
@@ -1,7 +1,4 @@
 components:
     schemas:
-        TestObject:
-            type: object
-            properties:
-                reference_to_parent_directory:
-                    $ref: "../definitions.yml#/components/schemas/TestSchema"
+        ReferenceToParentDirectory:
+            $ref: "../definitions.yml#/components/schemas/TestSchema"

--- a/openapi3/testdata/issue652/nested/schema.yml
+++ b/openapi3/testdata/issue652/nested/schema.yml
@@ -1,0 +1,7 @@
+components:
+    schemas:
+        TestObject:
+            type: object
+            properties:
+                reference_to_parent_directory:
+                    $ref: "../definitions.yml#/components/schemas/TestSchema"


### PR DESCRIPTION
Fixes panic from the issue #652, that occurs when trying to load specification from file that contains reference to the file insed of parent directory.