### PR TITLE
openapi3gen: fix panic when embedded type is not a struct

### DIFF
--- a/openapi3gen/field_info.go
+++ b/openapi3gen/field_info.go
@@ -34,6 +34,9 @@ iteration:
 
 		// See whether this is an embedded field
 		if f.Anonymous {
+			if f.Type.Kind() != reflect.Struct {
+				continue iteration
+			}
 			jsonTag := f.Tag.Get("json")
 			if jsonTag == "-" {
 				continue

--- a/openapi3gen/field_info.go
+++ b/openapi3gen/field_info.go
@@ -23,6 +23,10 @@ func appendFields(fields []theFieldInfo, parentIndex []int, t reflect.Type) []th
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}
+	if t.Kind() != reflect.Struct {
+		return fields
+	}
+
 	// For each field
 	numField := t.NumField()
 iteration:
@@ -34,9 +38,6 @@ iteration:
 
 		// See whether this is an embedded field
 		if f.Anonymous {
-			if f.Type.Kind() != reflect.Struct {
-				continue iteration
-			}
 			jsonTag := f.Tag.Get("json")
 			if jsonTag == "-" {
 				continue

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -24,6 +24,10 @@ func ExampleGenerator_SchemaRefs() {
 	type Embedded2 struct {
 		A string `json:"a"`
 	}
+	type EmbeddedNonStruct string
+	type Embedded3 struct {
+		EmbeddedNonStruct
+	}
 	type SomeStruct struct {
 		Bool    bool                      `json:"bool"`
 		Int     int                       `json:"int"`
@@ -48,6 +52,8 @@ func ExampleGenerator_SchemaRefs() {
 
 		Embedded2
 
+		Embedded3 `json:"embedded3"`
+
 		Ptr *SomeOtherType `json:"ptr"`
 	}
 
@@ -64,7 +70,7 @@ func ExampleGenerator_SchemaRefs() {
 	}
 	fmt.Printf("schemaRef: %s\n", data)
 	// Output:
-	// g.SchemaRefs: 16
+	// g.SchemaRefs: 17
 	// schemaRef: {
 	//   "properties": {
 	//     "a": {
@@ -85,6 +91,7 @@ func ExampleGenerator_SchemaRefs() {
 	//       },
 	//       "type": "object"
 	//     },
+	//     "embedded3": {},
 	//     "float64": {
 	//       "format": "double",
 	//       "type": "number"

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -25,8 +25,10 @@ func ExampleGenerator_SchemaRefs() {
 		A string `json:"a"`
 	}
 	type EmbeddedNonStruct string
+	type EmbeddedNonStructPtr string
 	type Embedded3 struct {
 		EmbeddedNonStruct
+		*EmbeddedNonStructPtr
 	}
 	type SomeStruct struct {
 		Bool    bool                      `json:"bool"`


### PR DESCRIPTION
This PR fixes a panic when an embedded type is not a struct. 

To infer the actual type from the embedded type is specifically complex, it is simpler in these cases to use a schema customizer. It makes the most sense to ignore the type.