### PR TITLE
Fix additional properties false not validated

### DIFF
--- a/openapi3/issue746_test.go
+++ b/openapi3/issue746_test.go
@@ -1,0 +1,26 @@
+package openapi3
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue746(t *testing.T) {
+	schema := &Schema{}
+	err := schema.UnmarshalJSON([]byte(`{"additionalProperties": false}`))
+	require.NoError(t, err)
+
+	var value interface{}
+	err = json.Unmarshal([]byte(`{"foo": "bar"}`), &value)
+	require.NoError(t, err)
+
+	err = schema.VisitJSON(value)
+	require.Error(t, err)
+
+	schemaErr := &SchemaError{}
+	require.ErrorAs(t, err, &schemaErr)
+	require.Equal(t, "properties", schemaErr.SchemaField)
+	require.Equal(t, `property "foo" is unsupported`, schemaErr.Reason)
+}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -810,7 +810,7 @@ func (schema *Schema) IsEmpty() bool {
 	if ap := schema.AdditionalProperties.Schema; ap != nil && !ap.Value.IsEmpty() {
 		return false
 	}
-	if apa := schema.AdditionalProperties.Has; apa != nil && *apa {
+	if apa := schema.AdditionalProperties.Has; apa != nil && !*apa {
 		return false
 	}
 	if items := schema.Items; items != nil && !items.Value.IsEmpty() {


### PR DESCRIPTION
Resolves #746

The issue was with `Schema.IsEmpty()` assuming incorrectly that `additionalProperties=false` means empty schema while the default value for `additionalProperties` is `true`.

From the [spec](https://spec.openapis.org/oas/v3.0.3#properties):

> `additionalProperties` - Value can be boolean or object. Inline or referenced schema MUST be of a Schema Object and not a standard JSON Schema. Consistent with JSON Schema, **`additionalProperties` defaults to `true`**.
