### PR TITLE
openapi2conv: fix that removes an extra `required` array from `formDataBody`

### DIFF
--- a/openapi2conv/issue847_test.go
+++ b/openapi2conv/issue847_test.go
@@ -2,59 +2,42 @@ package openapi2conv
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestIssue847(t *testing.T) {
-	spec := []byte(`
-{
-  "swagger": "2.0",
-  "info": {
-    "description": "Hello Java Sec API",
-    "version": "1.10",
-    "title": "Swagger2 RESTful API"
-  },
-  "host": "localhost:8888",
-  "basePath": "/",
-  "paths": {
-    "/UPLOAD/uploadSafe": {
-      "post": {
-        "operationId": "singleFileUploadSafeUsingPOST",
-        "consumes": [
-          "multipart/form-data"
-        ],
-        "parameters": [
-          {
-            "name": "file",
-            "in": "formData",
-            "description": "file",
-            "required": true,
-            "type": "file"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "schema": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    }
-  }
-}
+	v2 := []byte(`
+swagger: '2.0'
+info:
+  version: '1.10'
+  title: title
+paths:
+  "/ping":
+    post:
+      consumes:
+      - multipart/form-data
+      parameters:
+      - name: file
+        in: formData
+        description: file
+        required: true
+        type: file
+      responses:
+        '200':
+          description: OK
 `)
-	doc3, err := v2v3JSON(spec)
+
+	v3, err := v2v3YAML(v2)
 	require.NoError(t, err)
 
-	reqStr, err := json.MarshalIndent(doc3, "", "    ")
-	require.NotNil(t, reqStr)
+	err = v3.Validate(context.Background())
 	require.NoError(t, err)
 
-	err = doc3.Validate(context.Background())
-	require.NoError(t, err)
+	schemaRequired := v3.Paths["/ping"].Post.RequestBody.Value.Content["multipart/form-data"].Schema.Value.Required
+	require.Equal(t, schemaRequired, []string{"file"})
+
+	fieldRequired := v3.Paths["/ping"].Post.RequestBody.Value.Content["multipart/form-data"].Schema.Value.Properties["file"].Value.Required
+	require.Nil(t, fieldRequired)
 }

--- a/openapi2conv/issue847_test.go
+++ b/openapi2conv/issue847_test.go
@@ -1,0 +1,60 @@
+package openapi2conv
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue847(t *testing.T) {
+	spec := []byte(`
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "Hello Java Sec API",
+    "version": "1.10",
+    "title": "Swagger2 RESTful API"
+  },
+  "host": "localhost:8888",
+  "basePath": "/",
+  "paths": {
+    "/UPLOAD/uploadSafe": {
+      "post": {
+        "operationId": "singleFileUploadSafeUsingPOST",
+        "consumes": [
+          "multipart/form-data"
+        ],
+        "parameters": [
+          {
+            "name": "file",
+            "in": "formData",
+            "description": "file",
+            "required": true,
+            "type": "file"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+`)
+	doc3, err := v2v3JSON(spec)
+	require.NoError(t, err)
+
+	reqStr, err := json.MarshalIndent(doc3, "", "    ")
+	require.NotNil(t, reqStr)
+	require.NoError(t, err)
+
+	err = doc3.Validate(context.Background())
+	require.NoError(t, err)
+}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -339,6 +339,12 @@ func formDataBody(bodies map[string]*openapi3.SchemaRef, reqs map[string]bool, c
 			requireds = append(requireds, propName)
 		}
 	}
+	for s, ref := range bodies {
+		if ref.Value != nil && len(ref.Value.Required) > 0 {
+			ref.Value.Required = nil
+			bodies[s] = ref
+		}
+	}
 	schema := &openapi3.Schema{
 		Type:       "object",
 		Properties: ToV3Schemas(bodies),
@@ -701,7 +707,7 @@ func fromV3RequestBodies(name string, requestBodyRef *openapi3.RequestBodyRef, c
 		return
 	}
 
-	//Only select one formData or request body for an individual requestBody as OpenAPI 2 does not support multiples
+	// Only select one formData or request body for an individual requestBody as OpenAPI 2 does not support multiples
 	if requestBodyRef.Value != nil {
 		for contentType, mediaType := range requestBodyRef.Value.Content {
 			if consumes == nil {


### PR DESCRIPTION
issue #847 