### PR TITLE
openapi3: internalize refs for path parameters

### DIFF
--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -351,7 +351,10 @@ func (doc *T) derefPaths(paths map[string]*PathItem, refNameResolver RefNameReso
 		ops.Ref = ""
 
 		for _, param := range ops.Parameters {
-			doc.addParameterToSpec(param, refNameResolver, pathIsExternal)
+			isExternal := doc.addParameterToSpec(param, refNameResolver, pathIsExternal)
+			if param.Value != nil {
+				doc.derefParameter(*param.Value, refNameResolver, pathIsExternal || isExternal)
+			}
 		}
 
 		for _, op := range ops.Operations() {

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -23,6 +23,7 @@ func TestInternalizeRefs(t *testing.T) {
 		{"testdata/spec.yaml"},
 		{"testdata/callbacks.yml"},
 		{"testdata/issue831/testref.internalizepath.openapi.yml"},
+		{"testdata/issue959/openapi.yml"},
 	}
 
 	for _, test := range tests {

--- a/openapi3/testdata/issue959/components.yml
+++ b/openapi3/testdata/issue959/components.yml
@@ -1,0 +1,4 @@
+components:
+  schemas:
+    External1:
+      type: string

--- a/openapi3/testdata/issue959/openapi.yml
+++ b/openapi3/testdata/issue959/openapi.yml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+  title: foo
+  version: 0.0.0
+paths:
+  /{external1}:
+    parameters:
+      - in: path
+        name: external1
+        required: true
+        schema:
+          $ref: './components.yml#/components/schemas/External1'
+    get:
+      responses:
+        '204':
+          description: No content

--- a/openapi3/testdata/issue959/openapi.yml.internalized.yml
+++ b/openapi3/testdata/issue959/openapi.yml.internalized.yml
@@ -1,0 +1,35 @@
+{
+  "components": {
+    "schemas": {
+      "External1": {
+        "type": "string"
+      }
+    }
+  },
+  "info": {
+    "title": "foo",
+    "version": "0.0.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/{external1}": {
+      "get": {
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "external1",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/External1"
+          }
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This is an attempt to close #959.

It adapts the code path for `ops.Parameters` to the same logic as the code path for `op.Parameters` (the path parameters), which already uses `derefParameter` to resolve external references in the operations parameters.

Tests as described in the bug ticket are included.