### PR TITLE
openapi3: fix validation of non-empty interface slice value against array schema

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1120,6 +1120,17 @@ func (schema *Schema) visitJSON(settings *schemaValidationSettings, value interf
 			return schema.visitJSONObject(settings, values)
 		}
 	}
+
+	// Catch slice of non-empty interface type
+	if reflect.TypeOf(value).Kind() == reflect.Slice {
+		valueR := reflect.ValueOf(value)
+		newValue := make([]interface{}, valueR.Len())
+		for i := 0; i < valueR.Len(); i++ {
+			newValue[i] = valueR.Index(i).Interface()
+		}
+		return schema.visitJSONArray(settings, newValue)
+	}
+
 	return &SchemaError{
 		Value:                 value,
 		Schema:                schema,

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -1364,5 +1364,5 @@ func TestStringSliceIssue(t *testing.T) {
 	validData := []string{"foo", "bar"}
 	invalidData := []string{"foo", "foo"}
 	require.NoError(t, schema.VisitJSON(validData))
-	require.NoError(t, schema.VisitJSON(invalidData)) // TODO:
+	require.ErrorContains(t, schema.VisitJSON(invalidData), "duplicate items found")
 }

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -1355,7 +1355,7 @@ enum:
 	require.Error(t, err)
 }
 
-func TestStringSliceIssue(t *testing.T) {
+func TestIssue751(t *testing.T) {
 	schema := &Schema{
 		Type:        "array",
 		UniqueItems: true,

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -1359,7 +1359,7 @@ func TestIssue751(t *testing.T) {
 	schema := &Schema{
 		Type:        "array",
 		UniqueItems: true,
-		Items: NewStringSchema().NewRef(),
+		Items:       NewStringSchema().NewRef(),
 	}
 	validData := []string{"foo", "bar"}
 	invalidData := []string{"foo", "foo"}

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -1354,3 +1354,15 @@ enum:
 	err = schema.VisitJSON(map[string]interface{}{"d": "e"})
 	require.Error(t, err)
 }
+
+func TestStringSliceIssue(t *testing.T) {
+	schema := &Schema{
+		Type:        "array",
+		UniqueItems: true,
+		Items: NewStringSchema().NewRef(),
+	}
+	validData := []string{"foo", "bar"}
+	invalidData := []string{"foo", "foo"}
+	require.NoError(t, schema.VisitJSON(validData))
+	require.NoError(t, schema.VisitJSON(invalidData)) // TODO:
+}


### PR DESCRIPTION
Resolves #751 

In `VisitJSON` after the `switch` block, it checks `value`'s Kind. If it is a Slice, it transforms the `value` into a slice of empty interfaces and passes it to `visitJSONArray`

`TestSchemas` did not catch this because the data (`AllValid` and `AllInvalid`) are coerced to empty interface types.