### PR TITLE
openapi3,openapi3filter: refactor bytes.Buffer creation

### DIFF
--- a/openapi3/example_validation_test.go
+++ b/openapi3/example_validation_test.go
@@ -221,8 +221,7 @@ func TestExamplesSchemaValidation(t *testing.T) {
 			t.Parallel()
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					spec := bytes.Buffer{}
-					spec.WriteString(`
+					spec := bytes.NewBufferString(`
 openapi: 3.0.3
 info:
   title: An API
@@ -436,8 +435,7 @@ func TestExampleObjectValidation(t *testing.T) {
 			t.Parallel()
 			for _, tc := range testCases {
 				t.Run(tc.name, func(t *testing.T) {
-					spec := bytes.Buffer{}
-					spec.WriteString(`
+					spec := bytes.NewBufferString(`
 openapi: 3.0.3
 info:
   title: An API

--- a/openapi3filter/errors.go
+++ b/openapi3filter/errors.go
@@ -79,8 +79,7 @@ type SecurityRequirementsError struct {
 }
 
 func (err *SecurityRequirementsError) Error() string {
-	buff := &bytes.Buffer{}
-	buff.WriteString("security requirements failed: ")
+	buff := bytes.NewBufferString("security requirements failed: ")
 	for i, e := range err.Errors {
 		buff.WriteString(e.Error())
 		if i != len(err.Errors)-1 {

--- a/openapi3filter/validate_readonly_test.go
+++ b/openapi3filter/validate_readonly_test.go
@@ -141,8 +141,7 @@ func TestReadOnlyWriteOnlyPropertiesValidation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			spec := bytes.Buffer{}
-			spec.WriteString(`{
+			spec := bytes.NewBufferString(`{
 				"openapi": "3.0.3",
 				"info": {
 					"version": "1.0.0",

--- a/openapi3filter/validation_error.go
+++ b/openapi3filter/validation_error.go
@@ -35,8 +35,7 @@ var _ error = &ValidationError{}
 
 // Error implements the error interface.
 func (e *ValidationError) Error() string {
-	b := new(bytes.Buffer)
-	b.WriteString("[")
+	b := bytes.NewBufferString("[")
 	if e.Status != 0 {
 		b.WriteString(strconv.Itoa(e.Status))
 	}


### PR DESCRIPTION
This PR refactors code: we can combine declaration and write a string to `bytes.Buffer`.