### PR TITLE
openapi3: refactor tests: use BoolPtr, require.Same

### DIFF
--- a/openapi3/content_test.go
+++ b/openapi3/content_test.go
@@ -102,12 +102,8 @@ func TestContent_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Using require.True here because require.Same is not yet released.
-			// We're comparing pointer values and the require.Equal will
-			// dereference and compare the pointed to values rather than check
-			// if the memory addresses are the same. Once require.Same is released
-			// this test should convert to using that.
-			require.True(t, tt.want == tt.content.Get(tt.mime))
+			got := tt.content.Get(tt.mime)
+			require.Same(t, tt.want, got)
 		})
 	}
 }

--- a/openapi3/discriminator_test.go
+++ b/openapi3/discriminator_test.go
@@ -52,5 +52,5 @@ func TestParsingDiscriminator(t *testing.T) {
 	err = doc.Validate(loader.Context)
 	require.NoError(t, err)
 
-	require.Equal(t, 2, len(doc.Components.Schemas["MyResponseType"].Value.Discriminator.Mapping))
+	require.Len(t, doc.Components.Schemas["MyResponseType"].Value.Discriminator.Mapping, 2)
 }

--- a/openapi3/encoding_test.go
+++ b/openapi3/encoding_test.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -45,7 +44,6 @@ var encodingJSON = []byte(`
 `)
 
 func encoding() *Encoding {
-	explode := true
 	return &Encoding{
 		ContentType: "application/json",
 		Headers: map[string]*HeaderRef{
@@ -54,13 +52,12 @@ func encoding() *Encoding {
 			},
 		},
 		Style:         "form",
-		Explode:       &explode,
+		Explode:       BoolPtr(true),
 		AllowReserved: true,
 	}
 }
 
 func TestEncodingSerializationMethod(t *testing.T) {
-	boolPtr := func(b bool) *bool { return &b }
 	testCases := []struct {
 		name string
 		enc  *Encoding
@@ -77,24 +74,24 @@ func TestEncodingSerializationMethod(t *testing.T) {
 		},
 		{
 			name: "encoding with explode",
-			enc:  &Encoding{Explode: boolPtr(true)},
+			enc:  &Encoding{Explode: BoolPtr(true)},
 			want: &SerializationMethod{Style: SerializationForm, Explode: true},
 		},
 		{
 			name: "encoding with no explode",
-			enc:  &Encoding{Explode: boolPtr(false)},
+			enc:  &Encoding{Explode: BoolPtr(false)},
 			want: &SerializationMethod{Style: SerializationForm, Explode: false},
 		},
 		{
 			name: "encoding with style and explode ",
-			enc:  &Encoding{Style: SerializationSpaceDelimited, Explode: boolPtr(false)},
+			enc:  &Encoding{Style: SerializationSpaceDelimited, Explode: BoolPtr(false)},
 			want: &SerializationMethod{Style: SerializationSpaceDelimited, Explode: false},
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.enc.SerializationMethod()
-			require.True(t, reflect.DeepEqual(got, tc.want), "got %#v, want %#v", got, tc.want)
+			require.EqualValues(t, got, tc.want, "got %#v, want %#v", got, tc.want)
 		})
 	}
 }

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -23,9 +23,8 @@ import (
 
 func TestDecodeParameter(t *testing.T) {
 	var (
-		boolPtr   = func(b bool) *bool { return &b }
-		explode   = boolPtr(true)
-		noExplode = boolPtr(false)
+		explode   = openapi3.BoolPtr(true)
+		noExplode = openapi3.BoolPtr(false)
 		arrayOf   = func(items *openapi3.SchemaRef) *openapi3.SchemaRef {
 			return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: "array", Items: items}}
 		}
@@ -1079,8 +1078,6 @@ func TestDecodeParameter(t *testing.T) {
 }
 
 func TestDecodeBody(t *testing.T) {
-	boolPtr := func(b bool) *bool { return &b }
-
 	urlencodedForm := make(url.Values)
 	urlencodedForm.Set("a", "a1")
 	urlencodedForm.Set("b", "10")
@@ -1198,7 +1195,7 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("b", openapi3.NewIntegerSchema()).
 				WithProperty("c", openapi3.NewArraySchema().WithItems(openapi3.NewStringSchema())),
 			encoding: map[string]*openapi3.Encoding{
-				"c": {Style: openapi3.SerializationSpaceDelimited, Explode: boolPtr(false)},
+				"c": {Style: openapi3.SerializationSpaceDelimited, Explode: openapi3.BoolPtr(false)},
 			},
 			want: map[string]interface{}{"a": "a1", "b": int64(10), "c": []interface{}{"c1", "c2"}},
 		},
@@ -1211,7 +1208,7 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("b", openapi3.NewIntegerSchema()).
 				WithProperty("c", openapi3.NewArraySchema().WithItems(openapi3.NewStringSchema())),
 			encoding: map[string]*openapi3.Encoding{
-				"c": {Style: openapi3.SerializationPipeDelimited, Explode: boolPtr(false)},
+				"c": {Style: openapi3.SerializationPipeDelimited, Explode: openapi3.BoolPtr(false)},
 			},
 			want: map[string]interface{}{"a": "a1", "b": int64(10), "c": []interface{}{"c1", "c2"}},
 		},


### PR DESCRIPTION
This PR refactors tests:

- use `openapi3.BoolPtr` instead of declaring own function in every test;
- use `require.Same` instead of `require.True`;
- use `require.EqualValues` instead of `reflect.DeepEqual`.