### PR TITLE
openapi3: add length of circular reference to error message

### DIFF
--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -751,7 +751,7 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 		} else {
 			if visitedLimit(visited, ref) {
 				visited = append(visited, ref)
-				return fmt.Errorf("%s - %s", CircularReferenceError, strings.Join(visited, " -> "))
+				return fmt.Errorf("%s with length %d - %s", CircularReferenceError, len(visited), strings.Join(visited, " -> "))
 			}
 			visited = append(visited, ref)
 


### PR DESCRIPTION
To allow folks who do want to tune the value of the
`CircularReferenceCounter` to do so more easily, we can output the size
of the circular reference in the error message.
