### PR TITLE
feat(openapi3filter): add ExludeRequestQuery

### DIFF
--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -201,6 +201,9 @@ type Options struct {
 	// Set ExcludeRequestBody so ValidateRequest skips request body validation
 	ExcludeRequestBody bool
 
+	// Set ExcludeRequestQueryParams so ValidateRequest skips request query params validation
+	ExcludeRequestQueryParams bool
+
 	// Set ExcludeResponseBody so ValidateResponse skips response body validation
 	ExcludeResponseBody bool
 

--- a/openapi3filter/options.go
+++ b/openapi3filter/options.go
@@ -7,6 +7,9 @@ type Options struct {
 	// Set ExcludeRequestBody so ValidateRequest skips request body validation
 	ExcludeRequestBody bool
 
+	// Set ExcludeRequestQueryParams so ValidateRequest skips request query params validation
+	ExcludeRequestQueryParams bool
+
 	// Set ExcludeResponseBody so ValidateResponse skips response body validation
 	ExcludeResponseBody bool
 

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -75,6 +75,9 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 
 	// For each parameter of the Operation
 	for _, parameter := range operationParameters {
+		if options.ExcludeRequestQueryParams && parameter.Value.In == openapi3.ParameterInQuery {
+			continue
+		}
 		if err = ValidateParameter(ctx, input, parameter.Value); err != nil && !options.MultiError {
 			return
 		}


### PR DESCRIPTION
Proposal of remediation of https://github.com/getkin/kin-openapi/pull/855

Until we support the `deepObject` validation; here's a proposal of adding the skip of query like it's done for `body`.

This would offload the validation to the application layer

If this is ok for you @fenollp i'll add a test suite to validate the behavior