### PR TITLE
fix: setting defaults for oneOf and anyOf

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -933,10 +933,6 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 			matchedOneOfIdx  = 0
 			tempValue        = value
 		)
-		// make a deep copy to protect origin value from being injected default value that defined in mismatched oneOf schema
-		if settings.asreq || settings.asrep {
-			tempValue = deepcopy.Copy(value)
-		}
 		for idx, item := range v {
 			v := item.Value
 			if v == nil {
@@ -945,6 +941,11 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 
 			if discriminatorRef != "" && discriminatorRef != item.Ref {
 				continue
+			}
+
+			// make a deep copy to protect origin value from being injected default value that defined in mismatched oneOf schema
+			if settings.asreq || settings.asrep {
+				tempValue = deepcopy.Copy(value)
 			}
 
 			if err := v.visitJSON(settings, tempValue); err != nil {
@@ -989,14 +990,14 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 			matchedAnyOfIdx = 0
 			tempValue       = value
 		)
-		// make a deep copy to protect origin value from being injected default value that defined in mismatched anyOf schema
-		if settings.asreq || settings.asrep {
-			tempValue = deepcopy.Copy(value)
-		}
 		for idx, item := range v {
 			v := item.Value
 			if v == nil {
 				return foundUnresolvedRef(item.Ref)
+			}
+			// make a deep copy to protect origin value from being injected default value that defined in mismatched anyOf schema
+			if settings.asreq || settings.asrep {
+				tempValue = deepcopy.Copy(value)
 			}
 			if err := v.visitJSON(settings, tempValue); err == nil {
 				ok = true

--- a/openapi3filter/validate_set_default_test.go
+++ b/openapi3filter/validate_set_default_test.go
@@ -262,8 +262,7 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
                             "type": "string",
                             "default": "www.twitter.com"
                           }
-                        },
-                        "additionalProperties": false
+                        }
                       },
                       {
                         "type": "object",

--- a/openapi3filter/validate_set_default_test.go
+++ b/openapi3filter/validate_set_default_test.go
@@ -279,8 +279,7 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
                             "type": "string",
                             "default": "www.facebook.com"
                           }
-                        },
-                        "additionalProperties": false
+                        }
                       }
                     ]
                   },
@@ -317,6 +316,70 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
                             "default": "www.facebook.com"
                           }
                         }
+                      }
+                    ]
+                  },
+                  "contact": {
+                    "oneOf": [
+                      {
+                        "type": "object",
+                        "required": ["email"],
+                        "properties": {
+                          "email": {
+                            "type": "string"
+                          },
+                          "allow_image": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": ["phone"],
+                        "properties": {
+                          "phone": {
+                            "type": "string"
+                          },
+                          "allow_text": {
+                            "type": "boolean",
+                            "default": false
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "contact2": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "required": ["email"],
+                        "properties": {
+                          "email": {
+                            "type": "string"
+                          },
+                          "allow_image": {
+                            "type": "boolean",
+                            "default": true
+                          }
+                        },
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "required": ["phone"],
+                        "properties": {
+                          "phone": {
+                            "type": "string"
+                          },
+                          "allow_text": {
+                            "type": "boolean",
+                            "default": false
+                          }
+                        },
+                        "additionalProperties": false
                       }
                     ]
                   }
@@ -360,6 +423,10 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
 		FBLink   string `json:"fb_link,omitempty"`
 		TWLink   string `json:"tw_link,omitempty"`
 	}
+	type contact struct {
+		Email string `json:"email,omitempty"`
+		Phone string `json:"phone,omitempty"`
+	}
 	type body struct {
 		ID             string         `json:"id,omitempty"`
 		Name           string         `json:"name,omitempty"`
@@ -369,6 +436,8 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
 		Filters        []filter       `json:"filters,omitempty"`
 		SocialNetwork  *socialNetwork `json:"social_network,omitempty"`
 		SocialNetwork2 *socialNetwork `json:"social_network_2,omitempty"`
+		Contact        *contact       `json:"contact,omitempty"`
+		Contact2       *contact       `json:"contact2,omitempty"`
 	}
 
 	testCases := []struct {
@@ -657,6 +726,52 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
   "social_network_2": {
     "platform": "facebook",
     "fb_link": "www.facebook.com"
+  }
+}
+        `, body)
+			},
+		},
+		{
+			name: "contact(oneOf)",
+			body: body{
+				ID: "bt6kdc3d0cvp6u8u3ft0",
+				Contact: &contact{
+					Phone: "123456",
+				},
+			},
+			bodyAssertion: func(t *testing.T, body string) {
+				require.JSONEq(t, `
+{
+  "id": "bt6kdc3d0cvp6u8u3ft0",
+  "name": "default",
+  "code": 123,
+  "all": false,
+  "contact": {
+    "phone": "123456",
+    "allow_text": false
+  }
+}
+        `, body)
+			},
+		},
+		{
+			name: "contact(anyOf)",
+			body: body{
+				ID: "bt6kdc3d0cvp6u8u3ft0",
+				Contact2: &contact{
+					Phone: "123456",
+				},
+			},
+			bodyAssertion: func(t *testing.T, body string) {
+				require.JSONEq(t, `
+{
+  "id": "bt6kdc3d0cvp6u8u3ft0",
+  "name": "default",
+  "code": 123,
+  "all": false,
+  "contact2": {
+    "phone": "123456",
+    "allow_text": false
   }
 }
         `, body)

--- a/openapi3filter/validate_set_default_test.go
+++ b/openapi3filter/validate_set_default_test.go
@@ -262,7 +262,8 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
                             "type": "string",
                             "default": "www.twitter.com"
                           }
-                        }
+                        },
+                        "additionalProperties": false
                       },
                       {
                         "type": "object",
@@ -278,7 +279,8 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
                             "type": "string",
                             "default": "www.facebook.com"
                           }
-                        }
+                        },
+                        "additionalProperties": false
                       }
                     ]
                   },


### PR DESCRIPTION
When setting default values for oneOf or anyOf, a temporary value (tempValue) is used to prevent original value from being modified. However, tempValue should to be reset on the next iteration otherwise default value set from previous iteration can modify tempValue which can lead to failure.

The fix is to move the deepcopy inside the loop, which will reset tempValue to the original input.