### PR TITLE
docs: add github.com/a-h/rest to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Be sure to [give back to this project](https://github.com/sponsors/fenollp) like
 </p>
 
 Here's some projects that depend on _kin-openapi_:
+  * [github.com/a-h/rest](https://github.com/a-h/rest) - "Generate OpenAPI 3.0 specifications from Go code without annotations or magic comments"
   * [github.com/Tufin/oasdiff](https://github.com/Tufin/oasdiff) - "A diff tool for OpenAPI Specification 3"
   * [github.com/danielgtaylor/apisprout](https://github.com/danielgtaylor/apisprout) - "Lightweight, blazing fast, cross-platform OpenAPI 3 mock server with validation"
   * [github.com/deepmap/oapi-codegen](https://github.com/deepmap/oapi-codegen) - "Generate Go client and server boilerplate from OpenAPI 3 specifications"


### PR DESCRIPTION
`github.com/a-h/rest` uses kin-openapi to generate OpenAPI 3.0 specs from Go code.

It can also host the Swagger-UI endpoint for the generated OpenAPI spec.

You provide the API routes, and define the types used for requests and responses, and `github.com/a-h/rest` will generate the OpenAPI 3.0 spec for you.

You can further customise the generated OpenAPI spec by providing additional information, such as descriptions and examples by adding an `ApplyCustomSchema` method to your types, or by customising the generated OpenAPI spec object directly.
