### PR TITLE
openapi3: fix error phrase in security scheme

### DIFF
--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -194,7 +194,7 @@ func (ss *SecurityScheme) Validate(ctx context.Context, opts ...ValidationOption
 	} else if len(ss.In) > 0 {
 		return fmt.Errorf("security scheme of type %q can't have 'in'", ss.Type)
 	} else if len(ss.Name) > 0 {
-		return errors.New("security scheme of type %q can't have 'name'", ss.Type)
+		return fmt.Errorf("security scheme of type %q can't have 'name'", ss.Type)
 	}
 
 	// Validate "format"

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -194,7 +194,7 @@ func (ss *SecurityScheme) Validate(ctx context.Context, opts ...ValidationOption
 	} else if len(ss.In) > 0 {
 		return fmt.Errorf("security scheme of type %q can't have 'in'", ss.Type)
 	} else if len(ss.Name) > 0 {
-		return errors.New("security scheme of type 'apiKey' can't have 'name'")
+		return errors.New("security scheme of type %q can't have 'name'", ss.Type)
 	}
 
 	// Validate "format"


### PR DESCRIPTION
Encountered this while trying to validate a schema with "oauth2" type for security scheme.