### PR TITLE
Fix Enum Query Parameters 

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1149,6 +1149,10 @@ func (schema *Schema) visitSetOperations(settings *schemaValidationSettings, val
 				if v == f {
 					return
 				}
+			case int64:
+				if v == float64(c) {
+					return
+				}
 			default:
 				if reflect.DeepEqual(v, value) {
 					return


### PR DESCRIPTION
Query Parameters are evaluated as int64 vs. a float which is why reflect.DeepEqual fails. 