### PR TITLE
openapi3filter: fix oneOF validation in query params

### DIFF
--- a/openapi3filter/issue789_test.go
+++ b/openapi3filter/issue789_test.go
@@ -1,0 +1,128 @@
+package openapi3filter_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+func TestIssue789(t *testing.T) {
+
+	anyOfArraySpec := `
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Sample API
+paths:
+  /items:
+    get:
+      description: Returns a list of stuff
+      parameters:
+      - description: test object
+        explode: false
+        in: query
+        name: test
+        required: true
+        schema:
+          type: string
+          anyOf:
+            - pattern: '\babc\b'
+            - pattern: '\bfoo\b'
+            - pattern: '\bbar\b'
+      responses:
+        '200':
+          description: Successful response
+`[1:]
+
+	oneOfArraySpec := strings.ReplaceAll(anyOfArraySpec, "anyOf", "oneOf")
+
+	allOfArraySpec := strings.ReplaceAll(strings.ReplaceAll(anyOfArraySpec, "anyOf", "allOf"),
+		"type: boolean", "type: number")
+
+	tests := []struct {
+		name   string
+		spec   string
+		req    string
+		errStr string
+	}{
+		{
+			name: "success anyof string pattern match",
+			spec: anyOfArraySpec,
+			req:  "/items?test=abc",
+		},
+		{
+			name:   "failed anyof string pattern match",
+			spec:   anyOfArraySpec,
+			req:    "/items?test=def",
+			errStr: `parameter "test" in query has an error: doesn't match any schema from "anyOf"`,
+		},
+		{
+			name: "success allof object array",
+			spec: allOfArraySpec,
+			req:  `/items?test=abc foo bar`,
+		},
+		{
+			name:   "failed allof object array",
+			spec:   allOfArraySpec,
+			req:    `/items?test=foo`,
+			errStr: `parameter "test" in query has an error: string doesn't match the regular expression`,
+		},
+		{
+			name: "success oneof string pattern match",
+			spec: oneOfArraySpec,
+			req:  `/items?test=foo`,
+		},
+		{
+			name:   "failed oneof string pattern match",
+			spec:   oneOfArraySpec,
+			req:    `/items?test=def`,
+			errStr: `parameter "test" in query has an error: doesn't match schema due to: string doesn't match the regular expression`,
+		},
+		{
+			name:   "failed oneof string pattern match",
+			spec:   oneOfArraySpec,
+			req:    `/items?test=foo bar`,
+			errStr: `parameter "test" in query has an error: input matches more than one oneOf schemas`,
+		},
+	}
+
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			loader := openapi3.NewLoader()
+			ctx := loader.Context
+
+			doc, err := loader.LoadFromData([]byte(testcase.spec))
+			require.NoError(t, err)
+
+			err = doc.Validate(ctx)
+			require.NoError(t, err)
+
+			router, err := gorillamux.NewRouter(doc)
+			require.NoError(t, err)
+			httpReq, err := http.NewRequest(http.MethodGet, testcase.req, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(httpReq)
+			require.NoError(t, err)
+
+			requestValidationInput := &openapi3filter.RequestValidationInput{
+				Request:    httpReq,
+				PathParams: pathParams,
+				Route:      route,
+			}
+			err = openapi3filter.ValidateRequest(ctx, requestValidationInput)
+			if testcase.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Contains(t, err.Error(), testcase.errStr)
+			}
+		},
+		)
+	}
+}

--- a/openapi3filter/issue789_test.go
+++ b/openapi3filter/issue789_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestIssue789(t *testing.T) {
-
 	anyOfArraySpec := `
 openapi: 3.0.0
 info:
@@ -42,8 +41,7 @@ paths:
 
 	oneOfArraySpec := strings.ReplaceAll(anyOfArraySpec, "anyOf", "oneOf")
 
-	allOfArraySpec := strings.ReplaceAll(strings.ReplaceAll(anyOfArraySpec, "anyOf", "allOf"),
-		"type: boolean", "type: number")
+	allOfArraySpec := strings.ReplaceAll(anyOfArraySpec, "anyOf", "allOf")
 
 	tests := []struct {
 		name   string

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -301,10 +301,8 @@ func decodeValue(dec valueDecoder, param string, sm *openapi3.SerializationMetho
 				isMatched++
 			}
 		}
-		if isMatched == 1 {
+		if isMatched >= 1 {
 			return value, found, nil
-		} else if isMatched > 1 {
-			return nil, found, fmt.Errorf("decoding oneOf failed: %d schemas matched", isMatched)
 		}
 		if required {
 			return nil, found, fmt.Errorf("decoding oneOf failed: %q is required", param)

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -270,13 +270,6 @@ func TestFilter(t *testing.T) {
 
 	req = ExampleRequest{
 		Method: "POST",
-		URL:    "http://example.com/api/prefix/v/suffix?queryArgOneOf=567",
-	}
-	err = expect(req, resp)
-	require.IsType(t, &RequestError{}, err)
-
-	req = ExampleRequest{
-		Method: "POST",
 		URL:    "http://example.com/api/prefix/v/suffix?queryArgOneOf=2017-12-31T11:59:59",
 	}
 	err = expect(req, resp)


### PR DESCRIPTION
Addresses issue raised here https://github.com/getkin/kin-openapi/issues/789. The fix differs validation to within the schema as the current implemention would always validate incorrectly. I've added test cases for the original issue, along with removing a test within `validation_test.go` which would always fail, so wasn't actually testing the intended behaviour.