### PR TITLE
openapi3: support patterned fields in Responses (#819)

### DIFF
--- a/openapi3/issue819_test.go
+++ b/openapi3/issue819_test.go
@@ -35,4 +35,5 @@ paths:
 
 	require.NotNil(t, doc.Paths["/v1/operation"].Get.Responses.Get(201))
 	require.Nil(t, doc.Paths["/v1/operation"].Get.Responses.Get(404))
+	require.Nil(t, doc.Paths["/v1/operation"].Get.Responses.Get(999))
 }

--- a/openapi3/issue819_test.go
+++ b/openapi3/issue819_test.go
@@ -32,5 +32,7 @@ paths:
 	require.NoError(t, err)
 	err = doc.Validate(sl.Context)
 	require.NoError(t, err)
+
 	require.NotNil(t, doc.Paths["/v1/operation"].Get.Responses.Get(201))
+	require.Nil(t, doc.Paths["/v1/operation"].Get.Responses.Get(404))
 }

--- a/openapi3/issue_819_test.go
+++ b/openapi3/issue_819_test.go
@@ -1,0 +1,36 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue819ResponsesGetPatternedFields(t *testing.T) {
+	spec := `
+openapi: "3.0.3"
+info:
+  title: 'My app'
+  version: 1.0.0
+  description: 'An API'
+
+paths:
+  /v1/operation:
+    get:
+      summary: Fetch something
+      responses:
+        2XX:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                description: An error response body.
+`[1:]
+	sl := NewLoader()
+	doc, err := sl.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	err = doc.Validate(sl.Context)
+	require.NoError(t, err)
+	require.NotNil(t, doc.Paths["/v1/operation"].Get.Responses.Get(201))
+}

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -30,17 +30,27 @@ func (responses Responses) Default() *ResponseRef {
 // Get returns a ResponseRef for the given status
 // If an exact match isn't initially found a patterned field is checked using
 // the first digit to determine the range (eg: 201 to 2XX)
+// See https://spec.openapis.org/oas/v3.0.3#patterned-fields-0
 func (responses Responses) Get(status int) *ResponseRef {
 	st := strconv.FormatInt(int64(status), 10)
-	rref, ok := responses[st]
-	if ok {
+	if rref, ok := responses[st]; ok {
 		return rref
 	}
 	st = string(st[0]) + "XX"
-	if rref, ok = responses[st]; !ok {
+	switch st {
+	case "1XX":
+		return responses["1XX"]
+	case "2XX":
+		return responses["2XX"]
+	case "3XX":
+		return responses["3XX"]
+	case "4XX":
+		return responses["4XX"]
+	case "5XX":
+		return responses["5XX"]
+	default:
 		return nil
 	}
-	return rref
 }
 
 // Validate returns an error if Responses does not comply with the OpenAPI spec.

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -27,8 +27,21 @@ func (responses Responses) Default() *ResponseRef {
 	return responses["default"]
 }
 
+// Get returns a ResponseRef for the given status
+// If an exact match isn't initially found a patterned field is checked using
+// the first digit to determine the range (eg: 201 to 2XX)
 func (responses Responses) Get(status int) *ResponseRef {
-	return responses[strconv.FormatInt(int64(status), 10)]
+	st := strconv.FormatInt(int64(status), 10)
+	rref, ok := responses[strconv.FormatInt(int64(status), 10)]
+	if ok {
+		return rref
+	}
+	st = string(st[0]) + "XX"
+	rref, ok = responses[st]
+	if !ok {
+		return nil
+	}
+	return rref
 }
 
 // Validate returns an error if Responses does not comply with the OpenAPI spec.

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -32,13 +32,12 @@ func (responses Responses) Default() *ResponseRef {
 // the first digit to determine the range (eg: 201 to 2XX)
 func (responses Responses) Get(status int) *ResponseRef {
 	st := strconv.FormatInt(int64(status), 10)
-	rref, ok := responses[strconv.FormatInt(int64(status), 10)]
+	rref, ok := responses[st]
 	if ok {
 		return rref
 	}
 	st = string(st[0]) + "XX"
-	rref, ok = responses[st]
-	if !ok {
+	if rref, ok = responses[st]; !ok {
 		return nil
 	}
 	return rref


### PR DESCRIPTION
Implements patterned fields in `openapi3.Responses.Get` 

This seemed to be the quickest fix for #819. Open to other ideas as well!