### PR TITLE
openapi{2,3}: surface both json/yaml unmarshal errors

### DIFF
--- a/openapi2/marsh.go
+++ b/openapi2/marsh.go
@@ -17,10 +17,18 @@ func unmarshalError(jsonUnmarshalErr error) error {
 }
 
 func unmarshal(data []byte, v interface{}) error {
+	var jsonErr, yamlErr error
+
 	// See https://github.com/getkin/kin-openapi/issues/680
-	if err := json.Unmarshal(data, v); err != nil {
-		// UnmarshalStrict(data, v) TODO: investigate how ymlv3 handles duplicate map keys
-		return yaml.Unmarshal(data, v)
+	if jsonErr = json.Unmarshal(data, v); jsonErr == nil {
+		return nil
 	}
-	return nil
+
+	// UnmarshalStrict(data, v) TODO: investigate how ymlv3 handles duplicate map keys
+	if yamlErr = yaml.Unmarshal(data, v); yamlErr == nil {
+		return nil
+	}
+
+	// If both unmarshaling attempts fail, return a new error that includes both errors
+	return fmt.Errorf("failed to unmarshal data: json error: %v, yaml error: %v", jsonErr, yamlErr)
 }

--- a/openapi3/marsh.go
+++ b/openapi3/marsh.go
@@ -17,10 +17,18 @@ func unmarshalError(jsonUnmarshalErr error) error {
 }
 
 func unmarshal(data []byte, v interface{}) error {
+	var jsonErr, yamlErr error
+
 	// See https://github.com/getkin/kin-openapi/issues/680
-	if err := json.Unmarshal(data, v); err != nil {
-		// UnmarshalStrict(data, v) TODO: investigate how ymlv3 handles duplicate map keys
-		return yaml.Unmarshal(data, v)
+	if jsonErr = json.Unmarshal(data, v); jsonErr == nil {
+		return nil
 	}
-	return nil
+
+	// UnmarshalStrict(data, v) TODO: investigate how ymlv3 handles duplicate map keys
+	if yamlErr = yaml.Unmarshal(data, v); yamlErr == nil {
+		return nil
+	}
+
+	// If both unmarshaling attempts fail, return a new error that includes both errors
+	return fmt.Errorf("failed to unmarshal data: json error: %v, yaml error: %v", jsonErr, yamlErr)
 }


### PR DESCRIPTION
If an error is encountered when attempting to unmarshal an openapi document formatted as JSON, callers will only see the error message from the YAML unmarshal. This adds an error message that combines both.