### PR TITLE
openapi3: Implement YAML Marshaler interface for AdditionalProperties 

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -134,6 +134,9 @@ type AdditionalProperties struct {
 func (addProps AdditionalProperties) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of AdditionalProperties.
 
+func (addProps AdditionalProperties) MarshalYAML() (interface{}, error)
+    MarshalYAML returns the YAML encoding of AdditionalProperties.
+
 func (addProps *AdditionalProperties) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets AdditionalProperties to a copy of data.
 

--- a/openapi3/additionalProperties_test.go
+++ b/openapi3/additionalProperties_test.go
@@ -1,0 +1,40 @@
+package openapi3_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestMarshalAdditionalProperties(t *testing.T) {
+	ctx := context.Background()
+	data, err := os.ReadFile("testdata/test.openapi.additionalproperties.yml")
+	require.NoError(t, err)
+
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
+	spec, err := loader.LoadFromData(data)
+	require.NoError(t, err)
+
+	err = spec.Validate(ctx)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	err = enc.Encode(spec)
+	require.NoError(t, err)
+
+	// Load the doc from the serialized yaml.
+	spec2, err := loader.LoadFromData(buf.Bytes())
+	require.NoError(t, err)
+
+	err = spec2.Validate(ctx)
+	require.NoError(t, err)
+}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -213,6 +213,20 @@ type AdditionalProperties struct {
 	Schema *SchemaRef
 }
 
+// MarshalYAML returns the YAML encoding of AdditionalProperties.
+func (addProps AdditionalProperties) MarshalYAML() (interface{}, error) {
+	if x := addProps.Has; x != nil {
+		if *x {
+			return true, nil
+		}
+		return false, nil
+	}
+	if x := addProps.Schema; x != nil {
+		return x.Value, nil
+	}
+	return nil, nil
+}
+
 // MarshalJSON returns the JSON encoding of AdditionalProperties.
 func (addProps AdditionalProperties) MarshalJSON() ([]byte, error) {
 	if x := addProps.Has; x != nil {

--- a/openapi3/testdata/test.openapi.additionalproperties.yml
+++ b/openapi3/testdata/test.openapi.additionalproperties.yml
@@ -11,3 +11,7 @@ components:
         type: array
         items:
           type: string
+    TestSchema2:
+      type: object
+      additionalProperties:
+        type: string

--- a/openapi3/testdata/test.openapi.additionalproperties.yml
+++ b/openapi3/testdata/test.openapi.additionalproperties.yml
@@ -1,0 +1,13 @@
+openapi: 3.0.0
+info:
+  title: "OAI Specification in YAML"
+  version: 0.0.1
+paths: {}
+components:
+  schemas:
+    TestSchema:
+      type: object
+      additionalProperties:
+        type: array
+        items:
+          type: string


### PR DESCRIPTION
I discovered this bug when serializing an OpenAPI spec with component schemas that had `additionalProperties`. Once marshaled, the schema would end up with the raw `has` and `schema` properties of the `AdditionalProperties` struct type and thereafter it's impossible to have a successfully validating OpenAPI doc loaded from that modified schema. I've also added a test to describe the issue.

I've also run `./docs.sh` and committed the diff as a separate commit. Please let me know if you have any questions.