### PR TITLE
fix/ update version of go to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/getkin/kin-openapi
 
-go 1.18
+go 1.20
 
 require (
 	github.com/go-openapi/jsonpointer v0.19.6


### PR DESCRIPTION
[#836](https://github.com/getkin/kin-openapi/issues/836)

- use of the [sync.Map#CompareAndSwap](https://pkg.go.dev/sync@go1.20#Map.CompareAndSwap) method requires the version of go used to be 1.20