### PR TITLE
fix(schema): define uuid

### DIFF
--- a/openapi3/schema_formats.go
+++ b/openapi3/schema_formats.go
@@ -93,6 +93,8 @@ func init() {
 	// date-time
 	DefineStringFormat("date-time", `^[0-9]{4}-(0[0-9]|10|11|12)-([0-2][0-9]|30|31)T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|(\+|-)[0-9]{2}:[0-9]{2})?$`)
 
+	// uuid
+	DefineStringFormat("uuid", FormatOfStringForUUIDOfRFC4122)
 }
 
 // DefineIPv4Format opts in ipv4 format validation on top of OAS 3 spec

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -22,7 +22,6 @@ type schemaExample struct {
 }
 
 func TestSchemas(t *testing.T) {
-	DefineStringFormat("uuid", FormatOfStringForUUIDOfRFC4122)
 	for _, example := range schemaExamples {
 		t.Run(example.Title, testSchema(t, example))
 	}


### PR DESCRIPTION
Fix: https://github.com/getkin/kin-openapi/issues/724

Seems like the definition of `uuid` was missing. In the 3.0.0 spec it's written :

```
Formats such as "email", "uuid", and so on, MAY be used even though undefined by this specification
```

So because we already have `email`, we can add `uuid`