### PR TITLE
openapi3filter: use option to skip setting defaults on validation

### DIFF
--- a/openapi3filter/issue707_test.go
+++ b/openapi3filter/issue707_test.go
@@ -31,7 +31,7 @@ func TestIssue707(t *testing.T) {
           schema:
            default: 124
            type: integer
-           style: form 
+           style: form
           required: false
        responses:
         '200':

--- a/openapi3filter/issue707_test.go
+++ b/openapi3filter/issue707_test.go
@@ -1,0 +1,91 @@
+package openapi3filter
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+func TestIssue707(t *testing.T) {
+	loader := openapi3.NewLoader()
+	ctx := loader.Context
+	spec := `
+    openapi: 3.0.0
+    info:
+     version: 1.0.0
+     title: Sample API
+    paths:
+     /items:
+      get:
+       description: Returns a list of stuff
+       parameters:
+        - description: parameter with a default value
+          explode: true
+          in: query
+          name: param-with-default
+          schema:
+           default: 124
+           type: integer
+           style: form 
+          required: false
+       responses:
+        '200':
+           description: Successful response
+`[1:]
+
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	err = doc.Validate(ctx)
+	require.NoError(t, err)
+
+	router, err := gorillamux.NewRouter(doc)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		options       *Options
+		expectedQuery string
+	}{
+		{
+			name: "no defaults are added to requests parameters",
+			options: &Options{
+				SkipSettingDefaults: true,
+			},
+			expectedQuery: "",
+		},
+
+		{
+			name:          "defaults are added to requests",
+			expectedQuery: "param-with-default=124",
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			httpReq, err := http.NewRequest(http.MethodGet, "/items", strings.NewReader(""))
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(httpReq)
+			require.NoError(t, err)
+
+			requestValidationInput := &RequestValidationInput{
+				Request:    httpReq,
+				PathParams: pathParams,
+				Route:      route,
+				Options:    testcase.options,
+			}
+			err = ValidateRequest(ctx, requestValidationInput)
+			require.NoError(t, err)
+
+			require.NoError(t, err)
+			require.Equal(t, testcase.expectedQuery,
+				httpReq.URL.RawQuery, "default value must not be included")
+		})
+	}
+}

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -66,7 +66,7 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 			}
 		}
 
-		if err = ValidateParameter(ctx, input, parameter, options.SkipSettingDefaults); err != nil && !options.MultiError {
+		if err = ValidateParameter(ctx, input, parameter); err != nil && !options.MultiError {
 			return
 		}
 		if err != nil {
@@ -76,7 +76,7 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 
 	// For each parameter of the Operation
 	for _, parameter := range operationParameters {
-		if err = ValidateParameter(ctx, input, parameter.Value, options.SkipSettingDefaults); err != nil && !options.MultiError {
+		if err = ValidateParameter(ctx, input, parameter.Value); err != nil && !options.MultiError {
 			return
 		}
 		if err != nil {
@@ -106,8 +106,7 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 // The function returns RequestError with ErrInvalidRequired cause when a value of a required parameter is not defined.
 // The function returns RequestError with ErrInvalidEmptyValue cause when a value of a required parameter is not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
-func ValidateParameter(ctx context.Context, input *RequestValidationInput,
-	parameter *openapi3.Parameter, skipSettingDefaults bool) error {
+func ValidateParameter(ctx context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
 	if parameter.Schema == nil && parameter.Content == nil {
 		// We have no schema for the parameter. Assume that everything passes
 		// a schema-less check, but this could also be an error. The OpenAPI
@@ -138,7 +137,7 @@ func ValidateParameter(ctx context.Context, input *RequestValidationInput,
 	}
 
 	// Set default value if needed
-	if !skipSettingDefaults && value == nil && schema != nil && schema.Default != nil {
+	if !options.SkipSettingDefaults && value == nil && schema != nil && schema.Default != nil {
 		value = schema.Default
 		req := input.Request
 		switch parameter.In {


### PR DESCRIPTION
this pull request solves https://github.com/getkin/kin-openapi/issues/707 issue