### PR TITLE
fix(filters): allow oneOf inside deepObject

### DIFF
--- a/openapi3filter/issue294_test.go
+++ b/openapi3filter/issue294_test.go
@@ -1,0 +1,111 @@
+package openapi3filter_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+func TestIssue294(t *testing.T) {
+
+	deepObjectSpec := `
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Sample API
+paths:
+  /items:
+    get:
+      description: List documents in a collection
+      parameters:
+      - in: query
+        name: filter
+        required: false
+        style: deepObject
+        explode: true
+        schema:
+          type: object
+          properties:
+            id:
+              oneOf:
+                - oneOf:
+                  - type: string
+                  - type: object
+                    title: StringFieldEqualsComparison
+                    additionalProperties: false
+                    properties:
+                      eq:
+                        type: string
+                    required: [eq]
+                - oneOf:
+                  - type: object
+                    title: StringFieldOEQFilter
+                    additionalProperties: false
+                    properties:
+                      oeq:
+                        type: string
+                    required: [oeq]
+      responses:
+        '200':
+          description: Documents in the collection
+`
+	tests := []struct {
+		name   string
+		req    string
+		errStr string
+	}{
+		{
+			name: "success",
+			req:  "/items?filter[id][eq]=1",
+		},
+		{
+			name: "success",
+			req:  "/items?filter[id][oeq]=1,2",
+		},
+		{
+			name: "success",
+			req:  "/items?filter[id]=1",
+		},
+		{
+			name: "success",
+			req:  "/items?filter[id]=1",
+		},
+	}
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			loader := openapi3.NewLoader()
+			ctx := loader.Context
+
+			doc, err := loader.LoadFromData([]byte(deepObjectSpec))
+			require.NoError(t, err)
+
+			err = doc.Validate(ctx)
+			require.NoError(t, err)
+
+			router, err := gorillamux.NewRouter(doc)
+			require.NoError(t, err)
+			httpReq, err := http.NewRequest(http.MethodGet, testcase.req, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(httpReq)
+			require.NoError(t, err)
+
+			requestValidationInput := &openapi3filter.RequestValidationInput{
+				Request:    httpReq,
+				PathParams: pathParams,
+				Route:      route,
+			}
+			err = openapi3filter.ValidateRequest(ctx, requestValidationInput)
+			if testcase.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, testcase.errStr)
+			}
+		})
+	}
+}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -922,6 +922,14 @@ func parsePrimitive(raw string, schema *openapi3.SchemaRef) (interface{}, error)
 	case "string":
 		return raw, nil
 	default:
+		if len(schema.Value.OneOf) > 0 {
+			for i := range schema.Value.OneOf {
+				res, err := parsePrimitive(raw, schema.Value.OneOf[i])
+				if err == nil {
+					return res, nil
+				}
+			}
+		}
 		panic(fmt.Sprintf("schema has non primitive type %q", schema.Value.Type))
 	}
 }


### PR DESCRIPTION
Hello,
We encountered the same problems as in (#294 ),
This fixes it, and doesn't break other tests, but... yeah it might not be the ideal place to make the fix, I think it should be done earlier in the callstack, but I'm not sure where ?

I know this is kind of a gray area of the spec but this schema is considered valid by our parser in Typescript, but panics in go so I figured it should be valid ?

edit: I haven't added allOf or anyOf because I think it may be the wrong place to put that in the first place, but I could add it there easily I think ?