### PR TITLE
openapi3: empty scopes are valid

### DIFF
--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -363,8 +363,8 @@ func (flow *OAuthFlow) Validate(ctx context.Context, opts ...ValidationOption) e
 		}
 	}
 
-	if v := flow.Scopes; len(v) == 0 {
-		return errors.New("field 'scopes' is empty or missing")
+	if flow.Scopes == nil {
+		return errors.New("field 'scopes' is missing")
 	}
 
 	return validateExtensions(ctx, flow.Extensions)

--- a/openapi3/security_scheme_test.go
+++ b/openapi3/security_scheme_test.go
@@ -197,7 +197,7 @@ var securitySchemeExamples = []securitySchemeExample{
     }
   }
 }`),
-		valid: false,
+		valid: true,
 	},
 
 	{


### PR DESCRIPTION
accoriding to v3.1.0 documentation the scopes field can be empty.
https://spec.openapis.org/oas/v3.1.0#fixed-fields-24