### PR TITLE
openapi3: implement YAML Marshaller interface for paths and responses

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -963,6 +963,9 @@ func (paths *Paths) Map() (m map[string]*PathItem)
 func (paths *Paths) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Paths.
 
+func (paths *Paths) MarshalYAML() (any, error)
+    Support YAML Marshaler interface for gopkg.in/yaml
+
 func (paths *Paths) Set(key string, value *PathItem)
     Set adds or replaces key 'key' of 'paths' with 'value'. Note: 'paths' MUST
     be non-nil
@@ -1173,6 +1176,9 @@ func (responses *Responses) Map() (m map[string]*ResponseRef)
 
 func (responses *Responses) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Responses.
+
+func (responses *Responses) MarshalYAML() (any, error)
+    Support YAML Marshaler interface for gopkg.in/yaml
 
 func (responses *Responses) Set(key string, value *ResponseRef)
     Set adds or replaces key 'key' of 'responses' with 'value'. Note:

--- a/openapi3/paths.go
+++ b/openapi3/paths.go
@@ -218,6 +218,21 @@ func (paths *Paths) validateUniqueOperationIDs() error {
 	return nil
 }
 
+// Support YAML Marshaler interface for gopkg.in/yaml
+func (paths *Paths) MarshalYAML() (any, error) {
+	res := make(map[string]any, len(paths.Extensions)+len(paths.m))
+
+	for k, v := range paths.Extensions {
+		res[k] = v
+	}
+
+	for k, v := range paths.m {
+		res[k] = v
+	}
+
+	return res, nil
+}
+
 func normalizeTemplatedPath(path string) (string, uint, map[string]struct{}) {
 	if strings.IndexByte(path, '{') < 0 {
 		return path, 0, nil

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -98,6 +98,21 @@ func (responses *Responses) Validate(ctx context.Context, opts ...ValidationOpti
 	return validateExtensions(ctx, responses.Extensions)
 }
 
+// Support YAML Marshaler interface for gopkg.in/yaml
+func (responses *Responses) MarshalYAML() (any, error) {
+	res := make(map[string]any, len(responses.Extensions)+len(responses.m))
+
+	for k, v := range responses.Extensions {
+		res[k] = v
+	}
+
+	for k, v := range responses.m {
+		res[k] = v
+	}
+
+	return res, nil
+}
+
 // Response is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object
 type Response struct {


### PR DESCRIPTION
Support marshaling using [pkg.go.dev/gopkg.in/yaml.v3](https://pkg.go.dev/gopkg.in/yaml.v3)

Related to https://github.com/getkin/kin-openapi/issues/907.