### PR TITLE
openapi3: fix abort logic of validation for schemas with anyOf, allOf, oneOf

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -1355,6 +1355,8 @@ func (schema *Schema) WithProperty(name string, propertySchema *Schema) *Schema
 
 func (schema *Schema) WithPropertyRef(name string, ref *SchemaRef) *Schema
 
+func (schema *Schema) WithRequired(required []string) *Schema
+
 func (schema *Schema) WithUniqueItems(unique bool) *Schema
 
 func (schema *Schema) WithoutAdditionalProperties() *Schema

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -735,6 +735,11 @@ func (schema *Schema) WithProperties(properties map[string]*Schema) *Schema {
 	return schema
 }
 
+func (schema *Schema) WithRequired(required []string) *Schema {
+	schema.Required = required
+	return schema
+}
+
 func (schema *Schema) WithMinProperties(i int64) *Schema {
 	n := uint64(i)
 	schema.MinProps = n

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1362,7 +1362,7 @@ func (schema *Schema) visitXOFOperations(settings *schemaValidationSettings, val
 		visitedAllOf = true
 	}
 
-	run = !(visitedOneOf || visitedAnyOf || visitedAllOf)
+	run = !((visitedOneOf || visitedAnyOf || visitedAllOf) && value == nil)
 	return
 }
 

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -231,6 +231,39 @@ var schemaExamples = []schemaExample{
 	},
 
 	{
+		Title: "ANYOF WITH PARENT CONSTRAINTS",
+		Schema: NewAnyOfSchema(
+			NewObjectSchema().WithRequired([]string{"stringProp"}),
+			NewObjectSchema().WithRequired([]string{"boolProp"}),
+		).WithProperties(map[string]*Schema{
+			"stringProp": NewStringSchema().WithMaxLength(18),
+			"boolProp":   NewBoolSchema(),
+		}),
+		Serialization: map[string]interface{}{
+			"properties": map[string]interface{}{
+				"stringProp": map[string]interface{}{"type": "string", "maxLength": 18},
+				"boolProp":   map[string]interface{}{"type": "boolean"},
+			},
+			"anyOf": []interface{}{
+				map[string]interface{}{"type": "object", "required": []string{"stringProp"}},
+				map[string]interface{}{"type": "object", "required": []string{"boolProp"}},
+			},
+		},
+		AllValid: []interface{}{
+			map[string]interface{}{"stringProp": "valid string value"},
+			map[string]interface{}{"boolProp": true},
+			map[string]interface{}{"stringProp": "valid string value", "boolProp": true},
+		},
+		AllInvalid: []interface{}{
+			1,
+			map[string]interface{}{},
+			map[string]interface{}{"invalidProp": false},
+			map[string]interface{}{"stringProp": "invalid string value"},
+			map[string]interface{}{"stringProp": "invalid string value", "boolProp": true},
+		},
+	},
+
+	{
 		Title:  "BOOLEAN",
 		Schema: NewBoolSchema(),
 		Serialization: map[string]interface{}{


### PR DESCRIPTION
## Description

Only abort further validation if xOf validations were successful AND the value is `nil` (this means that the xOf was nullable for a fact). Otherwise, continue validating against the parent schema

## Related Issues

- Closes #890 