### PR TITLE
openapi3filter: introduce `func ConvertErrors(err error) error`

### DIFF
--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -4,6 +4,7 @@ var ErrAuthenticationServiceMissing = errors.New("missing AuthenticationFunc")
 var ErrInvalidEmptyValue = errors.New("empty value is not allowed")
 var ErrInvalidRequired = errors.New("value is required but missing")
 var JSONPrefixes = []string{ ... }
+func ConvertErrors(err error) error
 func DefaultErrorEncoder(_ context.Context, err error, w http.ResponseWriter)
 func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, ...) (interface{}, error)
 func NoopAuthenticationFunc(context.Context, *AuthenticationInput) error

--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -17,16 +17,18 @@ type ValidationErrorEncoder struct {
 
 // Encode implements the ErrorEncoder interface for encoding ValidationErrors
 func (enc *ValidationErrorEncoder) Encode(ctx context.Context, err error, w http.ResponseWriter) {
+	enc.Encoder(ctx, ConvertErrors(err), w)
+}
+
+// ConvertErrors converts all errors to the appropriate error format.
+func ConvertErrors(err error) error {
 	if e, ok := err.(*routers.RouteError); ok {
-		cErr := convertRouteError(e)
-		enc.Encoder(ctx, cErr, w)
-		return
+		return convertRouteError(e)
 	}
 
 	e, ok := err.(*RequestError)
 	if !ok {
-		enc.Encoder(ctx, err, w)
-		return
+		return err
 	}
 
 	var cErr *ValidationError
@@ -43,10 +45,9 @@ func (enc *ValidationErrorEncoder) Encode(ctx context.Context, err error, w http
 	}
 
 	if cErr != nil {
-		enc.Encoder(ctx, cErr, w)
-		return
+		return cErr
 	}
-	enc.Encoder(ctx, err, w)
+	return err
 }
 
 func convertRouteError(e *routers.RouteError) *ValidationError {


### PR DESCRIPTION
- Need to expose the ConvertErrors func for our service.
- fix failed CI