### PR TITLE
openapi3filter: add context to Validator Middleware's ErrFunc and LogFunc functions

### DIFF
--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -182,7 +182,7 @@ type ErrCode int
     occur during validation. These may be used to write an appropriate response
     in ErrFunc.
 
-type ErrFunc func(w http.ResponseWriter, status int, code ErrCode, err error)
+type ErrFunc func(ctx context.Context, w http.ResponseWriter, status int, code ErrCode, err error)
     ErrFunc handles errors that may occur during validation.
 
 type ErrorEncoder func(ctx context.Context, err error, w http.ResponseWriter)
@@ -198,7 +198,7 @@ type Headerer interface {
     Headerer, the provided headers will be applied to the response writer,
     after the Content-Type is set.
 
-type LogFunc func(message string, err error)
+type LogFunc func(ctx context.Context, message string, err error)
     LogFunc handles log messages that may occur during validation.
 
 type Options struct {

--- a/openapi3filter/middleware.go
+++ b/openapi3filter/middleware.go
@@ -13,23 +13,17 @@ import (
 // Validator provides HTTP request and response validation middleware.
 type Validator struct {
 	router  routers.Router
-	errFunc ErrContextFunc
-	logFunc LogContextFunc
+	errFunc ErrFunc
+	logFunc LogFunc
 	strict  bool
 	options Options
 }
 
 // ErrFunc handles errors that may occur during validation.
-type ErrFunc func(w http.ResponseWriter, status int, code ErrCode, err error)
-
-// ErrContextFunc handles errors that may occur during validation with the ability to use the request's context.
-type ErrContextFunc func(ctx context.Context, w http.ResponseWriter, status int, code ErrCode, err error)
+type ErrFunc func(ctx context.Context, w http.ResponseWriter, status int, code ErrCode, err error)
 
 // LogFunc handles log messages that may occur during validation.
-type LogFunc func(message string, err error)
-
-// LogContextFunc handles log messages that may occur during validation with the ability to use the request's context.
-type LogContextFunc func(ctx context.Context, message string, err error)
+type LogFunc func(ctx context.Context, message string, err error)
 
 // ErrCode is used for classification of different types of errors that may
 // occur during validation. These may be used to write an appropriate response
@@ -90,15 +84,6 @@ type ValidatorOption func(*Validator)
 // prescribing a particular form. This callback is only called on response
 // validator errors in Strict mode.
 func OnErr(f ErrFunc) ValidatorOption {
-	return OnErrContext(func(_ context.Context, w http.ResponseWriter, status int, code ErrCode, err error) {
-		f(w, status, code, err)
-	})
-}
-
-// OnErrContext provides a callback that handles writing an HTTP response
-// on a validation error, just as OnErr with the addition of the request's
-// context being added to the callback.
-func OnErrContext(f ErrContextFunc) ValidatorOption {
 	return func(v *Validator) {
 		v.errFunc = f
 	}
@@ -108,14 +93,6 @@ func OnErrContext(f ErrContextFunc) ValidatorOption {
 // the validator to integrate with a services' existing logging system without
 // prescribing a particular one.
 func OnLog(f LogFunc) ValidatorOption {
-	return OnLogContext(func(_ context.Context, message string, err error) {
-		f(message, err)
-	})
-}
-
-// OnLogContext provides a callback  that handles logging, just as OnLog with the
-// addition of the request's context being added to the callback.
-func OnLogContext(f LogContextFunc) ValidatorOption {
 	return func(v *Validator) {
 		v.logFunc = f
 	}

--- a/openapi3filter/middleware_test.go
+++ b/openapi3filter/middleware_test.go
@@ -2,6 +2,7 @@ package openapi3filter_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -489,7 +490,7 @@ paths:
 	// testing a service against its spec in development and CI. In production,
 	// availability may be more important than strictness.
 	v := openapi3filter.NewValidator(router, openapi3filter.Strict(true),
-		openapi3filter.OnErr(func(w http.ResponseWriter, status int, code openapi3filter.ErrCode, err error) {
+		openapi3filter.OnErr(func(_ context.Context, w http.ResponseWriter, status int, code openapi3filter.ErrCode, err error) {
 			// Customize validation error responses to use JSON
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(status)


### PR DESCRIPTION
This feature modifies the ErrFunc and LogFunc of the validator, just as described in #472 
In contrast to the change described in the issue, this is not a breaking changes, since it adds additional functions to set the LogFunc and the ErrFunc instead of overwriting the existing ones.