### PR TITLE
openapi3(tests): use testify's `YAMLEq` function

### DIFF
--- a/openapi3/openapi3_test.go
+++ b/openapi3/openapi3_test.go
@@ -82,18 +82,9 @@ func TestRefsYAML(t *testing.T) {
 	require.NoError(t, err)
 	dataB, err := yaml.Marshal(docB)
 	require.NoError(t, err)
-	eqYAML(t, data, specYAML)
-	eqYAML(t, data, dataA)
-	eqYAML(t, data, dataB)
-}
-
-func eqYAML(t *testing.T, expected, actual []byte) {
-	var e, a interface{}
-	err := yaml.Unmarshal(expected, &e)
-	require.NoError(t, err)
-	err = yaml.Unmarshal(actual, &a)
-	require.NoError(t, err)
-	require.Equal(t, e, a)
+	require.YAMLEq(t, string(data), string(specYAML))
+	require.YAMLEq(t, string(data), string(dataA))
+	require.YAMLEq(t, string(data), string(dataB))
 }
 
 var specYAML = []byte(`


### PR DESCRIPTION
Use https://pkg.go.dev/github.com/stretchr/testify@v1.9.0/require#YAMLEq which is already in use by other test files.
```
[alb@192 kin-openapi]$ git grep -i "yamlEq"
openapi2conv/issue187_test.go:  require.YAMLEq(t, string(spec3), expected)
openapi3/issue883_test.go:              require.YAMLEq(t, `
openapi3/issue883_test.go:              require.YAMLEq(t, spec, string(marshalledYaml))
openapi3/issue883_test.go:              require.YAMLEq(t, `
openapi3/issue883_test.go:              require.YAMLEq(t, `
openapi3/issue883_test.go:              require.YAMLEq(t, spec, string(marshalledYaml))
```