### PR TITLE
Update content length after replacing request body

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -285,6 +285,7 @@ func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, req
 		}
 		// Put the data back into the input
 		req.Body = ioutil.NopCloser(bytes.NewReader(data))
+		req.ContentLength = int64(len(data))
 	}
 
 	return nil


### PR DESCRIPTION
Update content length after replacing the request body when setting default values. Otherwise, the request gets inconsistent, and further operation on it, like proxying it, causes an error.