### PR TITLE
Replace deprecated io/ioutil with io

### DIFF
--- a/openapi3/loader_uri_reader.go
+++ b/openapi3/loader_uri_reader.go
@@ -3,7 +3,7 @@ package openapi3
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -64,7 +64,7 @@ func ReadFromHTTP(cl *http.Client) ReadFromURIFunc {
 		if resp.StatusCode > 399 {
 			return nil, fmt.Errorf("error loading %q: request returned status code %d", location.String(), resp.StatusCode)
 		}
-		return ioutil.ReadAll(resp.Body)
+		return io.ReadAll(resp.Body)
 	}
 }
 

--- a/openapi3filter/issue639_test.go
+++ b/openapi3filter/issue639_test.go
@@ -2,7 +2,7 @@ package openapi3filter
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -87,7 +87,7 @@ func TestIssue639(t *testing.T) {
 			}
 			err = ValidateRequest(ctx, requestValidationInput)
 			require.NoError(t, err)
-			bodyAfterValidation, err := ioutil.ReadAll(httpReq.Body)
+			bodyAfterValidation, err := io.ReadAll(httpReq.Body)
 			require.NoError(t, err)
 
 			raw := map[string]interface{}{}

--- a/openapi3filter/middleware.go
+++ b/openapi3filter/middleware.go
@@ -3,7 +3,6 @@ package openapi3filter
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 
@@ -149,7 +148,7 @@ func (v *Validator) Middleware(h http.Handler) http.Handler {
 			RequestValidationInput: requestValidationInput,
 			Status:                 wr.statusCode(),
 			Header:                 wr.Header(),
-			Body:                   ioutil.NopCloser(bytes.NewBuffer(wr.bodyContents())),
+			Body:                   io.NopCloser(bytes.NewBuffer(wr.bodyContents())),
 			Options:                &v.options,
 		}); err != nil {
 			v.logFunc("invalid response", err)

--- a/openapi3filter/middleware_test.go
+++ b/openapi3filter/middleware_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"path"
@@ -391,7 +390,7 @@ func TestValidator(t *testing.T) {
 			require.Equalf(t, test.response.statusCode, resp.StatusCode,
 				"response code expect %d got %d", test.response.statusCode, resp.StatusCode)
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err, "failed to read response body")
 			require.Equalf(t, test.response.body, string(body),
 				"response body expect %q got %q", test.response.body, string(body))
@@ -507,7 +506,7 @@ paths:
 			panic(err)
 		}
 		defer resp.Body.Close()
-		contents, err := ioutil.ReadAll(resp.Body)
+		contents, err := io.ReadAll(resp.Body)
 		if err != nil {
 			panic(err)
 		}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -1019,7 +1018,7 @@ func init() {
 }
 
 func plainBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, &ParseError{Kind: KindInvalidFormat, Cause: err}
 	}
@@ -1064,7 +1063,7 @@ func urlencodedBodyDecoder(body io.Reader, header http.Header, schema *openapi3.
 	}
 
 	// Parse form.
-	b, err := ioutil.ReadAll(body)
+	b, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}
@@ -1216,7 +1215,7 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 
 // FileBodyDecoder is a body decoder that decodes a file body to a string.
 func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -1337,7 +1336,7 @@ func TestRegisterAndUnregisterBodyDecoder(t *testing.T) {
 	var decoder BodyDecoder
 	decoder = func(body io.Reader, h http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (decoded interface{}, err error) {
 		var data []byte
-		if data, err = ioutil.ReadAll(body); err != nil {
+		if data, err = io.ReadAll(body); err != nil {
 			return
 		}
 		return strings.Split(string(data), ","), nil

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 
@@ -208,7 +207,7 @@ func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, req
 	if req.Body != http.NoBody && req.Body != nil {
 		defer req.Body.Close()
 		var err error
-		if data, err = ioutil.ReadAll(req.Body); err != nil {
+		if data, err = io.ReadAll(req.Body); err != nil {
 			return &RequestError{
 				Input:       input,
 				RequestBody: requestBody,

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -125,7 +125,7 @@ func ValidateResponse(ctx context.Context, input *ResponseValidationInput) error
 	defer body.Close()
 
 	// Read all
-	data, err := ioutil.ReadAll(body)
+	data, err := io.ReadAll(body)
 	if err != nil {
 		return &ResponseError{
 			Input:  input,

--- a/openapi3filter/validate_response_input.go
+++ b/openapi3filter/validate_response_input.go
@@ -3,7 +3,6 @@ package openapi3filter
 import (
 	"bytes"
 	"io"
-	"io/ioutil"
 	"net/http"
 )
 
@@ -16,7 +15,7 @@ type ResponseValidationInput struct {
 }
 
 func (input *ResponseValidationInput) SetBodyBytes(value []byte) *ResponseValidationInput {
-	input.Body = ioutil.NopCloser(bytes.NewReader(value))
+	input.Body = io.NopCloser(bytes.NewReader(value))
 	return input
 }
 

--- a/openapi3filter/validate_set_default_test.go
+++ b/openapi3filter/validate_set_default_test.go
@@ -3,7 +3,7 @@ package openapi3filter
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -795,7 +795,7 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			validatedReqBody, err := ioutil.ReadAll(httpReq.Body)
+			validatedReqBody, err := io.ReadAll(httpReq.Body)
 			require.NoError(t, err)
 			tc.bodyAssertion(t, string(validatedReqBody))
 		})

--- a/openapi3filter/validation_error_test.go
+++ b/openapi3filter/validation_error_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -657,7 +656,7 @@ func TestValidationHandler_ServeHTTP(t *testing.T) {
 		encoder := &ValidationErrorEncoder{Encoder: (ErrorEncoder)(DefaultErrorEncoder)}
 		resp := runTest_ServeHTTP(t, handler, encoder.Encode, r)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 		require.Equal(t, "[422][][] value must be an array [source pointer=/photoUrls]", string(body))
@@ -699,7 +698,7 @@ func TestValidationHandler_Middleware(t *testing.T) {
 		encoder := &ValidationErrorEncoder{Encoder: (ErrorEncoder)(DefaultErrorEncoder)}
 		resp := runTest_Middleware(t, handler, encoder.Encode, r)
 
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
 		require.Equal(t, "[422][][] value must be an array [source pointer=/photoUrls]", string(body))

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -365,7 +364,7 @@ func marshalReader(value interface{}) io.ReadCloser {
 	if err != nil {
 		panic(err)
 	}
-	return ioutil.NopCloser(bytes.NewReader(data))
+	return io.NopCloser(bytes.NewReader(data))
 }
 
 func TestValidateRequestBody(t *testing.T) {

--- a/routers/issue356_test.go
+++ b/routers/issue356_test.go
@@ -2,7 +2,7 @@ package routers_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -129,7 +129,7 @@ paths:
 				rep, err := http.DefaultClient.Do(req)
 				require.NoError(t, err)
 				defer rep.Body.Close()
-				body, err := ioutil.ReadAll(rep.Body)
+				body, err := io.ReadAll(rep.Body)
 				require.NoError(t, err)
 
 				if expectError {


### PR DESCRIPTION
This PR replaces usages of `io/ioutil` with `io` because [io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated:

> Deprecated: As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code. See the specific function documentation for details.

