### PR TITLE
draft: fix: handle security requirements as OpenAPI 3 specifies (I think!!!)

### DIFF
--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -315,8 +315,13 @@ func ValidateSecurityRequirements(ctx context.Context, input *RequestValidationI
 			errs = append(errs, err)
 			continue
 		}
+	}
+	if len(errs) == 0 {
+		// all security requirements have been met: success
 		return nil
 	}
+
+	// at least one security requirement was not met: fail
 	return &SecurityRequirementsError{
 		SecurityRequirements: srs,
 		Errors:               errs,

--- a/openapi3filter/validate_request_test.go
+++ b/openapi3filter/validate_request_test.go
@@ -67,13 +67,18 @@ paths:
         '201':
           description: Created
       security:
-      - apiKey: []
+        - apiKey: []
+        - queryToken: []
 components:
   securitySchemes:
     apiKey:
       type: apiKey
       name: Api-Key
       in: header
+    queryToken:
+      type: apiKey
+      name: tok
+      in: query
 `
 
 	router := setupTestRouter(t, spec)
@@ -117,7 +122,7 @@ components:
 			name: "Valid request with all fields set",
 			args: args{
 				requestBody: &testRequestBody{SubCategory: "Chocolate", Category: "Food"},
-				url:         "/category?category=cookies",
+				url:         "/category?category=cookies&tok=a",
 				apiKey:      "SomeKey",
 			},
 			expectedModification: false,
@@ -127,7 +132,7 @@ components:
 			name: "Valid request without certain fields",
 			args: args{
 				requestBody: &testRequestBody{SubCategory: "Chocolate"},
-				url:         "/category?category=cookies",
+				url:         "/category?category=cookies&tok=a",
 				apiKey:      "SomeKey",
 			},
 			expectedModification: true,
@@ -137,7 +142,7 @@ components:
 			name: "Invalid operation params",
 			args: args{
 				requestBody: &testRequestBody{SubCategory: "Chocolate"},
-				url:         "/category?invalidCategory=badCookie",
+				url:         "/category?invalidCategory=badCookie&tok=a",
 				apiKey:      "SomeKey",
 			},
 			expectedModification: false,
@@ -148,7 +153,7 @@ components:
 			name: "Invalid request body",
 			args: args{
 				requestBody: nil,
-				url:         "/category?category=cookies",
+				url:         "/category?category=cookies&tok=a",
 				apiKey:      "SomeKey",
 			},
 			expectedModification: false,
@@ -156,7 +161,7 @@ components:
 			expectedErrRegexp:    regexp.MustCompile(`value is required but missing`),
 		},
 		{
-			name: "Invalid security",
+			name: "Invalid security (header and query)",
 			args: args{
 				requestBody: &testRequestBody{SubCategory: "Chocolate"},
 				url:         "/category?category=cookies",
@@ -164,10 +169,10 @@ components:
 			},
 			expectedModification: false,
 			expectedErr:          &SecurityRequirementsError{},
-			expectedErrRegexp:    regexp.MustCompile(`security.*Api-Key not found in header`),
+			expectedErrRegexp:    regexp.MustCompile(`security.*Api-Key not found in header.*tok not found in query`),
 		},
 		{
-			name: "Invalid request body and security",
+			name: "Invalid request body and security (header and query)",
 			args: args{
 				requestBody: nil,
 				url:         "/category?category=cookies",

--- a/openapi3filter/validate_request_test.go
+++ b/openapi3filter/validate_request_test.go
@@ -172,6 +172,17 @@ components:
 			expectedErrRegexp:    regexp.MustCompile(`security.*Api-Key not found in header.*tok not found in query`),
 		},
 		{
+			name: "Invalid security (header only)",
+			args: args{
+				requestBody: &testRequestBody{SubCategory: "Chocolate"},
+				url:         "/category?category=cookies&tok=a",
+				apiKey:      "",
+			},
+			expectedModification: false,
+			expectedErr:          &SecurityRequirementsError{},
+			expectedErrRegexp:    regexp.MustCompile(`security.*Api-Key not found in header`),
+		},
+		{
 			name: "Invalid request body and security (header and query)",
 			args: args{
 				requestBody: nil,


### PR DESCRIPTION
From https://swagger.io/specification/#security-requirement-object:

> Security Requirement Objects that contain multiple schemes require
> that all schemes MUST be satisfied for a request to be authorized.
> This enables support for scenarios where multiple query parameters or
> HTTP headers are required to convey security information.

I'm fairly sure there was a bug in ValidateSecurityRequirements(),
which I've fixed. And I added a test case to TestValidateRequest() to
show the problem and prove that I've fixed it.

Unfortunately, this also breaks TestAnySecurityRequirementMet(), and
I'm not yet sure why. Not sure if the test is incorrect or if my fix
is incorrect.
