### PR TITLE
openapi3,routers: simplify code

### DIFF
--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -14,7 +14,7 @@ type Links map[string]*LinkRef
 // JSONLookup implements github.com/go-openapi/jsonpointer#JSONPointable
 func (links Links) JSONLookup(token string) (interface{}, error) {
 	ref, ok := links[token]
-	if ok == false {
+	if !ok {
 		return nil, fmt.Errorf("object has no field %q", token)
 	}
 

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -18,7 +18,7 @@ var _ jsonpointer.JSONPointable = (*ParametersMap)(nil)
 // JSONLookup implements github.com/go-openapi/jsonpointer#JSONPointable
 func (p ParametersMap) JSONLookup(token string) (interface{}, error) {
 	ref, ok := p[token]
-	if ref == nil || ok == false {
+	if ref == nil || !ok {
 		return nil, fmt.Errorf("object has no field %q", token)
 	}
 

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -16,7 +16,7 @@ var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
 // JSONLookup implements github.com/go-openapi/jsonpointer#JSONPointable
 func (r RequestBodies) JSONLookup(token string) (interface{}, error) {
 	ref, ok := r[token]
-	if ok == false {
+	if !ok {
 		return nil, fmt.Errorf("object has no field %q", token)
 	}
 

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -56,7 +56,7 @@ func (responses Responses) Validate(ctx context.Context, opts ...ValidationOptio
 // JSONLookup implements github.com/go-openapi/jsonpointer#JSONPointable
 func (responses Responses) JSONLookup(token string) (interface{}, error) {
 	ref, ok := responses[token]
-	if ok == false {
+	if !ok {
 		return nil, fmt.Errorf("invalid token reference: %q", token)
 	}
 

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -84,7 +84,7 @@ var _ jsonpointer.JSONPointable = (*Schemas)(nil)
 // JSONLookup implements github.com/go-openapi/jsonpointer#JSONPointable
 func (s Schemas) JSONLookup(token string) (interface{}, error) {
 	ref, ok := s[token]
-	if ref == nil || ok == false {
+	if ref == nil || !ok {
 		return nil, fmt.Errorf("object has no field %q", token)
 	}
 
@@ -1405,7 +1405,7 @@ func (schema *Schema) visitJSONNumber(settings *schemaValidationSettings, value 
 				Value:                 value,
 				Schema:                schema,
 				SchemaField:           "type",
-				Reason:                fmt.Sprintf("value must be an integer"),
+				Reason:                "value must be an integer",
 				customizeMessageError: settings.customizeMessageError,
 			}
 			if !settings.multiError {

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -15,7 +15,7 @@ type SecuritySchemes map[string]*SecuritySchemeRef
 // JSONLookup implements github.com/go-openapi/jsonpointer#JSONPointable
 func (s SecuritySchemes) JSONLookup(token string) (interface{}, error) {
 	ref, ok := s[token]
-	if ref == nil || ok == false {
+	if ref == nil || !ok {
 		return nil, fmt.Errorf("object has no field %q", token)
 	}
 

--- a/routers/legacy/router.go
+++ b/routers/legacy/router.go
@@ -157,10 +157,7 @@ func (router *Router) FindRoute(req *http.Request) (*routers.Route, map[string]s
 	}
 	paramKeys := node.VariableNames
 	for i, value := range paramValues {
-		key := paramKeys[i]
-		if strings.HasSuffix(key, "*") {
-			key = key[:len(key)-1]
-		}
+		key := strings.TrimSuffix(paramKeys[i], "*")
 		pathParams[key] = value
 	}
 	return route, pathParams, nil


### PR DESCRIPTION
This PR simplifies code by:

- use `!ok` instead of `ok == false`;
- use `strings.TrimSuffix` instead of `strings.HasPrefix` with a condition;
- remove unnecessary `fmt.Sprintf`.