### PR TITLE
Make the JSON body decode public

### DIFF
--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -54,6 +54,10 @@ func DefaultErrorEncoder(_ context.Context, err error, w http.ResponseWriter)
 func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error)
     FileBodyDecoder is a body decoder that decodes a file body to a string.
 
+func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error)
+    JSONBodyDecoder decodes a JSON formatted body. It is public so that is easy
+    to register additional JSON based formats.
+
 func NoopAuthenticationFunc(context.Context, *AuthenticationInput) error
     NoopAuthenticationFunc is an AuthenticationFunc
 

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1004,10 +1004,10 @@ func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, 
 }
 
 func init() {
-	RegisterBodyDecoder("application/json", jsonBodyDecoder)
-	RegisterBodyDecoder("application/json-patch+json", jsonBodyDecoder)
+	RegisterBodyDecoder("application/json", JSONBodyDecoder)
+	RegisterBodyDecoder("application/json-patch+json", JSONBodyDecoder)
 	RegisterBodyDecoder("application/octet-stream", FileBodyDecoder)
-	RegisterBodyDecoder("application/problem+json", jsonBodyDecoder)
+	RegisterBodyDecoder("application/problem+json", JSONBodyDecoder)
 	RegisterBodyDecoder("application/x-www-form-urlencoded", urlencodedBodyDecoder)
 	RegisterBodyDecoder("application/x-yaml", yamlBodyDecoder)
 	RegisterBodyDecoder("application/yaml", yamlBodyDecoder)
@@ -1025,7 +1025,9 @@ func plainBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Schem
 	return string(data), nil
 }
 
-func jsonBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+// JSONBodyDecoder decodes a JSON formatted body. It is public so that is easy
+// to register additional JSON based formats.
+func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
 	var value interface{}
 	dec := json.NewDecoder(body)
 	dec.UseNumber()


### PR DESCRIPTION
This makes it easier for a consumer of the library to register a media type that is JSON formatted, such as the many `+json` formats that are available.

Existing tests cover the renamed func.

Fixes #891