### PR TITLE
Replace interface{} with any

### DIFF
--- a/.github/docs/openapi2.txt
+++ b/.github/docs/openapi2.txt
@@ -20,7 +20,7 @@ func (header *Header) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets Header to a copy of data.
 
 type Operation struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Summary      string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
 	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
@@ -43,7 +43,7 @@ func (operation *Operation) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets Operation to a copy of data.
 
 type Parameter struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
@@ -61,7 +61,7 @@ type Parameter struct {
 	ExclusiveMax     bool                `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
 	Schema           *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Items            *openapi3.SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
-	Enum             []interface{}       `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Enum             []any               `json:"enum,omitempty" yaml:"enum,omitempty"`
 	MultipleOf       *float64            `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	Minimum          *float64            `json:"minimum,omitempty" yaml:"minimum,omitempty"`
 	Maximum          *float64            `json:"maximum,omitempty" yaml:"maximum,omitempty"`
@@ -69,7 +69,7 @@ type Parameter struct {
 	MaxItems         *uint64             `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
 	MinLength        uint64              `json:"minLength,omitempty" yaml:"minLength,omitempty"`
 	MinItems         uint64              `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	Default          interface{}         `json:"default,omitempty" yaml:"default,omitempty"`
+	Default          any                 `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
 func (parameter Parameter) MarshalJSON() ([]byte, error)
@@ -87,7 +87,7 @@ func (ps Parameters) Less(i, j int) bool
 func (ps Parameters) Swap(i, j int)
 
 type PathItem struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
@@ -114,14 +114,14 @@ func (pathItem *PathItem) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets PathItem to a copy of data.
 
 type Response struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Schema      *openapi3.SchemaRef    `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Headers     map[string]*Header     `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Examples    map[string]interface{} `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Schema      *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Headers     map[string]*Header  `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Examples    map[string]any      `json:"examples,omitempty" yaml:"examples,omitempty"`
 }
 
 func (response Response) MarshalJSON() ([]byte, error)
@@ -133,7 +133,7 @@ func (response *Response) UnmarshalJSON(data []byte) error
 type SecurityRequirements []map[string][]string
 
 type SecurityScheme struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
@@ -155,7 +155,7 @@ func (securityScheme *SecurityScheme) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets SecurityScheme to a copy of data.
 
 type T struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Swagger             string                         `json:"swagger" yaml:"swagger"` // required
 	Info                openapi3.Info                  `json:"info" yaml:"info"`       // required

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -178,14 +178,14 @@ type AdditionalProperties struct {
 func (addProps AdditionalProperties) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of AdditionalProperties.
 
-func (addProps AdditionalProperties) MarshalYAML() (interface{}, error)
+func (addProps AdditionalProperties) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of AdditionalProperties.
 
 func (addProps *AdditionalProperties) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets AdditionalProperties to a copy of data.
 
 type Callback struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	// Has unexported fields.
 }
@@ -201,7 +201,7 @@ func NewCallbackWithCapacity(cap int) *Callback
 func (callback *Callback) Delete(key string)
     Delete removes the entry associated with key 'key' from 'callback'.
 
-func (callback Callback) JSONLookup(token string) (interface{}, error)
+func (callback Callback) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -214,7 +214,7 @@ func (callback *Callback) Map() (m map[string]*PathItem)
 func (callback *Callback) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Callback.
 
-func (callback *Callback) MarshalYAML() (interface{}, error)
+func (callback *Callback) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Callback.
 
 func (callback *Callback) Set(key string, value *PathItem)
@@ -243,14 +243,14 @@ func (x *CallbackRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *CallbackRef) JSONLookup(token string) (interface{}, error)
+func (x *CallbackRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x CallbackRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of CallbackRef.
 
-func (x CallbackRef) MarshalYAML() (interface{}, error)
+func (x CallbackRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of CallbackRef.
 
 func (x *CallbackRef) RefPath() *url.URL
@@ -268,12 +268,12 @@ func (x *CallbackRef) Validate(ctx context.Context, opts ...ValidationOption) er
 
 type Callbacks map[string]*CallbackRef
 
-func (m Callbacks) JSONLookup(token string) (interface{}, error)
+func (m Callbacks) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 type Components struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Schemas         Schemas         `json:"schemas,omitempty" yaml:"schemas,omitempty"`
 	Parameters      ParametersMap   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
@@ -293,7 +293,7 @@ func NewComponents() Components
 func (components Components) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Components.
 
-func (components Components) MarshalYAML() (interface{}, error)
+func (components Components) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Components.
 
 func (components *Components) UnmarshalJSON(data []byte) error
@@ -304,7 +304,7 @@ func (components *Components) Validate(ctx context.Context, opts ...ValidationOp
     spec.
 
 type Contact struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
 	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -316,7 +316,7 @@ type Contact struct {
 func (contact Contact) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Contact.
 
-func (contact Contact) MarshalYAML() (interface{}, error)
+func (contact Contact) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Contact.
 
 func (contact *Contact) UnmarshalJSON(data []byte) error
@@ -348,7 +348,7 @@ func (content Content) Validate(ctx context.Context, opts ...ValidationOption) e
     Validate returns an error if Content does not comply with the OpenAPI spec.
 
 type Discriminator struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	PropertyName string            `json:"propertyName" yaml:"propertyName"` // required
 	Mapping      map[string]string `json:"mapping,omitempty" yaml:"mapping,omitempty"`
@@ -359,7 +359,7 @@ type Discriminator struct {
 func (discriminator Discriminator) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Discriminator.
 
-func (discriminator Discriminator) MarshalYAML() (interface{}, error)
+func (discriminator Discriminator) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Discriminator.
 
 func (discriminator *Discriminator) UnmarshalJSON(data []byte) error
@@ -370,7 +370,7 @@ func (discriminator *Discriminator) Validate(ctx context.Context, opts ...Valida
     spec.
 
 type Encoding struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	ContentType   string  `json:"contentType,omitempty" yaml:"contentType,omitempty"`
 	Headers       Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
@@ -386,7 +386,7 @@ func NewEncoding() *Encoding
 func (encoding Encoding) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Encoding.
 
-func (encoding Encoding) MarshalYAML() (interface{}, error)
+func (encoding Encoding) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Encoding.
 
 func (encoding *Encoding) SerializationMethod() *SerializationMethod
@@ -405,22 +405,22 @@ func (encoding *Encoding) WithHeader(name string, header *Header) *Encoding
 func (encoding *Encoding) WithHeaderRef(name string, ref *HeaderRef) *Encoding
 
 type Example struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
-	Summary       string      `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description   string      `json:"description,omitempty" yaml:"description,omitempty"`
-	Value         interface{} `json:"value,omitempty" yaml:"value,omitempty"`
-	ExternalValue string      `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
+	Summary       string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description   string `json:"description,omitempty" yaml:"description,omitempty"`
+	Value         any    `json:"value,omitempty" yaml:"value,omitempty"`
+	ExternalValue string `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
 }
     Example is specified by OpenAPI/Swagger 3.0 standard. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#example-object
 
-func NewExample(value interface{}) *Example
+func NewExample(value any) *Example
 
 func (example Example) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Example.
 
-func (example Example) MarshalYAML() (interface{}, error)
+func (example Example) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Example.
 
 func (example *Example) UnmarshalJSON(data []byte) error
@@ -442,14 +442,14 @@ func (x *ExampleRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *ExampleRef) JSONLookup(token string) (interface{}, error)
+func (x *ExampleRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x ExampleRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of ExampleRef.
 
-func (x ExampleRef) MarshalYAML() (interface{}, error)
+func (x ExampleRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of ExampleRef.
 
 func (x *ExampleRef) RefPath() *url.URL
@@ -467,12 +467,12 @@ func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) err
 
 type Examples map[string]*ExampleRef
 
-func (m Examples) JSONLookup(token string) (interface{}, error)
+func (m Examples) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 type ExternalDocs struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -483,7 +483,7 @@ type ExternalDocs struct {
 func (e ExternalDocs) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of ExternalDocs.
 
-func (e ExternalDocs) MarshalYAML() (interface{}, error)
+func (e ExternalDocs) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of ExternalDocs.
 
 func (e *ExternalDocs) UnmarshalJSON(data []byte) error
@@ -508,14 +508,14 @@ type Header struct {
     Header is specified by OpenAPI/Swagger 3.0 standard. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#header-object
 
-func (header Header) JSONLookup(token string) (interface{}, error)
+func (header Header) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (header Header) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Header.
 
-func (header Header) MarshalYAML() (interface{}, error)
+func (header Header) MarshalYAML() (any, error)
     MarshalYAML returns the JSON encoding of Header.
 
 func (header *Header) SerializationMethod() (*SerializationMethod, error)
@@ -540,14 +540,14 @@ func (x *HeaderRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *HeaderRef) JSONLookup(token string) (interface{}, error)
+func (x *HeaderRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x HeaderRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of HeaderRef.
 
-func (x HeaderRef) MarshalYAML() (interface{}, error)
+func (x HeaderRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of HeaderRef.
 
 func (x *HeaderRef) RefPath() *url.URL
@@ -565,12 +565,12 @@ func (x *HeaderRef) Validate(ctx context.Context, opts ...ValidationOption) erro
 
 type Headers map[string]*HeaderRef
 
-func (m Headers) JSONLookup(token string) (interface{}, error)
+func (m Headers) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 type Info struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Title          string   `json:"title" yaml:"title"` // Required
 	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
@@ -585,7 +585,7 @@ type Info struct {
 func (info Info) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Info.
 
-func (info Info) MarshalYAML() (interface{}, error)
+func (info Info) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Info.
 
 func (info *Info) UnmarshalJSON(data []byte) error
@@ -595,7 +595,7 @@ func (info *Info) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Info does not comply with the OpenAPI spec.
 
 type License struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name string `json:"name" yaml:"name"` // Required
 	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -606,7 +606,7 @@ type License struct {
 func (license License) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of License.
 
-func (license License) MarshalYAML() (interface{}, error)
+func (license License) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of License.
 
 func (license *License) UnmarshalJSON(data []byte) error
@@ -616,14 +616,14 @@ func (license *License) Validate(ctx context.Context, opts ...ValidationOption) 
     Validate returns an error if License does not comply with the OpenAPI spec.
 
 type Link struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
-	OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
-	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Server       *Server                `json:"server,omitempty" yaml:"server,omitempty"`
-	RequestBody  interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	OperationRef string         `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
+	OperationID  string         `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Description  string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Parameters   map[string]any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Server       *Server        `json:"server,omitempty" yaml:"server,omitempty"`
+	RequestBody  any            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 }
     Link is specified by OpenAPI/Swagger standard version 3. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object
@@ -631,7 +631,7 @@ type Link struct {
 func (link Link) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Link.
 
-func (link Link) MarshalYAML() (interface{}, error)
+func (link Link) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Link.
 
 func (link *Link) UnmarshalJSON(data []byte) error
@@ -653,14 +653,14 @@ func (x *LinkRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *LinkRef) JSONLookup(token string) (interface{}, error)
+func (x *LinkRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x LinkRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of LinkRef.
 
-func (x LinkRef) MarshalYAML() (interface{}, error)
+func (x LinkRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of LinkRef.
 
 func (x *LinkRef) RefPath() *url.URL
@@ -677,7 +677,7 @@ func (x *LinkRef) Validate(ctx context.Context, opts ...ValidationOption) error
 
 type Links map[string]*LinkRef
 
-func (m Links) JSONLookup(token string) (interface{}, error)
+func (m Links) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -721,10 +721,10 @@ func (loader *Loader) ResolveRefsIn(doc *T, location *url.URL) (err error)
     ResolveRefsIn expands references if for instance spec was just unmarshaled
 
 type MediaType struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Schema   *SchemaRef           `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example  interface{}          `json:"example,omitempty" yaml:"example,omitempty"`
+	Example  any                  `json:"example,omitempty" yaml:"example,omitempty"`
 	Examples Examples             `json:"examples,omitempty" yaml:"examples,omitempty"`
 	Encoding map[string]*Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
@@ -733,14 +733,14 @@ type MediaType struct {
 
 func NewMediaType() *MediaType
 
-func (mediaType MediaType) JSONLookup(token string) (interface{}, error)
+func (mediaType MediaType) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (mediaType MediaType) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of MediaType.
 
-func (mediaType MediaType) MarshalYAML() (interface{}, error)
+func (mediaType MediaType) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of MediaType.
 
 func (mediaType *MediaType) UnmarshalJSON(data []byte) error
@@ -752,7 +752,7 @@ func (mediaType *MediaType) Validate(ctx context.Context, opts ...ValidationOpti
 
 func (mediaType *MediaType) WithEncoding(name string, enc *Encoding) *MediaType
 
-func (mediaType *MediaType) WithExample(name string, value interface{}) *MediaType
+func (mediaType *MediaType) WithExample(name string, value any) *MediaType
 
 func (mediaType *MediaType) WithSchema(schema *Schema) *MediaType
 
@@ -762,7 +762,7 @@ type MultiError []error
     MultiError is a collection of errors, intended for when multiple issues need
     to be reported upstream
 
-func (me MultiError) As(target interface{}) bool
+func (me MultiError) As(target any) bool
     As allows you to use `errors.As()` to set target to the first error within
     the multi error that matches the target type
 
@@ -795,7 +795,7 @@ func WithStatus(status int, responseRef *ResponseRef) NewResponsesOption
     WithStatus adds a status code keyed ResponseRef
 
 type OAuthFlow struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
@@ -808,7 +808,7 @@ type OAuthFlow struct {
 func (flow OAuthFlow) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of OAuthFlow.
 
-func (flow OAuthFlow) MarshalYAML() (interface{}, error)
+func (flow OAuthFlow) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of OAuthFlow.
 
 func (flow *OAuthFlow) UnmarshalJSON(data []byte) error
@@ -819,7 +819,7 @@ func (flow *OAuthFlow) Validate(ctx context.Context, opts ...ValidationOption) e
     spec.
 
 type OAuthFlows struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Implicit          *OAuthFlow `json:"implicit,omitempty" yaml:"implicit,omitempty"`
 	Password          *OAuthFlow `json:"password,omitempty" yaml:"password,omitempty"`
@@ -832,7 +832,7 @@ type OAuthFlows struct {
 func (flows OAuthFlows) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of OAuthFlows.
 
-func (flows OAuthFlows) MarshalYAML() (interface{}, error)
+func (flows OAuthFlows) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of OAuthFlows.
 
 func (flows *OAuthFlows) UnmarshalJSON(data []byte) error
@@ -843,7 +843,7 @@ func (flows *OAuthFlows) Validate(ctx context.Context, opts ...ValidationOption)
     spec.
 
 type Operation struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	// Optional tags for documentation.
 	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
@@ -889,14 +889,14 @@ func (operation *Operation) AddParameter(p *Parameter)
 
 func (operation *Operation) AddResponse(status int, response *Response)
 
-func (operation Operation) JSONLookup(token string) (interface{}, error)
+func (operation Operation) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (operation Operation) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Operation.
 
-func (operation Operation) MarshalYAML() (interface{}, error)
+func (operation Operation) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Operation.
 
 func (operation *Operation) UnmarshalJSON(data []byte) error
@@ -907,21 +907,21 @@ func (operation *Operation) Validate(ctx context.Context, opts ...ValidationOpti
     spec.
 
 type Parameter struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
-	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
-	In              string      `json:"in,omitempty" yaml:"in,omitempty"`
-	Description     string      `json:"description,omitempty" yaml:"description,omitempty"`
-	Style           string      `json:"style,omitempty" yaml:"style,omitempty"`
-	Explode         *bool       `json:"explode,omitempty" yaml:"explode,omitempty"`
-	AllowEmptyValue bool        `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
-	AllowReserved   bool        `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
-	Deprecated      bool        `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Required        bool        `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema          *SchemaRef  `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example         interface{} `json:"example,omitempty" yaml:"example,omitempty"`
-	Examples        Examples    `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Content         Content     `json:"content,omitempty" yaml:"content,omitempty"`
+	Name            string     `json:"name,omitempty" yaml:"name,omitempty"`
+	In              string     `json:"in,omitempty" yaml:"in,omitempty"`
+	Description     string     `json:"description,omitempty" yaml:"description,omitempty"`
+	Style           string     `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode         *bool      `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowEmptyValue bool       `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool       `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+	Deprecated      bool       `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Required        bool       `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example         any        `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples        Examples   `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Content         Content    `json:"content,omitempty" yaml:"content,omitempty"`
 }
     Parameter is specified by OpenAPI/Swagger 3.0 standard. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object
@@ -934,14 +934,14 @@ func NewPathParameter(name string) *Parameter
 
 func NewQueryParameter(name string) *Parameter
 
-func (parameter Parameter) JSONLookup(token string) (interface{}, error)
+func (parameter Parameter) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (parameter Parameter) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Parameter.
 
-func (parameter Parameter) MarshalYAML() (interface{}, error)
+func (parameter Parameter) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Parameter.
 
 func (parameter *Parameter) SerializationMethod() (*SerializationMethod, error)
@@ -975,14 +975,14 @@ func (x *ParameterRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *ParameterRef) JSONLookup(token string) (interface{}, error)
+func (x *ParameterRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x ParameterRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of ParameterRef.
 
-func (x ParameterRef) MarshalYAML() (interface{}, error)
+func (x ParameterRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of ParameterRef.
 
 func (x *ParameterRef) RefPath() *url.URL
@@ -1005,7 +1005,7 @@ func NewParameters() Parameters
 
 func (parameters Parameters) GetByInAndName(in string, name string) *Parameter
 
-func (p Parameters) JSONLookup(token string) (interface{}, error)
+func (p Parameters) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1015,12 +1015,12 @@ func (parameters Parameters) Validate(ctx context.Context, opts ...ValidationOpt
 
 type ParametersMap map[string]*ParameterRef
 
-func (m ParametersMap) JSONLookup(token string) (interface{}, error)
+func (m ParametersMap) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 type PathItem struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref         string     `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 	Summary     string     `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -1045,7 +1045,7 @@ func (pathItem *PathItem) GetOperation(method string) *Operation
 func (pathItem PathItem) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of PathItem.
 
-func (pathItem PathItem) MarshalYAML() (interface{}, error)
+func (pathItem PathItem) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of PathItem.
 
 func (pathItem *PathItem) Operations() map[string]*Operation
@@ -1059,7 +1059,7 @@ func (pathItem *PathItem) Validate(ctx context.Context, opts ...ValidationOption
     Validate returns an error if PathItem does not comply with the OpenAPI spec.
 
 type Paths struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	// Has unexported fields.
 }
@@ -1097,7 +1097,7 @@ func (paths *Paths) InMatchingOrder() []string
     When matching URLs, concrete (non-templated) paths would be matched before
     their templated counterparts.
 
-func (paths Paths) JSONLookup(token string) (interface{}, error)
+func (paths Paths) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1110,7 +1110,7 @@ func (paths *Paths) Map() (m map[string]*PathItem)
 func (paths *Paths) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Paths.
 
-func (paths *Paths) MarshalYAML() (interface{}, error)
+func (paths *Paths) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Paths.
 
 func (paths *Paths) Set(key string, value *PathItem)
@@ -1157,12 +1157,12 @@ type RefNameResolver func(string) string
 
 type RequestBodies map[string]*RequestBodyRef
 
-func (m RequestBodies) JSONLookup(token string) (interface{}, error)
+func (m RequestBodies) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 type RequestBody struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
@@ -1178,7 +1178,7 @@ func (requestBody *RequestBody) GetMediaType(mediaType string) *MediaType
 func (requestBody RequestBody) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of RequestBody.
 
-func (requestBody RequestBody) MarshalYAML() (interface{}, error)
+func (requestBody RequestBody) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of RequestBody.
 
 func (requestBody *RequestBody) UnmarshalJSON(data []byte) error
@@ -1219,14 +1219,14 @@ func (x *RequestBodyRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *RequestBodyRef) JSONLookup(token string) (interface{}, error)
+func (x *RequestBodyRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x RequestBodyRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of RequestBodyRef.
 
-func (x RequestBodyRef) MarshalYAML() (interface{}, error)
+func (x RequestBodyRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of RequestBodyRef.
 
 func (x *RequestBodyRef) RefPath() *url.URL
@@ -1243,7 +1243,7 @@ func (x *RequestBodyRef) Validate(ctx context.Context, opts ...ValidationOption)
     spec.
 
 type Response struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	Headers     Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
@@ -1258,7 +1258,7 @@ func NewResponse() *Response
 func (response Response) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Response.
 
-func (response Response) MarshalYAML() (interface{}, error)
+func (response Response) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Response.
 
 func (response *Response) UnmarshalJSON(data []byte) error
@@ -1277,7 +1277,7 @@ func (response *Response) WithJSONSchemaRef(schema *SchemaRef) *Response
 
 type ResponseBodies map[string]*ResponseRef
 
-func (m ResponseBodies) JSONLookup(token string) (interface{}, error)
+func (m ResponseBodies) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1294,14 +1294,14 @@ func (x *ResponseRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *ResponseRef) JSONLookup(token string) (interface{}, error)
+func (x *ResponseRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x ResponseRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of ResponseRef.
 
-func (x ResponseRef) MarshalYAML() (interface{}, error)
+func (x ResponseRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of ResponseRef.
 
 func (x *ResponseRef) RefPath() *url.URL
@@ -1318,7 +1318,7 @@ func (x *ResponseRef) Validate(ctx context.Context, opts ...ValidationOption) er
     spec.
 
 type Responses struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	// Has unexported fields.
 }
@@ -1339,7 +1339,7 @@ func (responses *Responses) Default() *ResponseRef
 func (responses *Responses) Delete(key string)
     Delete removes the entry associated with key 'key' from 'responses'.
 
-func (responses Responses) JSONLookup(token string) (interface{}, error)
+func (responses Responses) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1352,7 +1352,7 @@ func (responses *Responses) Map() (m map[string]*ResponseRef)
 func (responses *Responses) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Responses.
 
-func (responses *Responses) MarshalYAML() (interface{}, error)
+func (responses *Responses) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Responses.
 
 func (responses *Responses) Set(key string, value *ResponseRef)
@@ -1376,7 +1376,7 @@ func (responses *Responses) Value(key string) *ResponseRef
     Value returns the responses for key or nil
 
 type Schema struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	OneOf        SchemaRefs    `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
 	AnyOf        SchemaRefs    `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
@@ -1386,9 +1386,9 @@ type Schema struct {
 	Title        string        `json:"title,omitempty" yaml:"title,omitempty"`
 	Format       string        `json:"format,omitempty" yaml:"format,omitempty"`
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
-	Enum         []interface{} `json:"enum,omitempty" yaml:"enum,omitempty"`
-	Default      interface{}   `json:"default,omitempty" yaml:"default,omitempty"`
-	Example      interface{}   `json:"example,omitempty" yaml:"example,omitempty"`
+	Enum         []any         `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Default      any           `json:"default,omitempty" yaml:"default,omitempty"`
+	Example      any           `json:"example,omitempty" yaml:"example,omitempty"`
 	ExternalDocs *ExternalDocs `json:"externalDocs,omitempty" yaml:"externalDocs,omitempty"`
 
 	// Array-related, here for struct compactness
@@ -1463,26 +1463,26 @@ func NewUUIDSchema() *Schema
 func (schema *Schema) IsEmpty() bool
     IsEmpty tells whether schema is equivalent to the empty schema `{}`.
 
-func (schema *Schema) IsMatching(value interface{}) bool
+func (schema *Schema) IsMatching(value any) bool
 
-func (schema *Schema) IsMatchingJSONArray(value []interface{}) bool
+func (schema *Schema) IsMatchingJSONArray(value []any) bool
 
 func (schema *Schema) IsMatchingJSONBoolean(value bool) bool
 
 func (schema *Schema) IsMatchingJSONNumber(value float64) bool
 
-func (schema *Schema) IsMatchingJSONObject(value map[string]interface{}) bool
+func (schema *Schema) IsMatchingJSONObject(value map[string]any) bool
 
 func (schema *Schema) IsMatchingJSONString(value string) bool
 
-func (schema Schema) JSONLookup(token string) (interface{}, error)
+func (schema Schema) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (schema Schema) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Schema.
 
-func (schema Schema) MarshalYAML() (interface{}, error)
+func (schema Schema) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Schema.
 
 func (schema *Schema) NewRef() *SchemaRef
@@ -1495,15 +1495,15 @@ func (schema *Schema) UnmarshalJSON(data []byte) error
 func (schema *Schema) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Schema does not comply with the OpenAPI spec.
 
-func (schema *Schema) VisitJSON(value interface{}, opts ...SchemaValidationOption) error
+func (schema *Schema) VisitJSON(value any, opts ...SchemaValidationOption) error
 
-func (schema *Schema) VisitJSONArray(value []interface{}) error
+func (schema *Schema) VisitJSONArray(value []any) error
 
 func (schema *Schema) VisitJSONBoolean(value bool) error
 
 func (schema *Schema) VisitJSONNumber(value float64) error
 
-func (schema *Schema) VisitJSONObject(value map[string]interface{}) error
+func (schema *Schema) VisitJSONObject(value map[string]any) error
 
 func (schema *Schema) VisitJSONString(value string) error
 
@@ -1511,9 +1511,9 @@ func (schema *Schema) WithAdditionalProperties(v *Schema) *Schema
 
 func (schema *Schema) WithAnyAdditionalProperties() *Schema
 
-func (schema *Schema) WithDefault(defaultValue interface{}) *Schema
+func (schema *Schema) WithDefault(defaultValue any) *Schema
 
-func (schema *Schema) WithEnum(values ...interface{}) *Schema
+func (schema *Schema) WithEnum(values ...any) *Schema
 
 func (schema *Schema) WithExclusiveMax(value bool) *Schema
 
@@ -1565,7 +1565,7 @@ func (schema *Schema) WithoutAdditionalProperties() *Schema
 
 type SchemaError struct {
 	// Value is the value that failed validation.
-	Value interface{}
+	Value any
 
 	// Schema is the schema that failed validation.
 	Schema *Schema
@@ -1603,14 +1603,14 @@ func (x *SchemaRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *SchemaRef) JSONLookup(token string) (interface{}, error)
+func (x *SchemaRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x SchemaRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of SchemaRef.
 
-func (x SchemaRef) MarshalYAML() (interface{}, error)
+func (x SchemaRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of SchemaRef.
 
 func (x *SchemaRef) RefPath() *url.URL
@@ -1628,7 +1628,7 @@ func (x *SchemaRef) Validate(ctx context.Context, opts ...ValidationOption) erro
 
 type SchemaRefs []*SchemaRef
 
-func (s SchemaRefs) JSONLookup(token string) (interface{}, error)
+func (s SchemaRefs) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1673,7 +1673,7 @@ func VisitAsResponse() SchemaValidationOption
 
 type Schemas map[string]*SchemaRef
 
-func (m Schemas) JSONLookup(token string) (interface{}, error)
+func (m Schemas) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1700,7 +1700,7 @@ func (srs SecurityRequirements) Validate(ctx context.Context, opts ...Validation
 func (srs *SecurityRequirements) With(securityRequirement SecurityRequirement) *SecurityRequirements
 
 type SecurityScheme struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Type             string      `json:"type,omitempty" yaml:"type,omitempty"`
 	Description      string      `json:"description,omitempty" yaml:"description,omitempty"`
@@ -1725,7 +1725,7 @@ func NewSecurityScheme() *SecurityScheme
 func (ss SecurityScheme) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of SecurityScheme.
 
-func (ss SecurityScheme) MarshalYAML() (interface{}, error)
+func (ss SecurityScheme) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of SecurityScheme.
 
 func (ss *SecurityScheme) UnmarshalJSON(data []byte) error
@@ -1761,14 +1761,14 @@ func (x *SecuritySchemeRef) CollectionName() string
     CollectionName returns the JSON string used for a collection of these
     components.
 
-func (x *SecuritySchemeRef) JSONLookup(token string) (interface{}, error)
+func (x *SecuritySchemeRef) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (x SecuritySchemeRef) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of SecuritySchemeRef.
 
-func (x SecuritySchemeRef) MarshalYAML() (interface{}, error)
+func (x SecuritySchemeRef) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of SecuritySchemeRef.
 
 func (x *SecuritySchemeRef) RefPath() *url.URL
@@ -1786,7 +1786,7 @@ func (x *SecuritySchemeRef) Validate(ctx context.Context, opts ...ValidationOpti
 
 type SecuritySchemes map[string]*SecuritySchemeRef
 
-func (m SecuritySchemes) JSONLookup(token string) (interface{}, error)
+func (m SecuritySchemes) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
@@ -1798,7 +1798,7 @@ type SerializationMethod struct {
     parameters and body.
 
 type Server struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	URL         string                     `json:"url" yaml:"url"` // Required
 	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
@@ -1814,7 +1814,7 @@ func (server *Server) BasePath() (string, error)
 func (server Server) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Server.
 
-func (server Server) MarshalYAML() (interface{}, error)
+func (server Server) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Server.
 
 func (server Server) MatchRawURL(input string) ([]string, string, bool)
@@ -1828,7 +1828,7 @@ func (server *Server) Validate(ctx context.Context, opts ...ValidationOption) (e
     Validate returns an error if Server does not comply with the OpenAPI spec.
 
 type ServerVariable struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Default     string   `json:"default,omitempty" yaml:"default,omitempty"`
@@ -1840,7 +1840,7 @@ type ServerVariable struct {
 func (serverVariable ServerVariable) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of ServerVariable.
 
-func (serverVariable ServerVariable) MarshalYAML() (interface{}, error)
+func (serverVariable ServerVariable) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of ServerVariable.
 
 func (serverVariable *ServerVariable) UnmarshalJSON(data []byte) error
@@ -1861,12 +1861,12 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string)
 func (servers Servers) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Servers does not comply with the OpenAPI spec.
 
-type SliceUniqueItemsChecker func(items []interface{}) bool
+type SliceUniqueItemsChecker func(items []any) bool
     SliceUniqueItemsChecker is an function used to check if an given slice have
     unique items.
 
 type T struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	OpenAPI      string               `json:"openapi" yaml:"openapi"` // Required
 	Components   *Components          `json:"components,omitempty" yaml:"components,omitempty"`
@@ -1901,14 +1901,14 @@ func (doc *T) InternalizeRefs(ctx context.Context, refNameResolver func(ref stri
 
         doc.InternalizeRefs(context.Background(), nil)
 
-func (doc *T) JSONLookup(token string) (interface{}, error)
+func (doc *T) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
 func (doc *T) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of T.
 
-func (doc *T) MarshalYAML() (interface{}, error)
+func (doc *T) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of T.
 
 func (doc *T) UnmarshalJSON(data []byte) error
@@ -1919,7 +1919,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error
     Validations Options can be provided to modify the validation behavior.
 
 type Tag struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
@@ -1931,7 +1931,7 @@ type Tag struct {
 func (t Tag) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Tag.
 
-func (t Tag) MarshalYAML() (interface{}, error)
+func (t Tag) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of Tag.
 
 func (t *Tag) UnmarshalJSON(data []byte) error
@@ -1956,7 +1956,7 @@ func (types *Types) Is(typ string) bool
 
 func (pTypes *Types) MarshalJSON() ([]byte, error)
 
-func (pTypes *Types) MarshalYAML() (interface{}, error)
+func (pTypes *Types) MarshalYAML() (any, error)
 
 func (types *Types) Permits(typ string) bool
 
@@ -2014,7 +2014,7 @@ type ValidationOptions struct {
     ValidationOptions provides configuration for validating OpenAPI documents.
 
 type XML struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
@@ -2028,7 +2028,7 @@ type XML struct {
 func (xml XML) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of XML.
 
-func (xml XML) MarshalYAML() (interface{}, error)
+func (xml XML) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of XML.
 
 func (xml *XML) UnmarshalJSON(data []byte) error

--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -141,8 +141,8 @@ func (input *AuthenticationInput) NewError(err error) error
 
 type BodyDecoder func(io.Reader, http.Header, *openapi3.SchemaRef, EncodingFn) (any, error)
     BodyDecoder is an interface to decode a body of a request or response.
-    An implementation must return a value that is a primitive, []interface{},
-    or map[string]interface{}.
+    An implementation must return a value that is a primitive, []any,
+    or map[string]any.
 
 func RegisteredBodyDecoder(contentType string) BodyDecoder
     RegisteredBodyDecoder returns the registered body decoder for the given

--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -51,10 +51,10 @@ func DefaultErrorEncoder(_ context.Context, err error, w http.ResponseWriter)
     encoded form of the error will be used. If the error implements StatusCoder,
     the provided StatusCode will be used instead of 500.
 
-func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error)
+func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error)
     FileBodyDecoder is a body decoder that decodes a file body to a string.
 
-func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error)
+func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error)
     JSONBodyDecoder decodes a JSON formatted body. It is public so that is easy
     to register additional JSON based formats.
 
@@ -139,7 +139,7 @@ type AuthenticationInput struct {
 
 func (input *AuthenticationInput) NewError(err error) error
 
-type BodyDecoder func(io.Reader, http.Header, *openapi3.SchemaRef, EncodingFn) (interface{}, error)
+type BodyDecoder func(io.Reader, http.Header, *openapi3.SchemaRef, EncodingFn) (any, error)
     BodyDecoder is an interface to decode a body of a request or response.
     An implementation must return a value that is a primitive, []interface{},
     or map[string]interface{}.
@@ -152,7 +152,7 @@ func RegisteredBodyDecoder(contentType string) BodyDecoder
     This call is not thread-safe: body decoders should not be created/destroyed
     by multiple goroutines.
 
-type BodyEncoder func(body interface{}) ([]byte, error)
+type BodyEncoder func(body any) ([]byte, error)
     BodyEncoder really is an (encoding/json).Marshaler
 
 func RegisteredBodyEncoder(contentType string) BodyEncoder
@@ -161,7 +161,7 @@ func RegisteredBodyEncoder(contentType string) BodyEncoder
 
     If no encoder was registered for the given content type, nil is returned.
 
-type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (interface{}, *openapi3.Schema, error)
+type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (any, *openapi3.Schema, error)
     A ContentParameterDecoder takes a parameter definition from the OpenAPI
     spec, and the value which we received for it. It is expected to return the
     value unmarshaled into an interface which can be traversed for validation,
@@ -243,7 +243,7 @@ func (o *Options) WithCustomSchemaErrorFunc(f CustomSchemaErrorFunc)
 
 type ParseError struct {
 	Kind   ParseErrorKind
-	Value  interface{}
+	Value  any
 	Reason string
 	Cause  error
 
@@ -254,7 +254,7 @@ type ParseError struct {
 
 func (e *ParseError) Error() string
 
-func (e *ParseError) Path() []interface{}
+func (e *ParseError) Path() []any
     Path returns a path to the root cause.
 
 func (e *ParseError) RootCause() error

--- a/.github/docs/openapi3gen.txt
+++ b/.github/docs/openapi3gen.txt
@@ -9,7 +9,7 @@ var RefSchemaRef = openapi3.NewSchemaRef("Ref",
 
 FUNCTIONS
 
-func NewSchemaRefForValue(value interface{}, schemas openapi3.Schemas, opts ...Option) (*openapi3.SchemaRef, error)
+func NewSchemaRefForValue(value any, schemas openapi3.Schemas, opts ...Option) (*openapi3.SchemaRef, error)
     NewSchemaRefForValue is a shortcut for
     NewGenerator(...).NewSchemaRefForValue(...)
 
@@ -48,7 +48,7 @@ func NewGenerator(opts ...Option) *Generator
 
 func (g *Generator) GenerateSchemaRef(t reflect.Type) (*openapi3.SchemaRef, error)
 
-func (g *Generator) NewSchemaRefForValue(value interface{}, schemas openapi3.Schemas) (*openapi3.SchemaRef, error)
+func (g *Generator) NewSchemaRefForValue(value any, schemas openapi3.Schemas) (*openapi3.SchemaRef, error)
     NewSchemaRefForValue uses reflection on the given value to produce a
     SchemaRef, and updates a supplied map with any dependent component schemas
     if they lead to cycles

--- a/.github/docs/routers_legacy_pathpattern.txt
+++ b/.github/docs/routers_legacy_pathpattern.txt
@@ -50,17 +50,17 @@ TYPES
 
 type Node struct {
 	VariableNames []string
-	Value         interface{}
+	Value         any
 	Suffixes      SuffixList
 }
 
-func (currentNode *Node) Add(path string, value interface{}, options *Options) error
+func (currentNode *Node) Add(path string, value any, options *Options) error
 
 func (currentNode *Node) CreateNode(path string, options *Options) (*Node, error)
 
 func (currentNode *Node) Match(path string) (*Node, []string)
 
-func (currentNode *Node) MustAdd(path string, value interface{}, options *Options)
+func (currentNode *Node) MustAdd(path string, value any, options *Options)
 
 func (currentNode *Node) String() string
 

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ This will change the schema validation errors to return only the `Reason` field,
 * The string format `email` has been removed by default. To use it please call `openapi3.DefineStringFormat("email", openapi3.FormatOfStringForEmail)`.
 * Field `openapi3.T.Components` is now a pointer.
 * Fields `openapi3.Schema.AdditionalProperties` and `openapi3.Schema.AdditionalPropertiesAllowed` are replaced by `openapi3.Schema.AdditionalProperties.Schema` and `openapi3.Schema.AdditionalProperties.Has` respectively.
-* Type `openapi3.ExtensionProps` is now just `map[string]interface{}` and extensions are accessible through the `Extensions` field.
+* Type `openapi3.ExtensionProps` is now just `map[string]any` and extensions are accessible through the `Extensions` field.
 
 ### v0.112.0
 * `(openapi3.ValidationOptions).ExamplesValidationDisabled` has been unexported.

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ func main() {
 	}
 }
 
-func xmlBodyDecoder(body io.Reader, h http.Header, schema *openapi3.SchemaRef, encFn openapi3filter.EncodingFn) (decoded interface{}, err error) {
-	// Decode body to a primitive, []interface{}, or map[string]interface{}.
+func xmlBodyDecoder(body io.Reader, h http.Header, schema *openapi3.SchemaRef, encFn openapi3filter.EncodingFn) (decoded any, err error) {
+	// Decode body to a primitive, []any, or map[string]any.
 }
 ```
 
@@ -177,7 +177,7 @@ func xmlBodyDecoder(body io.Reader, h http.Header, schema *openapi3.SchemaRef, e
 By default, the library checks unique items using the following predefined function:
 
 ```go
-func isSliceOfUniqueItems(xs []interface{}) bool {
+func isSliceOfUniqueItems(xs []any) bool {
 	s := len(xs)
 	m := make(map[string]struct{}, s)
 	for _, x := range xs {
@@ -203,7 +203,7 @@ func main() {
 	// ... other validate codes
 }
 
-func arrayUniqueItemsChecker(items []interface{}) bool {
+func arrayUniqueItemsChecker(items []any) bool {
 	// Check the uniqueness of the input slice
 }
 ```

--- a/maps.sh
+++ b/maps.sh
@@ -138,7 +138,7 @@ maplike_Pointable() {
 var _ jsonpointer.JSONPointable = (${type})(nil)
 
 // JSONLookup implements https://github.com/go-openapi/jsonpointer#JSONPointable
-func (${name} ${type#'*'}) JSONLookup(token string) (interface{}, error) {
+func (${name} ${type#'*'}) JSONLookup(token string) (any, error) {
 	if v := ${name}.Value(token); v == nil {
 		vv, _, err := jsonpointer.GetForToken(${name}.Extensions, token)
 		return vv, err
@@ -157,8 +157,8 @@ EOF
 maplike_UnMarsh() {
 	cat <<EOF >>"$maplike"
 // MarshalYAML returns the YAML encoding of ${type#'*'}.
-func (${name} ${type}) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, ${name}.Len()+len(${name}.Extensions))
+func (${name} ${type}) MarshalYAML() (any, error) {
+	m := make(map[string]any, ${name}.Len()+len(${name}.Extensions))
 	for k, v := range ${name}.Extensions {
 		m[k] = v
 	}
@@ -179,7 +179,7 @@ func (${name} ${type}) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON sets ${type#'*'} to a copy of data.
 func (${name} ${type}) UnmarshalJSON(data []byte) (err error) {
-	var m map[string]interface{}
+	var m map[string]any
 	if err = json.Unmarshal(data, &m); err != nil {
 		return
 	}
@@ -191,7 +191,7 @@ func (${name} ${type}) UnmarshalJSON(data []byte) (err error) {
 	sort.Strings(ks)
 
 	x := ${type#'*'}{
-		Extensions: make(map[string]interface{}),
+		Extensions: make(map[string]any),
 		m:          make(map[string]${value_type}, len(m)),
 	}
 

--- a/openapi2/marsh.go
+++ b/openapi2/marsh.go
@@ -16,7 +16,7 @@ func unmarshalError(jsonUnmarshalErr error) error {
 	return jsonUnmarshalErr
 }
 
-func unmarshal(data []byte, v interface{}) error {
+func unmarshal(data []byte, v any) error {
 	var jsonErr, yamlErr error
 
 	// See https://github.com/getkin/kin-openapi/issues/680

--- a/openapi2/openapi2.go
+++ b/openapi2/openapi2.go
@@ -8,7 +8,7 @@ import (
 
 // T is the root of an OpenAPI v2 document
 type T struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Swagger             string                         `json:"swagger" yaml:"swagger"` // required
 	Info                openapi3.Info                  `json:"info" yaml:"info"`       // required
@@ -29,7 +29,7 @@ type T struct {
 
 // MarshalJSON returns the JSON encoding of T.
 func (doc T) MarshalJSON() ([]byte, error) {
-	m := make(map[string]interface{}, 15+len(doc.Extensions))
+	m := make(map[string]any, 15+len(doc.Extensions))
 	for k, v := range doc.Extensions {
 		m[k] = v
 	}

--- a/openapi2/operation.go
+++ b/openapi2/operation.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Operation struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Summary      string                 `json:"summary,omitempty" yaml:"summary,omitempty"`
 	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
@@ -25,7 +25,7 @@ type Operation struct {
 
 // MarshalJSON returns the JSON encoding of Operation.
 func (operation Operation) MarshalJSON() ([]byte, error) {
-	m := make(map[string]interface{}, 12+len(operation.Extensions))
+	m := make(map[string]any, 12+len(operation.Extensions))
 	for k, v := range operation.Extensions {
 		m[k] = v
 	}

--- a/openapi2/parameter.go
+++ b/openapi2/parameter.go
@@ -24,7 +24,7 @@ func (ps Parameters) Less(i, j int) bool {
 }
 
 type Parameter struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
@@ -42,7 +42,7 @@ type Parameter struct {
 	ExclusiveMax     bool                `json:"exclusiveMaximum,omitempty" yaml:"exclusiveMaximum,omitempty"`
 	Schema           *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Items            *openapi3.SchemaRef `json:"items,omitempty" yaml:"items,omitempty"`
-	Enum             []interface{}       `json:"enum,omitempty" yaml:"enum,omitempty"`
+	Enum             []any               `json:"enum,omitempty" yaml:"enum,omitempty"`
 	MultipleOf       *float64            `json:"multipleOf,omitempty" yaml:"multipleOf,omitempty"`
 	Minimum          *float64            `json:"minimum,omitempty" yaml:"minimum,omitempty"`
 	Maximum          *float64            `json:"maximum,omitempty" yaml:"maximum,omitempty"`
@@ -50,7 +50,7 @@ type Parameter struct {
 	MaxItems         *uint64             `json:"maxItems,omitempty" yaml:"maxItems,omitempty"`
 	MinLength        uint64              `json:"minLength,omitempty" yaml:"minLength,omitempty"`
 	MinItems         uint64              `json:"minItems,omitempty" yaml:"minItems,omitempty"`
-	Default          interface{}         `json:"default,omitempty" yaml:"default,omitempty"`
+	Default          any                 `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Parameter.
@@ -59,7 +59,7 @@ func (parameter Parameter) MarshalJSON() ([]byte, error) {
 		return json.Marshal(openapi3.Ref{Ref: ref})
 	}
 
-	m := make(map[string]interface{}, 24+len(parameter.Extensions))
+	m := make(map[string]any, 24+len(parameter.Extensions))
 	for k, v := range parameter.Extensions {
 		m[k] = v
 	}

--- a/openapi2/path_item.go
+++ b/openapi2/path_item.go
@@ -9,7 +9,7 @@ import (
 )
 
 type PathItem struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
@@ -29,7 +29,7 @@ func (pathItem PathItem) MarshalJSON() ([]byte, error) {
 		return json.Marshal(openapi3.Ref{Ref: ref})
 	}
 
-	m := make(map[string]interface{}, 8+len(pathItem.Extensions))
+	m := make(map[string]any, 8+len(pathItem.Extensions))
 	for k, v := range pathItem.Extensions {
 		m[k] = v
 	}

--- a/openapi2/response.go
+++ b/openapi2/response.go
@@ -7,14 +7,14 @@ import (
 )
 
 type Response struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
-	Description string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Schema      *openapi3.SchemaRef    `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Headers     map[string]*Header     `json:"headers,omitempty" yaml:"headers,omitempty"`
-	Examples    map[string]interface{} `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Description string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Schema      *openapi3.SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Headers     map[string]*Header  `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Examples    map[string]any      `json:"examples,omitempty" yaml:"examples,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Response.
@@ -23,7 +23,7 @@ func (response Response) MarshalJSON() ([]byte, error) {
 		return json.Marshal(openapi3.Ref{Ref: ref})
 	}
 
-	m := make(map[string]interface{}, 4+len(response.Extensions))
+	m := make(map[string]any, 4+len(response.Extensions))
 	for k, v := range response.Extensions {
 		m[k] = v
 	}

--- a/openapi2/security_scheme.go
+++ b/openapi2/security_scheme.go
@@ -9,7 +9,7 @@ import (
 type SecurityRequirements []map[string][]string
 
 type SecurityScheme struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref string `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 
@@ -30,7 +30,7 @@ func (securityScheme SecurityScheme) MarshalJSON() ([]byte, error) {
 		return json.Marshal(openapi3.Ref{Ref: ref})
 	}
 
-	m := make(map[string]interface{}, 10+len(securityScheme.Extensions))
+	m := make(map[string]any, 10+len(securityScheme.Extensions))
 	for k, v := range securityScheme.Extensions {
 		m[k] = v
 	}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -236,7 +236,7 @@ func ToV3Parameter(components *openapi3.Components, parameter *openapi2.Paramete
 		}
 		if parameter.Name != "" {
 			if result.Extensions == nil {
-				result.Extensions = make(map[string]interface{}, 1)
+				result.Extensions = make(map[string]any, 1)
 			}
 			result.Extensions["x-originalParamName"] = parameter.Name
 		}
@@ -252,7 +252,7 @@ func ToV3Parameter(components *openapi3.Components, parameter *openapi2.Paramete
 			format, typ = "binary", &openapi3.Types{"string"}
 		}
 		if parameter.Extensions == nil {
-			parameter.Extensions = make(map[string]interface{}, 1)
+			parameter.Extensions = make(map[string]any, 1)
 		}
 		parameter.Extensions["x-formData-name"] = parameter.Name
 		var required []string
@@ -828,7 +828,7 @@ func FromV3SchemaRef(schema *openapi3.SchemaRef, components *openapi3.Components
 	if schema.Value.PermitsNull() {
 		schema.Value.Nullable = false
 		if schema.Value.Extensions == nil {
-			schema.Value.Extensions = make(map[string]interface{})
+			schema.Value.Extensions = make(map[string]any)
 		}
 		schema.Value.Extensions["x-nullable"] = true
 	}
@@ -1184,7 +1184,7 @@ var attemptedBodyParameterNames = []string{
 }
 
 // stripNonExtensions removes invalid extensions: those not prefixed by "x-" and returns them
-func stripNonExtensions(extensions map[string]interface{}) map[string]interface{} {
+func stripNonExtensions(extensions map[string]any) map[string]any {
 	for extName := range extensions {
 		if !strings.HasPrefix(extName, "x-") {
 			delete(extensions, extName)
@@ -1193,7 +1193,7 @@ func stripNonExtensions(extensions map[string]interface{}) map[string]interface{
 	return extensions
 }
 
-func addPathExtensions(doc2 *openapi2.T, path string, extensions map[string]interface{}) {
+func addPathExtensions(doc2 *openapi2.T, path string, extensions map[string]any) {
 	if doc2.Paths == nil {
 		doc2.Paths = make(map[string]*openapi2.PathItem)
 	}

--- a/openapi3/callback.go
+++ b/openapi3/callback.go
@@ -8,7 +8,7 @@ import (
 // Callback is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#callback-object
 type Callback struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	m map[string]*PathItem
 }

--- a/openapi3/components.go
+++ b/openapi3/components.go
@@ -24,7 +24,7 @@ type (
 // Components is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#components-object
 type Components struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Schemas         Schemas         `json:"schemas,omitempty" yaml:"schemas,omitempty"`
 	Parameters      ParametersMap   `json:"parameters,omitempty" yaml:"parameters,omitempty"`
@@ -51,8 +51,8 @@ func (components Components) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Components.
-func (components Components) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 9+len(components.Extensions))
+func (components Components) MarshalYAML() (any, error) {
+	m := make(map[string]any, 9+len(components.Extensions))
 	for k, v := range components.Extensions {
 		m[k] = v
 	}
@@ -255,7 +255,7 @@ func (components *Components) Validate(ctx context.Context, opts ...ValidationOp
 var _ jsonpointer.JSONPointable = (*Schemas)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m Schemas) JSONLookup(token string) (interface{}, error) {
+func (m Schemas) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no schema %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -268,7 +268,7 @@ func (m Schemas) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*ParametersMap)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m ParametersMap) JSONLookup(token string) (interface{}, error) {
+func (m ParametersMap) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no parameter %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -281,7 +281,7 @@ func (m ParametersMap) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*Headers)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m Headers) JSONLookup(token string) (interface{}, error) {
+func (m Headers) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no header %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -294,7 +294,7 @@ func (m Headers) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m RequestBodies) JSONLookup(token string) (interface{}, error) {
+func (m RequestBodies) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no request body %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -307,7 +307,7 @@ func (m RequestBodies) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*ResponseRef)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m ResponseBodies) JSONLookup(token string) (interface{}, error) {
+func (m ResponseBodies) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no response body %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -320,7 +320,7 @@ func (m ResponseBodies) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*SecuritySchemes)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m SecuritySchemes) JSONLookup(token string) (interface{}, error) {
+func (m SecuritySchemes) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no security scheme body %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -333,7 +333,7 @@ func (m SecuritySchemes) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*Examples)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m Examples) JSONLookup(token string) (interface{}, error) {
+func (m Examples) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no example body %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -346,7 +346,7 @@ func (m Examples) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*Links)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m Links) JSONLookup(token string) (interface{}, error) {
+func (m Links) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no link body %q", token)
 	} else if ref := v.Ref; ref != "" {
@@ -359,7 +359,7 @@ func (m Links) JSONLookup(token string) (interface{}, error) {
 var _ jsonpointer.JSONPointable = (*Callbacks)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (m Callbacks) JSONLookup(token string) (interface{}, error) {
+func (m Callbacks) JSONLookup(token string) (any, error) {
 	if v, ok := m[token]; !ok || v == nil {
 		return nil, fmt.Errorf("no callback body %q", token)
 	} else if ref := v.Ref; ref != "" {

--- a/openapi3/contact.go
+++ b/openapi3/contact.go
@@ -8,7 +8,7 @@ import (
 // Contact is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#contact-object
 type Contact struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name  string `json:"name,omitempty" yaml:"name,omitempty"`
 	URL   string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -25,8 +25,8 @@ func (contact Contact) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Contact.
-func (contact Contact) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 3+len(contact.Extensions))
+func (contact Contact) MarshalYAML() (any, error) {
+	m := make(map[string]any, 3+len(contact.Extensions))
 	for k, v := range contact.Extensions {
 		m[k] = v
 	}

--- a/openapi3/discriminator.go
+++ b/openapi3/discriminator.go
@@ -8,7 +8,7 @@ import (
 // Discriminator is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#discriminator-object
 type Discriminator struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	PropertyName string            `json:"propertyName" yaml:"propertyName"` // required
 	Mapping      map[string]string `json:"mapping,omitempty" yaml:"mapping,omitempty"`
@@ -24,8 +24,8 @@ func (discriminator Discriminator) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Discriminator.
-func (discriminator Discriminator) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 2+len(discriminator.Extensions))
+func (discriminator Discriminator) MarshalYAML() (any, error) {
+	m := make(map[string]any, 2+len(discriminator.Extensions))
 	for k, v := range discriminator.Extensions {
 		m[k] = v
 	}

--- a/openapi3/encoding.go
+++ b/openapi3/encoding.go
@@ -10,7 +10,7 @@ import (
 // Encoding is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#encoding-object
 type Encoding struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	ContentType   string  `json:"contentType,omitempty" yaml:"contentType,omitempty"`
 	Headers       Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
@@ -49,8 +49,8 @@ func (encoding Encoding) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Encoding.
-func (encoding Encoding) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 5+len(encoding.Extensions))
+func (encoding Encoding) MarshalYAML() (any, error) {
+	m := make(map[string]any, 5+len(encoding.Extensions))
 	for k, v := range encoding.Extensions {
 		m[k] = v
 	}

--- a/openapi3/errors.go
+++ b/openapi3/errors.go
@@ -39,7 +39,7 @@ func (me MultiError) Is(target error) bool {
 }
 
 // As allows you to use `errors.As()` to set target to the first error within the multi error that matches the target type
-func (me MultiError) As(target interface{}) bool {
+func (me MultiError) As(target any) bool {
 	for _, e := range me {
 		if errors.As(e, target) {
 			return true

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -9,15 +9,15 @@ import (
 // Example is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#example-object
 type Example struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
-	Summary       string      `json:"summary,omitempty" yaml:"summary,omitempty"`
-	Description   string      `json:"description,omitempty" yaml:"description,omitempty"`
-	Value         interface{} `json:"value,omitempty" yaml:"value,omitempty"`
-	ExternalValue string      `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
+	Summary       string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description   string `json:"description,omitempty" yaml:"description,omitempty"`
+	Value         any    `json:"value,omitempty" yaml:"value,omitempty"`
+	ExternalValue string `json:"externalValue,omitempty" yaml:"externalValue,omitempty"`
 }
 
-func NewExample(value interface{}) *Example {
+func NewExample(value any) *Example {
 	return &Example{Value: value}
 }
 
@@ -31,8 +31,8 @@ func (example Example) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Example.
-func (example Example) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(example.Extensions))
+func (example Example) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(example.Extensions))
 	for k, v := range example.Extensions {
 		m[k] = v
 	}

--- a/openapi3/example_validation.go
+++ b/openapi3/example_validation.go
@@ -2,7 +2,7 @@ package openapi3
 
 import "context"
 
-func validateExampleValue(ctx context.Context, input interface{}, schema *Schema) error {
+func validateExampleValue(ctx context.Context, input any, schema *Schema) error {
 	opts := make([]SchemaValidationOption, 0, 2)
 
 	if vo := getValidationOptions(ctx); vo.examplesValidationAsReq {

--- a/openapi3/extension.go
+++ b/openapi3/extension.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func validateExtensions(ctx context.Context, extensions map[string]interface{}) error { // FIXME: newtype + Validate(...)
+func validateExtensions(ctx context.Context, extensions map[string]any) error { // FIXME: newtype + Validate(...)
 	allowed := getValidationOptions(ctx).extraSiblingFieldsAllowed
 
 	var unknowns []string

--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -11,7 +11,7 @@ import (
 // ExternalDocs is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#external-documentation-object
 type ExternalDocs struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 	URL         string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -27,8 +27,8 @@ func (e ExternalDocs) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of ExternalDocs.
-func (e ExternalDocs) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 2+len(e.Extensions))
+func (e ExternalDocs) MarshalYAML() (any, error) {
+	m := make(map[string]any, 2+len(e.Extensions))
 	for k, v := range e.Extensions {
 		m[k] = v
 	}

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -17,7 +17,7 @@ type Header struct {
 var _ jsonpointer.JSONPointable = (*Header)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (header Header) JSONLookup(token string) (interface{}, error) {
+func (header Header) JSONLookup(token string) (any, error) {
 	return header.Parameter.JSONLookup(token)
 }
 
@@ -32,7 +32,7 @@ func (header *Header) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalYAML returns the JSON encoding of Header.
-func (header Header) MarshalYAML() (interface{}, error) {
+func (header Header) MarshalYAML() (any, error) {
 	return header.Parameter, nil
 }
 

--- a/openapi3/info.go
+++ b/openapi3/info.go
@@ -9,7 +9,7 @@ import (
 // Info is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#info-object
 type Info struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Title          string   `json:"title" yaml:"title"` // Required
 	Description    string   `json:"description,omitempty" yaml:"description,omitempty"`
@@ -29,8 +29,8 @@ func (info Info) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Info.
-func (info Info) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 6+len(info.Extensions))
+func (info Info) MarshalYAML() (any, error) {
+	m := make(map[string]any, 6+len(info.Extensions))
 	for k, v := range info.Extensions {
 		m[k] = v
 	}

--- a/openapi3/issue657_test.go
+++ b/openapi3/issue657_test.go
@@ -52,7 +52,7 @@ components:
 		{
 			name:  "no valid value",
 			value: "ABCDE",
-			checkErr: func(t require.TestingT, err error, i ...interface{}) {
+			checkErr: func(t require.TestingT, err error, i ...any) {
 				require.ErrorContains(t, err, "doesn't match schema due to: minimum string length is 10")
 
 				wErr := &openapi3.MultiError{}

--- a/openapi3/issue689_test.go
+++ b/openapi3/issue689_test.go
@@ -14,7 +14,7 @@ func TestIssue689(t *testing.T) {
 	tests := [...]struct {
 		name     string
 		schema   *openapi3.Schema
-		value    map[string]interface{}
+		value    map[string]any
 		opts     []openapi3.SchemaValidationOption
 		checkErr require.ErrorAssertionFunc
 	}{
@@ -23,7 +23,7 @@ func TestIssue689(t *testing.T) {
 			name: "read-only property succeeds when read-only validation is disabled",
 			schema: openapi3.NewSchema().WithProperties(map[string]*openapi3.Schema{
 				"foo": {Type: &openapi3.Types{"boolean"}, ReadOnly: true}}),
-			value: map[string]interface{}{"foo": true},
+			value: map[string]any{"foo": true},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest(),
 				openapi3.DisableReadOnlyValidation()},
@@ -35,7 +35,7 @@ func TestIssue689(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, ReadOnly: false}}),
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest()},
-			value:    map[string]interface{}{"foo": true},
+			value:    map[string]any{"foo": true},
 			checkErr: require.NoError,
 		},
 		{
@@ -44,7 +44,7 @@ func TestIssue689(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, ReadOnly: true}}),
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest()},
-			value:    map[string]interface{}{"foo": true},
+			value:    map[string]any{"foo": true},
 			checkErr: require.Error,
 		},
 		{
@@ -53,7 +53,7 @@ func TestIssue689(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, ReadOnly: false}}),
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest()},
-			value:    map[string]interface{}{"foo": true},
+			value:    map[string]any{"foo": true},
 			checkErr: require.NoError,
 		},
 		// write-only
@@ -61,7 +61,7 @@ func TestIssue689(t *testing.T) {
 			name: "write-only property succeeds when write-only validation is disabled",
 			schema: openapi3.NewSchema().WithProperties(map[string]*openapi3.Schema{
 				"foo": {Type: &openapi3.Types{"boolean"}, WriteOnly: true}}),
-			value: map[string]interface{}{"foo": true},
+			value: map[string]any{"foo": true},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsResponse(),
 				openapi3.DisableWriteOnlyValidation()},
@@ -73,7 +73,7 @@ func TestIssue689(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, WriteOnly: false}}),
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsResponse()},
-			value:    map[string]interface{}{"foo": true},
+			value:    map[string]any{"foo": true},
 			checkErr: require.NoError,
 		},
 		{
@@ -82,7 +82,7 @@ func TestIssue689(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, WriteOnly: true}}),
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsResponse()},
-			value:    map[string]interface{}{"foo": true},
+			value:    map[string]any{"foo": true},
 			checkErr: require.Error,
 		},
 		{
@@ -91,7 +91,7 @@ func TestIssue689(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, WriteOnly: false}}),
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsResponse()},
-			value:    map[string]interface{}{"foo": true},
+			value:    map[string]any{"foo": true},
 			checkErr: require.NoError,
 		},
 	}

--- a/openapi3/issue735_test.go
+++ b/openapi3/issue735_test.go
@@ -10,8 +10,8 @@ import (
 type testCase struct {
 	name             string
 	schema           *Schema
-	value            interface{}
-	extraNotContains []interface{}
+	value            any
+	extraNotContains []any
 	options          []SchemaValidationOption
 }
 
@@ -100,60 +100,60 @@ func TestIssue735(t *testing.T) {
 		{
 			name:             "items",
 			schema:           NewSchema().WithItems(NewStringSchema()),
-			value:            []interface{}{42},
-			extraNotContains: []interface{}{42},
+			value:            []any{42},
+			extraNotContains: []any{42},
 		},
 		{
 			name:             "min items",
 			schema:           NewSchema().WithMinItems(100),
-			value:            []interface{}{42},
-			extraNotContains: []interface{}{42},
+			value:            []any{42},
+			extraNotContains: []any{42},
 		},
 		{
 			name:             "max items",
 			schema:           NewSchema().WithMaxItems(0),
-			value:            []interface{}{42},
-			extraNotContains: []interface{}{42},
+			value:            []any{42},
+			extraNotContains: []any{42},
 		},
 		{
 			name:             "unique items",
 			schema:           NewSchema().WithUniqueItems(true),
-			value:            []interface{}{42, 42},
-			extraNotContains: []interface{}{42},
+			value:            []any{42, 42},
+			extraNotContains: []any{42},
 		},
 		{
 			name:             "min properties",
 			schema:           NewSchema().WithMinProperties(100),
-			value:            map[string]interface{}{"foo": 42},
-			extraNotContains: []interface{}{42},
+			value:            map[string]any{"foo": 42},
+			extraNotContains: []any{42},
 		},
 		{
 			name:             "max properties",
 			schema:           NewSchema().WithMaxProperties(0),
-			value:            map[string]interface{}{"foo": 42},
-			extraNotContains: []interface{}{42},
+			value:            map[string]any{"foo": 42},
+			extraNotContains: []any{42},
 		},
 		{
 			name:             "additional properties other schema type",
 			schema:           NewSchema().WithAdditionalProperties(NewStringSchema()),
-			value:            map[string]interface{}{"foo": 42},
-			extraNotContains: []interface{}{42},
+			value:            map[string]any{"foo": 42},
+			extraNotContains: []any{42},
 		},
 		{
 			name: "additional properties false",
 			schema: &Schema{AdditionalProperties: AdditionalProperties{
 				Has: BoolPtr(false),
 			}},
-			value:            map[string]interface{}{"foo": 42},
-			extraNotContains: []interface{}{42},
+			value:            map[string]any{"foo": 42},
+			extraNotContains: []any{42},
 		},
 		{
 			name: "invalid properties schema",
 			schema: NewSchema().WithProperties(map[string]*Schema{
 				"foo": NewStringSchema(),
 			}),
-			value:            map[string]interface{}{"foo": 42},
-			extraNotContains: []interface{}{42},
+			value:            map[string]any{"foo": 42},
+			extraNotContains: []any{42},
 		},
 		// TODO: uncomment when https://github.com/getkin/kin-openapi/issues/502 is fixed
 		//{
@@ -182,8 +182,8 @@ func TestIssue735(t *testing.T) {
 				},
 				Required: []string{"bar"},
 			},
-			value:            map[string]interface{}{"foo": 42},
-			extraNotContains: []interface{}{42},
+			value:            map[string]any{"foo": 42},
+			extraNotContains: []any{42},
 		},
 		{
 			name: "one of (matches more then one)",

--- a/openapi3/issue735_test.go
+++ b/openapi3/issue735_test.go
@@ -161,8 +161,8 @@ func TestIssue735(t *testing.T) {
 		//	schema: NewSchema().WithProperties(map[string]*Schema{
 		//		"foo": {ReadOnly: true},
 		//	}).WithoutAdditionalProperties(),
-		//	value:            map[string]interface{}{"foo": 42},
-		//	extraNotContains: []interface{}{42},
+		//	value:            map[string]any{"foo": 42},
+		//	extraNotContains: []any{42},
 		//	options:          []SchemaValidationOption{VisitAsRequest()},
 		//},
 		//{
@@ -170,8 +170,8 @@ func TestIssue735(t *testing.T) {
 		//	schema: NewSchema().WithProperties(map[string]*Schema{
 		//		"foo": {WriteOnly: true},
 		//	}).WithoutAdditionalProperties(),
-		//	value:            map[string]interface{}{"foo": 42},
-		//	extraNotContains: []interface{}{42},
+		//	value:            map[string]any{"foo": 42},
+		//	extraNotContains: []any{42},
 		//	options:          []SchemaValidationOption{VisitAsResponse()},
 		//},
 		{

--- a/openapi3/issue746_test.go
+++ b/openapi3/issue746_test.go
@@ -12,7 +12,7 @@ func TestIssue746(t *testing.T) {
 	err := schema.UnmarshalJSON([]byte(`{"additionalProperties": false}`))
 	require.NoError(t, err)
 
-	var value interface{}
+	var value any
 	err = json.Unmarshal([]byte(`{"foo": "bar"}`), &value)
 	require.NoError(t, err)
 

--- a/openapi3/issue767_test.go
+++ b/openapi3/issue767_test.go
@@ -14,7 +14,7 @@ func TestIssue767(t *testing.T) {
 	tests := [...]struct {
 		name     string
 		schema   *openapi3.Schema
-		value    map[string]interface{}
+		value    map[string]any
 		opts     []openapi3.SchemaValidationOption
 		checkErr require.ErrorAssertionFunc
 	}{
@@ -22,7 +22,7 @@ func TestIssue767(t *testing.T) {
 			name: "default values disabled should fail with minProps 1",
 			schema: openapi3.NewSchema().WithProperties(map[string]*openapi3.Schema{
 				"foo": {Type: &openapi3.Types{"boolean"}, Default: true}}).WithMinProperties(1),
-			value: map[string]interface{}{},
+			value: map[string]any{},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest(),
 			},
@@ -32,7 +32,7 @@ func TestIssue767(t *testing.T) {
 			name: "default values enabled should pass with minProps 1",
 			schema: openapi3.NewSchema().WithProperties(map[string]*openapi3.Schema{
 				"foo": {Type: &openapi3.Types{"boolean"}, Default: true}}).WithMinProperties(1),
-			value: map[string]interface{}{},
+			value: map[string]any{},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest(),
 				openapi3.DefaultsSet(func() {}),
@@ -45,7 +45,7 @@ func TestIssue767(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, Default: true},
 				"bar": {Type: &openapi3.Types{"boolean"}},
 			}).WithMinProperties(2),
-			value: map[string]interface{}{"bar": false},
+			value: map[string]any{"bar": false},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest(),
 				openapi3.DefaultsSet(func() {}),
@@ -58,7 +58,7 @@ func TestIssue767(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, Default: true},
 				"bar": {Type: &openapi3.Types{"boolean"}},
 			}).WithMaxProperties(1),
-			value: map[string]interface{}{"bar": false},
+			value: map[string]any{"bar": false},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest(),
 				openapi3.DefaultsSet(func() {}),
@@ -71,7 +71,7 @@ func TestIssue767(t *testing.T) {
 				"foo": {Type: &openapi3.Types{"boolean"}, Default: true},
 				"bar": {Type: &openapi3.Types{"boolean"}},
 			}).WithMaxProperties(1),
-			value: map[string]interface{}{"bar": false},
+			value: map[string]any{"bar": false},
 			opts: []openapi3.SchemaValidationOption{
 				openapi3.VisitAsRequest(),
 			},

--- a/openapi3/license.go
+++ b/openapi3/license.go
@@ -9,7 +9,7 @@ import (
 // License is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#license-object
 type License struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name string `json:"name" yaml:"name"` // Required
 	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
@@ -25,8 +25,8 @@ func (license License) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of License.
-func (license License) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 2+len(license.Extensions))
+func (license License) MarshalYAML() (any, error) {
+	m := make(map[string]any, 2+len(license.Extensions))
 	for k, v := range license.Extensions {
 		m[k] = v
 	}

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -10,14 +10,14 @@ import (
 // Link is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#link-object
 type Link struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
-	OperationRef string                 `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
-	OperationID  string                 `json:"operationId,omitempty" yaml:"operationId,omitempty"`
-	Description  string                 `json:"description,omitempty" yaml:"description,omitempty"`
-	Parameters   map[string]interface{} `json:"parameters,omitempty" yaml:"parameters,omitempty"`
-	Server       *Server                `json:"server,omitempty" yaml:"server,omitempty"`
-	RequestBody  interface{}            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
+	OperationRef string         `json:"operationRef,omitempty" yaml:"operationRef,omitempty"`
+	OperationID  string         `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Description  string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Parameters   map[string]any `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Server       *Server        `json:"server,omitempty" yaml:"server,omitempty"`
+	RequestBody  any            `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 }
 
 // MarshalJSON returns the JSON encoding of Link.
@@ -30,8 +30,8 @@ func (link Link) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Link.
-func (link Link) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 6+len(link.Extensions))
+func (link Link) MarshalYAML() (any, error) {
+	m := make(map[string]any, 6+len(link.Extensions))
 	for k, v := range link.Extensions {
 		m[k] = v
 	}

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -93,7 +93,7 @@ func (loader *Loader) allowsExternalRefs(ref string) (err error) {
 	return
 }
 
-func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, element interface{}) (*url.URL, error) {
+func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, element any) (*url.URL, error) {
 	if err := loader.allowsExternalRefs(ref); err != nil {
 		return nil, err
 	}
@@ -299,7 +299,7 @@ func isSingleRefElement(ref string) bool {
 	return !strings.Contains(ref, "#")
 }
 
-func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolved interface{}) (
+func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolved any) (
 	componentDoc *T,
 	componentPath *url.URL,
 	err error,
@@ -320,7 +320,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		return nil, nil, fmt.Errorf("expected fragment prefix '#/' in URI %q", ref)
 	}
 
-	drill := func(cursor interface{}) (interface{}, error) {
+	drill := func(cursor any) (any, error) {
 		for _, pathPart := range strings.Split(fragment[1:], "/") {
 			pathPart = unescapeRefString(pathPart)
 			attempted := false
@@ -366,7 +366,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		}
 		return cursor, nil
 	}
-	var cursor interface{}
+	var cursor any
 	if cursor, err = drill(componentDoc); err != nil {
 		if path == nil {
 			return nil, nil, err
@@ -390,8 +390,8 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		reflect.ValueOf(resolved).Elem().Set(reflect.ValueOf(cursor).Elem())
 		return componentDoc, componentPath, nil
 
-	case reflect.TypeOf(cursor) == reflect.TypeOf(map[string]interface{}{}):
-		codec := func(got, expect interface{}) error {
+	case reflect.TypeOf(cursor) == reflect.TypeOf(map[string]any{}):
+		codec := func(got, expect any) error {
 			enc, err := json.Marshal(got)
 			if err != nil {
 				return err
@@ -411,7 +411,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 	}
 }
 
-func readableType(x interface{}) string {
+func readableType(x any) string {
 	switch x.(type) {
 	case *Callback:
 		return "callback object"
@@ -440,7 +440,7 @@ func readableType(x interface{}) string {
 	}
 }
 
-func drillIntoField(cursor interface{}, fieldName string) (interface{}, error) {
+func drillIntoField(cursor any, fieldName string) (any, error) {
 	switch val := reflect.Indirect(reflect.ValueOf(cursor)); val.Kind() {
 
 	case reflect.Map:
@@ -481,7 +481,7 @@ func drillIntoField(cursor interface{}, fieldName string) (interface{}, error) {
 		}
 		if hasFields {
 			if ff := val.Type().Field(0); ff.PkgPath == "" && ff.Name == "Extensions" {
-				extensions := val.Field(0).Interface().(map[string]interface{})
+				extensions := val.Field(0).Interface().(map[string]any)
 				if enc, ok := extensions[fieldName]; ok {
 					return enc, nil
 				}

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -171,7 +171,7 @@ paths:
 
 	example := doc.Paths.Value("/").Get.Responses.Status(200).Value.Content.Get("application/json").Examples["test"]
 	require.NotNil(t, example.Value)
-	require.Equal(t, example.Value.Value.(map[string]interface{})["error"].(bool), false)
+	require.Equal(t, example.Value.Value.(map[string]any)["error"].(bool), false)
 }
 
 func TestLoadErrorOnRefMisuse(t *testing.T) {
@@ -520,7 +520,7 @@ func TestLinksFromOAISpec(t *testing.T) {
 	require.NoError(t, err)
 	response := doc.Paths.Value("/2.0/repositories/{username}/{slug}").Get.Responses.Status(200).Value
 	link := response.Links[`repositoryPullRequests`].Value
-	require.Equal(t, map[string]interface{}{
+	require.Equal(t, map[string]any{
 		"username": "$response.body#/owner/username",
 		"slug":     "$response.body#/slug",
 	}, link.Parameters)

--- a/openapi3/maplike.go
+++ b/openapi3/maplike.go
@@ -64,7 +64,7 @@ func (responses *Responses) Map() (m map[string]*ResponseRef) {
 var _ jsonpointer.JSONPointable = (*Responses)(nil)
 
 // JSONLookup implements https://github.com/go-openapi/jsonpointer#JSONPointable
-func (responses Responses) JSONLookup(token string) (interface{}, error) {
+func (responses Responses) JSONLookup(token string) (any, error) {
 	if v := responses.Value(token); v == nil {
 		vv, _, err := jsonpointer.GetForToken(responses.Extensions, token)
 		return vv, err
@@ -77,8 +77,8 @@ func (responses Responses) JSONLookup(token string) (interface{}, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Responses.
-func (responses *Responses) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, responses.Len()+len(responses.Extensions))
+func (responses *Responses) MarshalYAML() (any, error) {
+	m := make(map[string]any, responses.Len()+len(responses.Extensions))
 	for k, v := range responses.Extensions {
 		m[k] = v
 	}
@@ -99,7 +99,7 @@ func (responses *Responses) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON sets Responses to a copy of data.
 func (responses *Responses) UnmarshalJSON(data []byte) (err error) {
-	var m map[string]interface{}
+	var m map[string]any
 	if err = json.Unmarshal(data, &m); err != nil {
 		return
 	}
@@ -111,7 +111,7 @@ func (responses *Responses) UnmarshalJSON(data []byte) (err error) {
 	sort.Strings(ks)
 
 	x := Responses{
-		Extensions: make(map[string]interface{}),
+		Extensions: make(map[string]any),
 		m:          make(map[string]*ResponseRef, len(m)),
 	}
 
@@ -192,7 +192,7 @@ func (callback *Callback) Map() (m map[string]*PathItem) {
 var _ jsonpointer.JSONPointable = (*Callback)(nil)
 
 // JSONLookup implements https://github.com/go-openapi/jsonpointer#JSONPointable
-func (callback Callback) JSONLookup(token string) (interface{}, error) {
+func (callback Callback) JSONLookup(token string) (any, error) {
 	if v := callback.Value(token); v == nil {
 		vv, _, err := jsonpointer.GetForToken(callback.Extensions, token)
 		return vv, err
@@ -205,8 +205,8 @@ func (callback Callback) JSONLookup(token string) (interface{}, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Callback.
-func (callback *Callback) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, callback.Len()+len(callback.Extensions))
+func (callback *Callback) MarshalYAML() (any, error) {
+	m := make(map[string]any, callback.Len()+len(callback.Extensions))
 	for k, v := range callback.Extensions {
 		m[k] = v
 	}
@@ -227,7 +227,7 @@ func (callback *Callback) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON sets Callback to a copy of data.
 func (callback *Callback) UnmarshalJSON(data []byte) (err error) {
-	var m map[string]interface{}
+	var m map[string]any
 	if err = json.Unmarshal(data, &m); err != nil {
 		return
 	}
@@ -239,7 +239,7 @@ func (callback *Callback) UnmarshalJSON(data []byte) (err error) {
 	sort.Strings(ks)
 
 	x := Callback{
-		Extensions: make(map[string]interface{}),
+		Extensions: make(map[string]any),
 		m:          make(map[string]*PathItem, len(m)),
 	}
 
@@ -320,7 +320,7 @@ func (paths *Paths) Map() (m map[string]*PathItem) {
 var _ jsonpointer.JSONPointable = (*Paths)(nil)
 
 // JSONLookup implements https://github.com/go-openapi/jsonpointer#JSONPointable
-func (paths Paths) JSONLookup(token string) (interface{}, error) {
+func (paths Paths) JSONLookup(token string) (any, error) {
 	if v := paths.Value(token); v == nil {
 		vv, _, err := jsonpointer.GetForToken(paths.Extensions, token)
 		return vv, err
@@ -333,8 +333,8 @@ func (paths Paths) JSONLookup(token string) (interface{}, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Paths.
-func (paths *Paths) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, paths.Len()+len(paths.Extensions))
+func (paths *Paths) MarshalYAML() (any, error) {
+	m := make(map[string]any, paths.Len()+len(paths.Extensions))
 	for k, v := range paths.Extensions {
 		m[k] = v
 	}
@@ -355,7 +355,7 @@ func (paths *Paths) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON sets Paths to a copy of data.
 func (paths *Paths) UnmarshalJSON(data []byte) (err error) {
-	var m map[string]interface{}
+	var m map[string]any
 	if err = json.Unmarshal(data, &m); err != nil {
 		return
 	}
@@ -367,7 +367,7 @@ func (paths *Paths) UnmarshalJSON(data []byte) (err error) {
 	sort.Strings(ks)
 
 	x := Paths{
-		Extensions: make(map[string]interface{}),
+		Extensions: make(map[string]any),
 		m:          make(map[string]*PathItem, len(m)),
 	}
 

--- a/openapi3/marsh.go
+++ b/openapi3/marsh.go
@@ -16,7 +16,7 @@ func unmarshalError(jsonUnmarshalErr error) error {
 	return jsonUnmarshalErr
 }
 
-func unmarshal(data []byte, v interface{}) error {
+func unmarshal(data []byte, v any) error {
 	var jsonErr, yamlErr error
 
 	// See https://github.com/getkin/kin-openapi/issues/680

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -13,10 +13,10 @@ import (
 // MediaType is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#media-type-object
 type MediaType struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Schema   *SchemaRef           `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example  interface{}          `json:"example,omitempty" yaml:"example,omitempty"`
+	Example  any                  `json:"example,omitempty" yaml:"example,omitempty"`
 	Examples Examples             `json:"examples,omitempty" yaml:"examples,omitempty"`
 	Encoding map[string]*Encoding `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
@@ -41,7 +41,7 @@ func (mediaType *MediaType) WithSchemaRef(schema *SchemaRef) *MediaType {
 	return mediaType
 }
 
-func (mediaType *MediaType) WithExample(name string, value interface{}) *MediaType {
+func (mediaType *MediaType) WithExample(name string, value any) *MediaType {
 	example := mediaType.Examples
 	if example == nil {
 		example = make(map[string]*ExampleRef)
@@ -73,8 +73,8 @@ func (mediaType MediaType) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of MediaType.
-func (mediaType MediaType) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(mediaType.Extensions))
+func (mediaType MediaType) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(mediaType.Extensions))
 	for k, v := range mediaType.Extensions {
 		m[k] = v
 	}
@@ -158,7 +158,7 @@ func (mediaType *MediaType) Validate(ctx context.Context, opts ...ValidationOpti
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (mediaType MediaType) JSONLookup(token string) (interface{}, error) {
+func (mediaType MediaType) JSONLookup(token string) (any, error) {
 	switch token {
 	case "schema":
 		if mediaType.Schema != nil {

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -13,7 +13,7 @@ import (
 // T is the root of an OpenAPI v3 document
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#openapi-object
 type T struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	OpenAPI      string               `json:"openapi" yaml:"openapi"` // Required
 	Components   *Components          `json:"components,omitempty" yaml:"components,omitempty"`
@@ -31,7 +31,7 @@ type T struct {
 var _ jsonpointer.JSONPointable = (*T)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (doc *T) JSONLookup(token string) (interface{}, error) {
+func (doc *T) JSONLookup(token string) (any, error) {
 	switch token {
 	case "openapi":
 		return doc.OpenAPI, nil
@@ -65,8 +65,8 @@ func (doc *T) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of T.
-func (doc *T) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(doc.Extensions))
+func (doc *T) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(doc.Extensions))
 	for k, v := range doc.Extensions {
 		m[k] = v
 	}

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -13,7 +13,7 @@ import (
 // Operation represents "operation" specified by" OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#operation-object
 type Operation struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	// Optional tags for documentation.
 	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty"`
@@ -66,8 +66,8 @@ func (operation Operation) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Operation.
-func (operation Operation) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 12+len(operation.Extensions))
+func (operation Operation) MarshalYAML() (any, error) {
+	m := make(map[string]any, 12+len(operation.Extensions))
 	for k, v := range operation.Extensions {
 		m[k] = v
 	}
@@ -136,7 +136,7 @@ func (operation *Operation) UnmarshalJSON(data []byte) error {
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (operation Operation) JSONLookup(token string) (interface{}, error) {
+func (operation Operation) JSONLookup(token string) (any, error) {
 	switch token {
 	case "requestBody":
 		if operation.RequestBody != nil {

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -17,7 +17,7 @@ type Parameters []*ParameterRef
 var _ jsonpointer.JSONPointable = (*Parameters)(nil)
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (p Parameters) JSONLookup(token string) (interface{}, error) {
+func (p Parameters) JSONLookup(token string) (any, error) {
 	index, err := strconv.Atoi(token)
 	if err != nil {
 		return nil, err
@@ -72,21 +72,21 @@ func (parameters Parameters) Validate(ctx context.Context, opts ...ValidationOpt
 // Parameter is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#parameter-object
 type Parameter struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
-	Name            string      `json:"name,omitempty" yaml:"name,omitempty"`
-	In              string      `json:"in,omitempty" yaml:"in,omitempty"`
-	Description     string      `json:"description,omitempty" yaml:"description,omitempty"`
-	Style           string      `json:"style,omitempty" yaml:"style,omitempty"`
-	Explode         *bool       `json:"explode,omitempty" yaml:"explode,omitempty"`
-	AllowEmptyValue bool        `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
-	AllowReserved   bool        `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
-	Deprecated      bool        `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
-	Required        bool        `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema          *SchemaRef  `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example         interface{} `json:"example,omitempty" yaml:"example,omitempty"`
-	Examples        Examples    `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Content         Content     `json:"content,omitempty" yaml:"content,omitempty"`
+	Name            string     `json:"name,omitempty" yaml:"name,omitempty"`
+	In              string     `json:"in,omitempty" yaml:"in,omitempty"`
+	Description     string     `json:"description,omitempty" yaml:"description,omitempty"`
+	Style           string     `json:"style,omitempty" yaml:"style,omitempty"`
+	Explode         *bool      `json:"explode,omitempty" yaml:"explode,omitempty"`
+	AllowEmptyValue bool       `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	AllowReserved   bool       `json:"allowReserved,omitempty" yaml:"allowReserved,omitempty"`
+	Deprecated      bool       `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
+	Required        bool       `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Example         any        `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples        Examples   `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Content         Content    `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 var _ jsonpointer.JSONPointable = (*Parameter)(nil)
@@ -158,8 +158,8 @@ func (parameter Parameter) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Parameter.
-func (parameter Parameter) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 13+len(parameter.Extensions))
+func (parameter Parameter) MarshalYAML() (any, error) {
+	m := make(map[string]any, 13+len(parameter.Extensions))
 	for k, v := range parameter.Extensions {
 		m[k] = v
 	}
@@ -238,7 +238,7 @@ func (parameter *Parameter) UnmarshalJSON(data []byte) error {
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (parameter Parameter) JSONLookup(token string) (interface{}, error) {
+func (parameter Parameter) JSONLookup(token string) (any, error) {
 	switch token {
 	case "schema":
 		if parameter.Schema != nil {

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -11,7 +11,7 @@ import (
 // PathItem is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object
 type PathItem struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Ref         string     `json:"$ref,omitempty" yaml:"$ref,omitempty"`
 	Summary     string     `json:"summary,omitempty" yaml:"summary,omitempty"`
@@ -39,12 +39,12 @@ func (pathItem PathItem) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of PathItem.
-func (pathItem PathItem) MarshalYAML() (interface{}, error) {
+func (pathItem PathItem) MarshalYAML() (any, error) {
 	if ref := pathItem.Ref; ref != "" {
 		return Ref{Ref: ref}, nil
 	}
 
-	m := make(map[string]interface{}, 13+len(pathItem.Extensions))
+	m := make(map[string]any, 13+len(pathItem.Extensions))
 	for k, v := range pathItem.Extensions {
 		m[k] = v
 	}

--- a/openapi3/paths.go
+++ b/openapi3/paths.go
@@ -10,7 +10,7 @@ import (
 // Paths is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#paths-object
 type Paths struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	m map[string]*PathItem
 }

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -36,7 +36,7 @@ func (x *CallbackRef) CollectionName() string { return "callbacks" }
 func (x *CallbackRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of CallbackRef.
-func (x CallbackRef) MarshalYAML() (interface{}, error) {
+func (x CallbackRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -94,7 +94,7 @@ func (x *CallbackRef) Validate(ctx context.Context, opts ...ValidationOption) er
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *CallbackRef) JSONLookup(token string) (interface{}, error) {
+func (x *CallbackRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -126,7 +126,7 @@ func (x *ExampleRef) CollectionName() string { return "examples" }
 func (x *ExampleRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of ExampleRef.
-func (x ExampleRef) MarshalYAML() (interface{}, error) {
+func (x ExampleRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -184,7 +184,7 @@ func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) err
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *ExampleRef) JSONLookup(token string) (interface{}, error) {
+func (x *ExampleRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -216,7 +216,7 @@ func (x *HeaderRef) CollectionName() string { return "headers" }
 func (x *HeaderRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of HeaderRef.
-func (x HeaderRef) MarshalYAML() (interface{}, error) {
+func (x HeaderRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -274,7 +274,7 @@ func (x *HeaderRef) Validate(ctx context.Context, opts ...ValidationOption) erro
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *HeaderRef) JSONLookup(token string) (interface{}, error) {
+func (x *HeaderRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -306,7 +306,7 @@ func (x *LinkRef) CollectionName() string { return "links" }
 func (x *LinkRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of LinkRef.
-func (x LinkRef) MarshalYAML() (interface{}, error) {
+func (x LinkRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -364,7 +364,7 @@ func (x *LinkRef) Validate(ctx context.Context, opts ...ValidationOption) error 
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *LinkRef) JSONLookup(token string) (interface{}, error) {
+func (x *LinkRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -396,7 +396,7 @@ func (x *ParameterRef) CollectionName() string { return "parameters" }
 func (x *ParameterRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of ParameterRef.
-func (x ParameterRef) MarshalYAML() (interface{}, error) {
+func (x ParameterRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -454,7 +454,7 @@ func (x *ParameterRef) Validate(ctx context.Context, opts ...ValidationOption) e
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *ParameterRef) JSONLookup(token string) (interface{}, error) {
+func (x *ParameterRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -486,7 +486,7 @@ func (x *RequestBodyRef) CollectionName() string { return "requestBodies" }
 func (x *RequestBodyRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of RequestBodyRef.
-func (x RequestBodyRef) MarshalYAML() (interface{}, error) {
+func (x RequestBodyRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -544,7 +544,7 @@ func (x *RequestBodyRef) Validate(ctx context.Context, opts ...ValidationOption)
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *RequestBodyRef) JSONLookup(token string) (interface{}, error) {
+func (x *RequestBodyRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -576,7 +576,7 @@ func (x *ResponseRef) CollectionName() string { return "responses" }
 func (x *ResponseRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of ResponseRef.
-func (x ResponseRef) MarshalYAML() (interface{}, error) {
+func (x ResponseRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -634,7 +634,7 @@ func (x *ResponseRef) Validate(ctx context.Context, opts ...ValidationOption) er
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *ResponseRef) JSONLookup(token string) (interface{}, error) {
+func (x *ResponseRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -666,7 +666,7 @@ func (x *SchemaRef) CollectionName() string { return "schemas" }
 func (x *SchemaRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of SchemaRef.
-func (x SchemaRef) MarshalYAML() (interface{}, error) {
+func (x SchemaRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -724,7 +724,7 @@ func (x *SchemaRef) Validate(ctx context.Context, opts ...ValidationOption) erro
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *SchemaRef) JSONLookup(token string) (interface{}, error) {
+func (x *SchemaRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}
@@ -756,7 +756,7 @@ func (x *SecuritySchemeRef) CollectionName() string { return "securitySchemes" }
 func (x *SecuritySchemeRef) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of SecuritySchemeRef.
-func (x SecuritySchemeRef) MarshalYAML() (interface{}, error) {
+func (x SecuritySchemeRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -814,7 +814,7 @@ func (x *SecuritySchemeRef) Validate(ctx context.Context, opts ...ValidationOpti
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *SecuritySchemeRef) JSONLookup(token string) (interface{}, error) {
+func (x *SecuritySchemeRef) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}

--- a/openapi3/refs.tmpl
+++ b/openapi3/refs.tmpl
@@ -36,7 +36,7 @@ func (x *{{ $type.Name }}Ref) CollectionName() string { return "{{ $type.Collect
 func (x *{{ $type.Name }}Ref) RefPath() *url.URL { return &x.refPath }
 
 // MarshalYAML returns the YAML encoding of {{ $type.Name }}Ref.
-func (x {{ $type.Name }}Ref) MarshalYAML() (interface{}, error) {
+func (x {{ $type.Name }}Ref) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
 		return &Ref{Ref: ref}, nil
 	}
@@ -94,7 +94,7 @@ func (x *{{ $type.Name }}Ref) Validate(ctx context.Context, opts ...ValidationOp
 }
 
 // JSONLookup implements https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
-func (x *{{ $type.Name }}Ref) JSONLookup(token string) (interface{}, error) {
+func (x *{{ $type.Name }}Ref) JSONLookup(token string) (any, error) {
 	if token == "$ref" {
 		return x.Ref, nil
 	}

--- a/openapi3/refs_test.go
+++ b/openapi3/refs_test.go
@@ -226,7 +226,7 @@ components:
 	require.NoError(t, err)
 
 	var ptr jsonpointer.Pointer
-	var v interface{}
+	var v any
 	var kind reflect.Kind
 
 	ptr, err = jsonpointer.New("/paths")

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -9,7 +9,7 @@ import (
 // RequestBody is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#request-body-object
 type RequestBody struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Description string  `json:"description,omitempty" yaml:"description,omitempty"`
 	Required    bool    `json:"required,omitempty" yaml:"required,omitempty"`
@@ -83,8 +83,8 @@ func (requestBody RequestBody) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of RequestBody.
-func (requestBody RequestBody) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 3+len(requestBody.Extensions))
+func (requestBody RequestBody) MarshalYAML() (any, error) {
+	m := make(map[string]any, 3+len(requestBody.Extensions))
 	for k, v := range requestBody.Extensions {
 		m[k] = v
 	}

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -11,7 +11,7 @@ import (
 // Responses is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#responses-object
 type Responses struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	m map[string]*ResponseRef
 }
@@ -101,7 +101,7 @@ func (responses *Responses) Validate(ctx context.Context, opts ...ValidationOpti
 // Response is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#response-object
 type Response struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	Headers     Headers `json:"headers,omitempty" yaml:"headers,omitempty"`
@@ -143,8 +143,8 @@ func (response Response) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Response.
-func (response Response) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(response.Extensions))
+func (response Response) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(response.Extensions))
 	for k, v := range response.Extensions {
 		m[k] = v
 	}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1210,7 +1210,7 @@ func (schema *Schema) visitJSON(settings *schemaValidationSettings, value any) (
 		return schema.visitJSONArray(settings, value)
 	case map[string]any:
 		return schema.visitJSONObject(settings, value)
-	case map[any]any:
+	case map[any]any: // for YAML cf. issue https://github.com/getkin/kin-openapi/issues/444
 		values := make(map[string]any, len(value))
 		for key, v := range value {
 			if k, ok := key.(string); ok {

--- a/openapi3/schema_formats_test.go
+++ b/openapi3/schema_formats_test.go
@@ -97,7 +97,7 @@ components:
 	doc, err := l.LoadFromData([]byte(spc))
 	require.NoError(t, err)
 
-	err = doc.Components.Schemas["Something"].Value.VisitJSON(map[string]interface{}{
+	err = doc.Components.Schemas["Something"].Value.VisitJSON(map[string]any{
 		`ip`: `123.0.0.11111`,
 	})
 

--- a/openapi3/schema_issue289_test.go
+++ b/openapi3/schema_issue289_test.go
@@ -41,7 +41,7 @@ paths: {}
 	err = doc.Validate(loader.Context)
 	require.NoError(t, err)
 
-	err = doc.Components.Schemas["Server"].Value.VisitJSON(map[string]interface{}{
+	err = doc.Components.Schemas["Server"].Value.VisitJSON(map[string]any{
 		"name":    "kin-openapi",
 		"address": "127.0.0.1",
 	})

--- a/openapi3/schema_issue492_test.go
+++ b/openapi3/schema_issue492_test.go
@@ -35,14 +35,14 @@ info:
 	require.NoError(t, err)
 
 	// verify that the expected format works
-	err = doc.Components.Schemas["Server"].Value.VisitJSON(map[string]interface{}{
+	err = doc.Components.Schemas["Server"].Value.VisitJSON(map[string]any{
 		"name": "kin-openapi",
 		"time": "2001-02-03T04:05:06.789Z",
 	})
 	require.NoError(t, err)
 
 	// verify that the issue is fixed
-	err = doc.Components.Schemas["Server"].Value.VisitJSON(map[string]interface{}{
+	err = doc.Components.Schemas["Server"].Value.VisitJSON(map[string]any{
 		"name": "kin-openapi",
 		"time": "2001-02-03T04:05:06:789Z",
 	})

--- a/openapi3/schema_issue940_test.go
+++ b/openapi3/schema_issue940_test.go
@@ -46,7 +46,7 @@ func TestOneOfErrorPreserved(t *testing.T) {
 	err = s.Validate(context.Background())
 	require.NoError(t, err)
 
-	obj := make(map[string]interface{})
+	obj := make(map[string]any)
 	err = json.Unmarshal([]byte(raw), &obj)
 	require.NoError(t, err)
 

--- a/openapi3/schema_oneOf_test.go
+++ b/openapi3/schema_oneOf_test.go
@@ -119,7 +119,7 @@ components:
 
 func TestVisitJSON_OneOf_MissingDescriptorProperty(t *testing.T) {
 	doc := oneofSpec(t)
-	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]any{
 		"name": "snoopy",
 	})
 	require.ErrorContains(t, err, `input does not contain the discriminator property "$type"`)
@@ -127,7 +127,7 @@ func TestVisitJSON_OneOf_MissingDescriptorProperty(t *testing.T) {
 
 func TestVisitJSON_OneOf_MissingDescriptorValue(t *testing.T) {
 	doc := oneofSpec(t)
-	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]any{
 		"name":  "snoopy",
 		"$type": "snake",
 	})
@@ -136,7 +136,7 @@ func TestVisitJSON_OneOf_MissingDescriptorValue(t *testing.T) {
 
 func TestVisitJSON_OneOf_MissingField(t *testing.T) {
 	doc := oneofSpec(t)
-	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]any{
 		"name":  "snoopy",
 		"$type": "dog",
 	})
@@ -145,7 +145,7 @@ func TestVisitJSON_OneOf_MissingField(t *testing.T) {
 
 func TestVisitJSON_OneOf_NoDescriptor_MissingField(t *testing.T) {
 	doc := oneofNoDiscriminatorSpec(t)
-	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]any{
 		"name": "snoopy",
 	})
 	require.ErrorContains(t, err, `doesn't match schema due to: Error at "/scratches": property "scratches" is missing`)
@@ -153,14 +153,14 @@ func TestVisitJSON_OneOf_NoDescriptor_MissingField(t *testing.T) {
 
 func TestVisitJSON_OneOf_BadDiscriminatorType(t *testing.T) {
 	doc := oneofSpec(t)
-	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+	err := doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]any{
 		"name":      "snoopy",
 		"scratches": true,
 		"$type":     1,
 	})
 	require.ErrorContains(t, err, `value of discriminator property "$type" is not a string`)
 
-	err = doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]interface{}{
+	err = doc.Components.Schemas["Animal"].Value.VisitJSON(map[string]any{
 		"name":  "snoopy",
 		"barks": true,
 		"$type": nil,
@@ -205,9 +205,9 @@ components:
 	err = doc.Validate(loader.Context)
 	require.NoError(t, err)
 
-	err = doc.Components.Schemas["Something"].Value.VisitJSON(map[string]interface{}{
-		"first": map[string]interface{}{
-			"second": map[string]interface{}{
+	err = doc.Components.Schemas["Something"].Value.VisitJSON(map[string]any{
+		"first": map[string]any{
+			"second": map[string]any{
 				"third": "123456789",
 			},
 		},

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -16,9 +16,9 @@ import (
 type schemaExample struct {
 	Title         string
 	Schema        *Schema
-	Serialization interface{}
-	AllValid      []interface{}
-	AllInvalid    []interface{}
+	Serialization any
+	AllValid      []any
+	AllInvalid    []any
 }
 
 func TestSchemas(t *testing.T) {
@@ -56,32 +56,32 @@ func testSchema(t *testing.T, example schemaExample) func(*testing.T) {
 			}
 		}
 		// NaN and Inf aren't valid JSON but are handled
-		for index, value := range []interface{}{math.NaN(), math.Inf(-1), math.Inf(+1)} {
+		for index, value := range []any{math.NaN(), math.Inf(-1), math.Inf(+1)} {
 			err := schema.VisitJSON(value)
 			require.Errorf(t, err, "NaNAndInf #%d: %#v", index, value)
 		}
 	}
 }
 
-func validateSchemaJSON(t *testing.T, schema *Schema, value interface{}, opts ...SchemaValidationOption) error {
+func validateSchemaJSON(t *testing.T, schema *Schema, value any, opts ...SchemaValidationOption) error {
 	data, err := json.Marshal(value)
 	require.NoError(t, err)
-	var val interface{}
+	var val any
 	err = json.Unmarshal(data, &val)
 	require.NoError(t, err)
 	return schema.VisitJSON(val, opts...)
 }
 
-func validateSchemaYAML(t *testing.T, schema *Schema, value interface{}, opts ...SchemaValidationOption) error {
+func validateSchemaYAML(t *testing.T, schema *Schema, value any, opts ...SchemaValidationOption) error {
 	data, err := yaml.Marshal(value)
 	require.NoError(t, err)
-	var val interface{}
+	var val any
 	err = yaml.Unmarshal(data, &val)
 	require.NoError(t, err)
 	return schema.VisitJSON(val, opts...)
 }
 
-type validateSchemaFunc func(t *testing.T, schema *Schema, value interface{}, opts ...SchemaValidationOption) error
+type validateSchemaFunc func(t *testing.T, schema *Schema, value any, opts ...SchemaValidationOption) error
 
 var validateSchemaFuncs = []validateSchemaFunc{
 	validateSchemaJSON,
@@ -92,19 +92,16 @@ var schemaExamples = []schemaExample{
 	{
 		Title:         "EMPTY SCHEMA",
 		Schema:        &Schema{},
-		Serialization: map[string]interface{}{
-			// This OA3 schema is exactly this draft-04 schema:
-			//   {"not": {"type": "null"}}
-		},
-		AllValid: []interface{}{
+		Serialization: map[string]any{},
+		AllValid: []any{
 			false,
 			true,
 			3.14,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 		},
 	},
@@ -112,13 +109,13 @@ var schemaExamples = []schemaExample{
 	{
 		Title:  "JUST NULLABLE",
 		Schema: NewSchema().WithNullable(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			// This OA3 schema is exactly both this draft-04 schema: {} and:
 			// {anyOf: [type:string, type:number, type:integer, type:boolean
 			//         ,{type:array, items:{}}, type:object]}
 			"nullable": true,
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			nil,
 			false,
 			true,
@@ -126,30 +123,30 @@ var schemaExamples = []schemaExample{
 			0.0,
 			3.14,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 
 	{
 		Title:  "NULLABLE BOOLEAN",
 		Schema: NewBoolSchema().WithNullable(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"nullable": true,
 			"type":     "boolean",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			nil,
 			false,
 			true,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			0,
 			0.0,
 			3.14,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 
@@ -158,13 +155,13 @@ var schemaExamples = []schemaExample{
 		Schema: &Schema{
 			Type: &Types{TypeString, TypeBoolean},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			"",
 			"xyz",
 			true,
 			false,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			1,
 			nil,
 		},
@@ -175,15 +172,15 @@ var schemaExamples = []schemaExample{
 		Schema: &Schema{
 			Type: &Types{TypeNumber, TypeNull},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			0,
 			1,
 			2.3,
 			nil,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			"x",
-			[]interface{}{},
+			[]any{},
 		},
 	},
 
@@ -193,23 +190,23 @@ var schemaExamples = []schemaExample{
 			NewIntegerSchema(),
 			NewFloat64Schema(),
 		).WithNullable(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"nullable": true,
-			"anyOf": []interface{}{
-				map[string]interface{}{"type": "integer"},
-				map[string]interface{}{"type": "number"},
+			"anyOf": []any{
+				map[string]any{"type": "integer"},
+				map[string]any{"type": "number"},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			nil,
 			42,
 			4.2,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			true,
-			[]interface{}{42},
+			[]any{42},
 			"bla",
-			map[string]interface{}{},
+			map[string]any{},
 		},
 	},
 
@@ -219,22 +216,22 @@ var schemaExamples = []schemaExample{
 			NewIntegerSchema().WithNullable(),
 			NewFloat64Schema(),
 		),
-		Serialization: map[string]interface{}{
-			"anyOf": []interface{}{
-				map[string]interface{}{"type": "integer", "nullable": true},
-				map[string]interface{}{"type": "number"},
+		Serialization: map[string]any{
+			"anyOf": []any{
+				map[string]any{"type": "integer", "nullable": true},
+				map[string]any{"type": "number"},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			nil,
 			42,
 			4.2,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			true,
-			[]interface{}{42},
+			[]any{42},
 			"bla",
-			map[string]interface{}{},
+			map[string]any{},
 		},
 	},
 
@@ -244,23 +241,23 @@ var schemaExamples = []schemaExample{
 			NewBoolSchema().WithNullable(),
 			NewBoolSchema().WithNullable(),
 		),
-		Serialization: map[string]interface{}{
-			"allOf": []interface{}{
-				map[string]interface{}{"type": "boolean", "nullable": true},
-				map[string]interface{}{"type": "boolean", "nullable": true},
+		Serialization: map[string]any{
+			"allOf": []any{
+				map[string]any{"type": "boolean", "nullable": true},
+				map[string]any{"type": "boolean", "nullable": true},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			nil,
 			true,
 			false,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			2,
 			4.2,
-			[]interface{}{42},
+			[]any{42},
 			"bla",
-			map[string]interface{}{},
+			map[string]any{},
 		},
 	},
 
@@ -273,46 +270,46 @@ var schemaExamples = []schemaExample{
 			"stringProp": NewStringSchema().WithMaxLength(18),
 			"boolProp":   NewBoolSchema(),
 		}),
-		Serialization: map[string]interface{}{
-			"properties": map[string]interface{}{
-				"stringProp": map[string]interface{}{"type": "string", "maxLength": 18},
-				"boolProp":   map[string]interface{}{"type": "boolean"},
+		Serialization: map[string]any{
+			"properties": map[string]any{
+				"stringProp": map[string]any{"type": "string", "maxLength": 18},
+				"boolProp":   map[string]any{"type": "boolean"},
 			},
-			"anyOf": []interface{}{
-				map[string]interface{}{"type": "object", "required": []string{"stringProp"}},
-				map[string]interface{}{"type": "object", "required": []string{"boolProp"}},
+			"anyOf": []any{
+				map[string]any{"type": "object", "required": []string{"stringProp"}},
+				map[string]any{"type": "object", "required": []string{"boolProp"}},
 			},
 		},
-		AllValid: []interface{}{
-			map[string]interface{}{"stringProp": "valid string value"},
-			map[string]interface{}{"boolProp": true},
-			map[string]interface{}{"stringProp": "valid string value", "boolProp": true},
+		AllValid: []any{
+			map[string]any{"stringProp": "valid string value"},
+			map[string]any{"boolProp": true},
+			map[string]any{"stringProp": "valid string value", "boolProp": true},
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			1,
-			map[string]interface{}{},
-			map[string]interface{}{"invalidProp": false},
-			map[string]interface{}{"stringProp": "invalid string value"},
-			map[string]interface{}{"stringProp": "invalid string value", "boolProp": true},
+			map[string]any{},
+			map[string]any{"invalidProp": false},
+			map[string]any{"stringProp": "invalid string value"},
+			map[string]any{"stringProp": "invalid string value", "boolProp": true},
 		},
 	},
 
 	{
 		Title:  "BOOLEAN",
 		Schema: NewBoolSchema(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type": "boolean",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			false,
 			true,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			3.14,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 
@@ -321,25 +318,25 @@ var schemaExamples = []schemaExample{
 		Schema: NewFloat64Schema().
 			WithMin(2.5).
 			WithMax(3.5),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":    "number",
 			"minimum": 2.5,
 			"maximum": 3.5,
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			2.5,
 			3.14,
 			3.5,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			false,
 			true,
 			2.4,
 			3.6,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 
@@ -348,17 +345,17 @@ var schemaExamples = []schemaExample{
 		Schema: NewInt64Schema().
 			WithMin(2).
 			WithMax(5),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":    "integer",
 			"format":  "int64",
 			"minimum": 2,
 			"maximum": 5,
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			2,
 			5,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			false,
 			true,
@@ -366,49 +363,49 @@ var schemaExamples = []schemaExample{
 			6,
 			3.5,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 	{
 		Title:  "INTEGER OPTIONAL INT64 FORMAT",
 		Schema: NewInt64Schema(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":   "integer",
 			"format": "int64",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			1,
 			256,
 			65536,
 			int64(math.MaxInt32) + 10,
 			int64(math.MinInt32) - 10,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			false,
 			3.5,
 			true,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 	{
 		Title:  "INTEGER OPTIONAL INT32 FORMAT",
 		Schema: NewInt32Schema(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":   "integer",
 			"format": "int32",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			1,
 			256,
 			65536,
 			int64(math.MaxInt32),
 			int64(math.MaxInt32),
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			false,
 			3.5,
@@ -416,8 +413,8 @@ var schemaExamples = []schemaExample{
 			int64(math.MinInt32) - 10,
 			true,
 			"",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 	{
@@ -426,17 +423,17 @@ var schemaExamples = []schemaExample{
 			WithMinLength(2).
 			WithMaxLength(3).
 			WithPattern("^[abc]+$"),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":      "string",
 			"minLength": 2,
 			"maxLength": 3,
 			"pattern":   "^[abc]+$",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			"ab",
 			"abc",
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			false,
 			true,
@@ -444,19 +441,19 @@ var schemaExamples = []schemaExample{
 			"a",
 			"xy",
 			"aaaa",
-			[]interface{}{},
-			map[string]interface{}{},
+			[]any{},
+			map[string]any{},
 		},
 	},
 
 	{
 		Title:  "STRING: optional format 'uuid'",
 		Schema: NewUUIDSchema(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":   "string",
 			"format": "uuid",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			"dd7d8481-81a3-407f-95f0-a2f1cb382a4b",
 			"dcba3901-2fba-48c1-9db2-00422055804e",
 			"ace8e3be-c254-4c10-8859-1401d9a9d52a",
@@ -467,7 +464,7 @@ var schemaExamples = []schemaExample{
 			"DCBA3901-2FBA-48C1-9db2-00422055804e",
 			"ACE8E3BE-c254-4C10-8859-1401D9A9D52A",
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			"g39840b1-d0ef-446d-e555-48fcca50a90a",
 			"4cf3i040-ea14-4daa-b0b5-ea9329473519",
@@ -486,11 +483,11 @@ var schemaExamples = []schemaExample{
 	{
 		Title:  "STRING: format 'date-time'",
 		Schema: NewDateTimeSchema(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":   "string",
 			"format": "date-time",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			"2017-12-31T11:59:59",
 			"2017-12-31T11:59:59Z",
 			"2017-12-31T11:59:59-11:30",
@@ -498,7 +495,7 @@ var schemaExamples = []schemaExample{
 			"2017-12-31T11:59:59.999+11:30",
 			"2017-12-31T11:59:59.999Z",
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			3.14,
 			"2017-12-31",
@@ -511,11 +508,11 @@ var schemaExamples = []schemaExample{
 	{
 		Title:  "STRING: format 'date-time'",
 		Schema: NewBytesSchema(),
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":   "string",
 			"format": "byte",
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			"",
 			base64.StdEncoding.EncodeToString(func() []byte {
 				data := make([]byte, 0, 1024)
@@ -532,7 +529,7 @@ var schemaExamples = []schemaExample{
 				return data
 			}()),
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			" ",
 			"\n\n", // a \n is ok for JSON but not for YAML decoder/encoder
@@ -549,33 +546,33 @@ var schemaExamples = []schemaExample{
 			UniqueItems: true,
 			Items:       NewFloat64Schema().NewRef(),
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":        "array",
 			"minItems":    2,
 			"maxItems":    3,
 			"uniqueItems": true,
-			"items": map[string]interface{}{
+			"items": map[string]any{
 				"type": "number",
 			},
 		},
-		AllValid: []interface{}{
-			[]interface{}{
+		AllValid: []any{
+			[]any{
 				1, 2,
 			},
-			[]interface{}{
+			[]any{
 				1, 2, 3,
 			},
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			3.14,
-			[]interface{}{
+			[]any{
 				1,
 			},
-			[]interface{}{
+			[]any{
 				42, 42,
 			},
-			[]interface{}{
+			[]any{
 				1, 2, 3, 4,
 			},
 		},
@@ -592,45 +589,45 @@ var schemaExamples = []schemaExample{
 				},
 			}).NewRef(),
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":        "array",
 			"uniqueItems": true,
-			"items": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"key1": map[string]interface{}{
+			"items": map[string]any{
+				"properties": map[string]any{
+					"key1": map[string]any{
 						"type": "number",
 					},
 				},
 				"type": "object",
 			},
 		},
-		AllValid: []interface{}{
-			[]interface{}{
-				map[string]interface{}{
+		AllValid: []any{
+			[]any{
+				map[string]any{
 					"key1": 1,
 					"key2": 1,
 					// Additional properties will make object different
 					// By default additionalProperties is true
 				},
-				map[string]interface{}{
+				map[string]any{
 					"key1": 1,
 				},
 			},
-			[]interface{}{
-				map[string]interface{}{
+			[]any{
+				map[string]any{
 					"key1": 1,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"key1": 2,
 				},
 			},
 		},
-		AllInvalid: []interface{}{
-			[]interface{}{
-				map[string]interface{}{
+		AllInvalid: []any{
+			[]any{
+				map[string]any{
 					"key1": 1,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"key1": 1,
 				},
 			},
@@ -653,15 +650,15 @@ var schemaExamples = []schemaExample{
 				},
 			}).NewRef(),
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":        "array",
 			"uniqueItems": true,
-			"items": map[string]interface{}{
-				"properties": map[string]interface{}{
-					"key1": map[string]interface{}{
+			"items": map[string]any{
+				"properties": map[string]any{
+					"key1": map[string]any{
 						"type":        "array",
 						"uniqueItems": true,
-						"items": map[string]interface{}{
+						"items": map[string]any{
 							"type": "number",
 						},
 					},
@@ -669,53 +666,53 @@ var schemaExamples = []schemaExample{
 				"type": "object",
 			},
 		},
-		AllValid: []interface{}{
-			[]interface{}{
-				map[string]interface{}{
-					"key1": []interface{}{
+		AllValid: []any{
+			[]any{
+				map[string]any{
+					"key1": []any{
 						1, 2,
 					},
 				},
-				map[string]interface{}{
-					"key1": []interface{}{
+				map[string]any{
+					"key1": []any{
 						3, 4,
 					},
 				},
 			},
-			[]interface{}{ // Slice have items with the same value but with different index will treated as different slices
-				map[string]interface{}{
-					"key1": []interface{}{
+			[]any{
+				map[string]any{
+					"key1": []any{
 						10, 9,
 					},
 				},
-				map[string]interface{}{
-					"key1": []interface{}{
+				map[string]any{
+					"key1": []any{
 						9, 10,
 					},
 				},
 			},
 		},
-		AllInvalid: []interface{}{
-			[]interface{}{ // Violate outer array uniqueItems: true
-				map[string]interface{}{
-					"key1": []interface{}{
+		AllInvalid: []any{
+			[]any{
+				map[string]any{
+					"key1": []any{
 						9, 9,
 					},
 				},
-				map[string]interface{}{
-					"key1": []interface{}{
+				map[string]any{
+					"key1": []any{
 						9, 9,
 					},
 				},
 			},
-			[]interface{}{ // Violate inner(array in object) array uniqueItems: true
-				map[string]interface{}{
-					"key1": []interface{}{
+			[]any{
+				map[string]any{
+					"key1": []any{
 						9, 9,
 					},
 				},
-				map[string]interface{}{
-					"key1": []interface{}{
+				map[string]any{
+					"key1": []any{
 						8, 8,
 					},
 				},
@@ -734,35 +731,35 @@ var schemaExamples = []schemaExample{
 				Items:       NewFloat64Schema().NewRef(),
 			}).NewRef(),
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":        "array",
 			"uniqueItems": true,
-			"items": map[string]interface{}{
-				"items": map[string]interface{}{
+			"items": map[string]any{
+				"items": map[string]any{
 					"type": "number",
 				},
 				"uniqueItems": true,
 				"type":        "array",
 			},
 		},
-		AllValid: []interface{}{
-			[]interface{}{
-				[]interface{}{1, 2},
-				[]interface{}{3, 4},
+		AllValid: []any{
+			[]any{
+				[]any{1, 2},
+				[]any{3, 4},
 			},
-			[]interface{}{ // Slice have items with the same value but with different index will treated as different slices
-				[]interface{}{1, 2},
-				[]interface{}{2, 1},
+			[]any{
+				[]any{1, 2},
+				[]any{2, 1},
 			},
 		},
-		AllInvalid: []interface{}{
-			[]interface{}{ // Violate outer array uniqueItems: true
-				[]interface{}{8, 9},
-				[]interface{}{8, 9},
+		AllInvalid: []any{
+			[]any{
+				[]any{8, 9},
+				[]any{8, 9},
 			},
-			[]interface{}{ // Violate inner array uniqueItems: true
-				[]interface{}{9, 9},
-				[]interface{}{8, 8},
+			[]any{
+				[]any{9, 9},
+				[]any{8, 8},
 			},
 		},
 	},
@@ -783,14 +780,14 @@ var schemaExamples = []schemaExample{
 				}).NewRef(),
 			}).NewRef(),
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":        "array",
 			"uniqueItems": true,
-			"items": map[string]interface{}{
-				"items": map[string]interface{}{
+			"items": map[string]any{
+				"items": map[string]any{
 					"type": "object",
-					"properties": map[string]interface{}{
-						"key1": map[string]interface{}{
+					"properties": map[string]any{
+						"key1": map[string]any{
 							"type": "number",
 						},
 					},
@@ -799,71 +796,71 @@ var schemaExamples = []schemaExample{
 				"type":        "array",
 			},
 		},
-		AllValid: []interface{}{
-			[]interface{}{
-				[]interface{}{
-					map[string]interface{}{
+		AllValid: []any{
+			[]any{
+				[]any{
+					map[string]any{
 						"key1": 1,
 					},
 				},
-				[]interface{}{
-					map[string]interface{}{
+				[]any{
+					map[string]any{
 						"key1": 2,
 					},
 				},
 			},
-			[]interface{}{ // Slice have items with the same value but with different index will treated as different slices
-				[]interface{}{
-					map[string]interface{}{
+			[]any{
+				[]any{
+					map[string]any{
 						"key1": 1,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key1": 2,
 					},
 				},
-				[]interface{}{
-					map[string]interface{}{
+				[]any{
+					map[string]any{
 						"key1": 2,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key1": 1,
 					},
 				},
 			},
 		},
-		AllInvalid: []interface{}{
-			[]interface{}{ // Violate outer array uniqueItems: true
-				[]interface{}{
-					map[string]interface{}{
+		AllInvalid: []any{
+			[]any{
+				[]any{
+					map[string]any{
 						"key1": 1,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key1": 2,
 					},
 				},
-				[]interface{}{
-					map[string]interface{}{
+				[]any{
+					map[string]any{
 						"key1": 1,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key1": 2,
 					},
 				},
 			},
-			[]interface{}{ // Violate inner array uniqueItems: true
-				[]interface{}{
-					map[string]interface{}{
+			[]any{
+				[]any{
+					map[string]any{
 						"key1": 1,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key1": 1,
 					},
 				},
-				[]interface{}{
-					map[string]interface{}{
+				[]any{
+					map[string]any{
 						"key1": 2,
 					},
-					map[string]interface{}{
+					map[string]any{
 						"key1": 2,
 					},
 				},
@@ -880,36 +877,36 @@ var schemaExamples = []schemaExample{
 				"numberProperty": NewFloat64Schema().NewRef(),
 			},
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":          "object",
 			"maxProperties": 2,
-			"properties": map[string]interface{}{
-				"numberProperty": map[string]interface{}{
+			"properties": map[string]any{
+				"numberProperty": map[string]any{
 					"type": "number",
 				},
 			},
 		},
-		AllValid: []interface{}{
-			map[string]interface{}{},
-			map[string]interface{}{
+		AllValid: []any{
+			map[string]any{},
+			map[string]any{
 				"numberProperty": 3.14,
 			},
-			map[string]interface{}{
+			map[string]any{
 				"numberProperty": 3.14,
 				"some prop":      nil,
 			},
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			false,
 			true,
 			3.14,
 			"",
-			[]interface{}{},
-			map[string]interface{}{
+			[]any{},
+			map[string]any{
 				"numberProperty": "abc",
 			},
-			map[string]interface{}{
+			map[string]any{
 				"numberProperty": 3.14,
 				"some prop":      42,
 				"third":          "prop",
@@ -925,21 +922,21 @@ var schemaExamples = []schemaExample{
 				},
 			}},
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type": "object",
-			"additionalProperties": map[string]interface{}{
+			"additionalProperties": map[string]any{
 				"type": "number",
 			},
 		},
-		AllValid: []interface{}{
-			map[string]interface{}{},
-			map[string]interface{}{
+		AllValid: []any{
+			map[string]any{},
+			map[string]any{
 				"x": 3.14,
 				"y": 3.14,
 			},
 		},
-		AllInvalid: []interface{}{
-			map[string]interface{}{
+		AllInvalid: []any{
+			map[string]any{
 				"x": "abc",
 			},
 		},
@@ -949,13 +946,13 @@ var schemaExamples = []schemaExample{
 			Type:                 &Types{"object"},
 			AdditionalProperties: AdditionalProperties{Has: BoolPtr(true)},
 		},
-		Serialization: map[string]interface{}{
+		Serialization: map[string]any{
 			"type":                 "object",
 			"additionalProperties": true,
 		},
-		AllValid: []interface{}{
-			map[string]interface{}{},
-			map[string]interface{}{
+		AllValid: []any{
+			map[string]any{},
+			map[string]any{
 				"x": false,
 				"y": 3.14,
 			},
@@ -967,7 +964,7 @@ var schemaExamples = []schemaExample{
 		Schema: &Schema{
 			Not: &SchemaRef{
 				Value: &Schema{
-					Enum: []interface{}{
+					Enum: []any{
 						nil,
 						true,
 						3.14,
@@ -976,9 +973,9 @@ var schemaExamples = []schemaExample{
 				},
 			},
 		},
-		Serialization: map[string]interface{}{
-			"not": map[string]interface{}{
-				"enum": []interface{}{
+		Serialization: map[string]any{
+			"not": map[string]any{
+				"enum": []any{
 					nil,
 					true,
 					3.14,
@@ -986,12 +983,12 @@ var schemaExamples = []schemaExample{
 				},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			false,
 			2,
 			"abc",
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			nil,
 			true,
 			3.14,
@@ -1015,26 +1012,26 @@ var schemaExamples = []schemaExample{
 				},
 			},
 		},
-		Serialization: map[string]interface{}{
-			"anyOf": []interface{}{
-				map[string]interface{}{
+		Serialization: map[string]any{
+			"anyOf": []any{
+				map[string]any{
 					"type":    "number",
 					"minimum": 1,
 					"maximum": 2,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type":    "number",
 					"minimum": 2,
 					"maximum": 3,
 				},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			1,
 			2,
 			3,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			0,
 			4,
 		},
@@ -1056,24 +1053,24 @@ var schemaExamples = []schemaExample{
 				},
 			},
 		},
-		Serialization: map[string]interface{}{
-			"allOf": []interface{}{
-				map[string]interface{}{
+		Serialization: map[string]any{
+			"allOf": []any{
+				map[string]any{
 					"type":    "number",
 					"minimum": 1,
 					"maximum": 2,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type":    "number",
 					"minimum": 2,
 					"maximum": 3,
 				},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			2,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			0,
 			1,
 			3,
@@ -1097,25 +1094,25 @@ var schemaExamples = []schemaExample{
 				},
 			},
 		},
-		Serialization: map[string]interface{}{
-			"oneOf": []interface{}{
-				map[string]interface{}{
+		Serialization: map[string]any{
+			"oneOf": []any{
+				map[string]any{
 					"type":    "number",
 					"minimum": 1,
 					"maximum": 2,
 				},
-				map[string]interface{}{
+				map[string]any{
 					"type":    "number",
 					"minimum": 2,
 					"maximum": 3,
 				},
 			},
 		},
-		AllValid: []interface{}{
+		AllValid: []any{
 			1,
 			3,
 		},
-		AllInvalid: []interface{}{
+		AllInvalid: []any{
 			0,
 			2,
 			4,
@@ -1247,7 +1244,7 @@ var schemaErrorExamples = []schemaErrorExample{
 type schemaMultiErrorExample struct {
 	Title          string
 	Schema         *Schema
-	Values         []interface{}
+	Values         []any
 	ExpectedErrors []MultiError
 }
 
@@ -1296,7 +1293,7 @@ var schemaMultiErrorExamples = []schemaMultiErrorExample{
 			WithMinLength(2).
 			WithMaxLength(3).
 			WithPattern("^[abc]+$"),
-		Values: []interface{}{
+		Values: []any{
 			"f",
 			"foobar",
 		},
@@ -1310,7 +1307,7 @@ var schemaMultiErrorExamples = []schemaMultiErrorExample{
 		Schema: NewIntegerSchema().
 			WithMin(1).
 			WithMax(10),
-		Values: []interface{}{
+		Values: []any{
 			0.5,
 			10.1,
 		},
@@ -1326,9 +1323,9 @@ var schemaMultiErrorExamples = []schemaMultiErrorExample{
 			WithMaxItems(2).
 			WithItems(NewStringSchema().
 				WithPattern("^[abc]+$")),
-		Values: []interface{}{
-			[]interface{}{"foo"},
-			[]interface{}{"foo", "bar", "fizz"},
+		Values: []any{
+			[]any{"foo"},
+			[]any{"foo", "bar", "fizz"},
 		},
 		ExpectedErrors: []MultiError{
 			{
@@ -1352,9 +1349,9 @@ var schemaMultiErrorExamples = []schemaMultiErrorExample{
 					"key2": NewIntegerSchema(),
 				}),
 			),
-		Values: []interface{}{
-			[]interface{}{
-				map[string]interface{}{
+		Values: []any{
+			[]any{
+				map[string]any{
 					"key1": 100, // not a string
 					"key2": "not an integer",
 				},
@@ -1377,11 +1374,11 @@ var schemaMultiErrorExamples = []schemaMultiErrorExample{
 					WithItems(NewStringSchema().
 						WithPattern("^[abc]+$")),
 			}),
-		Values: []interface{}{
-			map[string]interface{}{
+		Values: []any{
+			map[string]any{
 				"key1": 100, // not a string
 				"key2": "not an integer",
-				"key3": []interface{}{"abc", "def"},
+				"key3": []any{"abc", "def"},
 			},
 		},
 		ExpectedErrors: []MultiError{
@@ -1413,7 +1410,7 @@ components:
       type: object
 `[1:])
 
-	data := map[string]interface{}{
+	data := map[string]any{
 		"name":      "kin-openapi",
 		"ownerName": true,
 	}
@@ -1463,22 +1460,22 @@ enum:
 	err = schema.VisitJSON(1337)
 	require.Error(t, err)
 
-	err = schema.VisitJSON([]interface{}{})
+	err = schema.VisitJSON([]any{})
 	require.NoError(t, err)
 
-	err = schema.VisitJSON([]interface{}{"a"})
+	err = schema.VisitJSON([]any{"a"})
 	require.NoError(t, err)
 
-	err = schema.VisitJSON([]interface{}{"b"})
+	err = schema.VisitJSON([]any{"b"})
 	require.Error(t, err)
 
-	err = schema.VisitJSON(map[string]interface{}{})
+	err = schema.VisitJSON(map[string]any{})
 	require.NoError(t, err)
 
-	err = schema.VisitJSON(map[string]interface{}{"b": "c"})
+	err = schema.VisitJSON(map[string]any{"b": "c"})
 	require.NoError(t, err)
 
-	err = schema.VisitJSON(map[string]interface{}{"d": "e"})
+	err = schema.VisitJSON(map[string]any{"d": "e"})
 	require.Error(t, err)
 }
 

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -11,7 +11,7 @@ import (
 // SecurityScheme is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#security-scheme-object
 type SecurityScheme struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Type             string      `json:"type,omitempty" yaml:"type,omitempty"`
 	Description      string      `json:"description,omitempty" yaml:"description,omitempty"`
@@ -60,8 +60,8 @@ func (ss SecurityScheme) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of SecurityScheme.
-func (ss SecurityScheme) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 8+len(ss.Extensions))
+func (ss SecurityScheme) MarshalYAML() (any, error) {
+	m := make(map[string]any, 8+len(ss.Extensions))
 	for k, v := range ss.Extensions {
 		m[k] = v
 	}
@@ -215,7 +215,7 @@ func (ss *SecurityScheme) Validate(ctx context.Context, opts ...ValidationOption
 // OAuthFlows is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oauth-flows-object
 type OAuthFlows struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Implicit          *OAuthFlow `json:"implicit,omitempty" yaml:"implicit,omitempty"`
 	Password          *OAuthFlow `json:"password,omitempty" yaml:"password,omitempty"`
@@ -242,8 +242,8 @@ func (flows OAuthFlows) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of OAuthFlows.
-func (flows OAuthFlows) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(flows.Extensions))
+func (flows OAuthFlows) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(flows.Extensions))
 	for k, v := range flows.Extensions {
 		m[k] = v
 	}
@@ -315,7 +315,7 @@ func (flows *OAuthFlows) Validate(ctx context.Context, opts ...ValidationOption)
 // OAuthFlow is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#oauth-flow-object
 type OAuthFlow struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	AuthorizationURL string            `json:"authorizationUrl,omitempty" yaml:"authorizationUrl,omitempty"`
 	TokenURL         string            `json:"tokenUrl,omitempty" yaml:"tokenUrl,omitempty"`
@@ -333,8 +333,8 @@ func (flow OAuthFlow) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of OAuthFlow.
-func (flow OAuthFlow) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(flow.Extensions))
+func (flow OAuthFlow) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(flow.Extensions))
 	for k, v := range flow.Extensions {
 		m[k] = v
 	}

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -51,7 +51,7 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string) 
 // Server is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-object
 type Server struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	URL         string                     `json:"url" yaml:"url"` // Required
 	Description string                     `json:"description,omitempty" yaml:"description,omitempty"`
@@ -92,8 +92,8 @@ func (server Server) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Server.
-func (server Server) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 3+len(server.Extensions))
+func (server Server) MarshalYAML() (any, error) {
+	m := make(map[string]any, 3+len(server.Extensions))
 	for k, v := range server.Extensions {
 		m[k] = v
 	}
@@ -234,7 +234,7 @@ func (server *Server) Validate(ctx context.Context, opts ...ValidationOption) (e
 // ServerVariable is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object
 type ServerVariable struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Enum        []string `json:"enum,omitempty" yaml:"enum,omitempty"`
 	Default     string   `json:"default,omitempty" yaml:"default,omitempty"`
@@ -251,8 +251,8 @@ func (serverVariable ServerVariable) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of ServerVariable.
-func (serverVariable ServerVariable) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 4+len(serverVariable.Extensions))
+func (serverVariable ServerVariable) MarshalYAML() (any, error) {
+	m := make(map[string]any, 4+len(serverVariable.Extensions))
 	for k, v := range serverVariable.Extensions {
 		m[k] = v
 	}

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -33,7 +33,7 @@ func (tags Tags) Validate(ctx context.Context, opts ...ValidationOption) error {
 // Tag is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#tag-object
 type Tag struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name         string        `json:"name,omitempty" yaml:"name,omitempty"`
 	Description  string        `json:"description,omitempty" yaml:"description,omitempty"`
@@ -50,8 +50,8 @@ func (t Tag) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of Tag.
-func (t Tag) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 3+len(t.Extensions))
+func (t Tag) MarshalYAML() (any, error) {
+	m := make(map[string]any, 3+len(t.Extensions))
 	for k, v := range t.Extensions {
 		m[k] = v
 	}

--- a/openapi3/unique_items_checker_test.go
+++ b/openapi3/unique_items_checker_test.go
@@ -15,7 +15,7 @@ func TestRegisterArrayUniqueItemsChecker(t *testing.T) {
 			UniqueItems: true,
 			Items:       openapi3.NewStringSchema().NewRef(),
 		}
-		val = []interface{}{"1", "2", "3"}
+		val = []any{"1", "2", "3"}
 	)
 
 	// Fist checked by predefined function
@@ -25,7 +25,7 @@ func TestRegisterArrayUniqueItemsChecker(t *testing.T) {
 	// Register a function will always return false when check if a
 	// slice has unique items, then use a slice indeed has unique
 	// items to verify that check unique items will failed.
-	openapi3.RegisterArrayUniqueItemsChecker(func(items []interface{}) bool {
+	openapi3.RegisterArrayUniqueItemsChecker(func(items []any) bool {
 		return false
 	})
 	defer openapi3.RegisterArrayUniqueItemsChecker(nil) // Reset for other tests

--- a/openapi3/xml.go
+++ b/openapi3/xml.go
@@ -8,7 +8,7 @@ import (
 // XML is specified by OpenAPI/Swagger standard version 3.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#xml-object
 type XML struct {
-	Extensions map[string]interface{} `json:"-" yaml:"-"`
+	Extensions map[string]any `json:"-" yaml:"-"`
 
 	Name      string `json:"name,omitempty" yaml:"name,omitempty"`
 	Namespace string `json:"namespace,omitempty" yaml:"namespace,omitempty"`
@@ -27,8 +27,8 @@ func (xml XML) MarshalJSON() ([]byte, error) {
 }
 
 // MarshalYAML returns the YAML encoding of XML.
-func (xml XML) MarshalYAML() (interface{}, error) {
-	m := make(map[string]interface{}, 5+len(xml.Extensions))
+func (xml XML) MarshalYAML() (any, error) {
+	m := make(map[string]any, 5+len(xml.Extensions))
 	for k, v := range xml.Extensions {
 		m[k] = v
 	}

--- a/openapi3filter/internal.go
+++ b/openapi3filter/internal.go
@@ -13,7 +13,7 @@ func parseMediaType(contentType string) string {
 	return contentType[:i]
 }
 
-func isNilValue(value interface{}) bool {
+func isNilValue(value any) bool {
 	if value == nil {
 		return true
 	}

--- a/openapi3filter/issue639_test.go
+++ b/openapi3filter/issue639_test.go
@@ -52,7 +52,7 @@ func TestIssue639(t *testing.T) {
 	tests := []struct {
 		name               string
 		options            *Options
-		expectedDefaultVal interface{}
+		expectedDefaultVal any
 	}{
 		{
 			name: "no defaults are added to requests",
@@ -90,7 +90,7 @@ func TestIssue639(t *testing.T) {
 			bodyAfterValidation, err := io.ReadAll(httpReq.Body)
 			require.NoError(t, err)
 
-			raw := map[string]interface{}{}
+			raw := map[string]any{}
 			err = json.Unmarshal(bodyAfterValidation, &raw)
 			require.NoError(t, err)
 			require.Equal(t, testcase.expectedDefaultVal,

--- a/openapi3filter/issue733_test.go
+++ b/openapi3filter/issue733_test.go
@@ -76,7 +76,7 @@ paths:
 
 			dec := json.NewDecoder(req.Body)
 			dec.UseNumber()
-			var jsonAfter map[string]interface{}
+			var jsonAfter map[string]any
 			err = dec.Decode(&jsonAfter)
 			require.NoError(t, err)
 

--- a/openapi3filter/middleware_test.go
+++ b/openapi3filter/middleware_test.go
@@ -451,7 +451,7 @@ paths:
 			panic(err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		result := map[string]interface{}{"result": x * x}
+		result := map[string]any{"result": x * x}
 		if x == 42 {
 			// An easter egg. Unfortunately, the spec does not allow additional properties...
 			result["comment"] = "the answer to the ultimate question of life, the universe, and everything"
@@ -494,7 +494,7 @@ paths:
 			// Customize validation error responses to use JSON
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(status)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"status":  status,
 				"message": http.StatusText(status),
 			})

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1184,7 +1184,7 @@ func parsePrimitiveCase(raw string, schema *openapi3.SchemaRef, typ string) (any
 type EncodingFn func(partName string) *openapi3.Encoding
 
 // BodyDecoder is an interface to decode a body of a request or response.
-// An implementation must return a value that is a primitive, []interface{}, or map[string]interface{}.
+// An implementation must return a value that is a primitive, []any, or map[string]any.
 type BodyDecoder func(io.Reader, http.Header, *openapi3.SchemaRef, EncodingFn) (any, error)
 
 // bodyDecoders contains decoders for supported content types of a body.

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -39,11 +39,11 @@ const (
 // ParseError describes errors which happens while parse operation's parameters, requestBody, or response.
 type ParseError struct {
 	Kind   ParseErrorKind
-	Value  interface{}
+	Value  any
 	Reason string
 	Cause  error
 
-	path []interface{}
+	path []any
 }
 
 var _ interface{ Unwrap() error } = ParseError{}
@@ -92,8 +92,8 @@ func (e ParseError) Unwrap() error {
 }
 
 // Path returns a path to the root cause.
-func (e *ParseError) Path() []interface{} {
-	var path []interface{}
+func (e *ParseError) Path() []any {
+	var path []any
 	if v, ok := e.Cause.(*ParseError); ok {
 		p := v.Path()
 		if len(p) > 0 {
@@ -113,7 +113,7 @@ func invalidSerializationMethodErr(sm *openapi3.SerializationMethod) error {
 // Decodes a parameter defined via the content property as an object. It uses
 // the user specified decoder, or our build-in decoder for application/json
 func decodeContentParameter(param *openapi3.Parameter, input *RequestValidationInput) (
-	value interface{},
+	value any,
 	schema *openapi3.Schema,
 	found bool,
 	err error,
@@ -164,7 +164,7 @@ func decodeContentParameter(param *openapi3.Parameter, input *RequestValidationI
 }
 
 func defaultContentParameterDecoder(param *openapi3.Parameter, values []string) (
-	outValue interface{},
+	outValue any,
 	outSchema *openapi3.Schema,
 	err error,
 ) {
@@ -192,7 +192,7 @@ func defaultContentParameterDecoder(param *openapi3.Parameter, values []string) 
 	}
 	outSchema = mt.Schema.Value
 
-	unmarshal := func(encoded string, paramSchema *openapi3.SchemaRef) (decoded interface{}, err error) {
+	unmarshal := func(encoded string, paramSchema *openapi3.SchemaRef) (decoded any, err error) {
 		if err = json.Unmarshal([]byte(encoded), &decoded); err != nil {
 			if paramSchema != nil && !paramSchema.Value.Type.Is("object") {
 				decoded, err = encoded, nil
@@ -207,9 +207,9 @@ func defaultContentParameterDecoder(param *openapi3.Parameter, values []string) 
 			return
 		}
 	} else {
-		outArray := make([]interface{}, 0, len(values))
+		outArray := make([]any, 0, len(values))
 		for _, v := range values {
-			var item interface{}
+			var item any
 			if item, err = unmarshal(v, outSchema.Items); err != nil {
 				err = fmt.Errorf("error unmarshaling parameter %q", param.Name)
 				return
@@ -222,15 +222,15 @@ func defaultContentParameterDecoder(param *openapi3.Parameter, values []string) 
 }
 
 type valueDecoder interface {
-	DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error)
-	DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]interface{}, bool, error)
-	DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]interface{}, bool, error)
+	DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error)
+	DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]any, bool, error)
+	DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]any, bool, error)
 }
 
 // decodeStyledParameter returns a value of an operation's parameter from HTTP request for
 // parameters defined using the style format, and whether the parameter is supplied in the input.
 // The function returns ParseError when HTTP request contains an invalid value of a parameter.
-func decodeStyledParameter(param *openapi3.Parameter, input *RequestValidationInput) (interface{}, bool, error) {
+func decodeStyledParameter(param *openapi3.Parameter, input *RequestValidationInput) (any, bool, error) {
 	sm, err := param.SerializationMethod()
 	if err != nil {
 		return nil, false, err
@@ -259,11 +259,11 @@ func decodeStyledParameter(param *openapi3.Parameter, input *RequestValidationIn
 	return decodeValue(dec, param.Name, sm, param.Schema, param.Required)
 }
 
-func decodeValue(dec valueDecoder, param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef, required bool) (interface{}, bool, error) {
+func decodeValue(dec valueDecoder, param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef, required bool) (any, bool, error) {
 	var found bool
 
 	if len(schema.Value.AllOf) > 0 {
-		var value interface{}
+		var value any
 		var err error
 		for _, sr := range schema.Value.AllOf {
 			var f bool
@@ -292,7 +292,7 @@ func decodeValue(dec valueDecoder, param string, sm *openapi3.SerializationMetho
 
 	if len(schema.Value.OneOf) > 0 {
 		isMatched := 0
-		var value interface{}
+		var value any
 		for _, sr := range schema.Value.OneOf {
 			v, f, _ := decodeValue(dec, param, sm, sr, required)
 			found = found || f
@@ -316,14 +316,14 @@ func decodeValue(dec valueDecoder, param string, sm *openapi3.SerializationMetho
 	}
 
 	if schema.Value.Type != nil {
-		var decodeFn func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error)
+		var decodeFn func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error)
 		switch {
 		case schema.Value.Type.Is("array"):
-			decodeFn = func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error) {
+			decodeFn = func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
 				return dec.DecodeArray(param, sm, schema)
 			}
 		case schema.Value.Type.Is("object"):
-			decodeFn = func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error) {
+			decodeFn = func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
 				return dec.DecodeObject(param, sm, schema)
 			}
 		default:
@@ -355,7 +355,7 @@ type pathParamDecoder struct {
 	pathParams map[string]string
 }
 
-func (d *pathParamDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error) {
+func (d *pathParamDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
 	var prefix string
 	switch sm.Style {
 	case "simple":
@@ -385,7 +385,7 @@ func (d *pathParamDecoder) DecodePrimitive(param string, sm *openapi3.Serializat
 	return val, ok, err
 }
 
-func (d *pathParamDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]interface{}, bool, error) {
+func (d *pathParamDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]any, bool, error) {
 	var prefix, delim string
 	switch {
 	case sm.Style == "simple":
@@ -423,7 +423,7 @@ func (d *pathParamDecoder) DecodeArray(param string, sm *openapi3.SerializationM
 	return val, ok, err
 }
 
-func (d *pathParamDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]interface{}, bool, error) {
+func (d *pathParamDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]any, bool, error) {
 	var prefix, propsDelim, valueDelim string
 	switch {
 	case sm.Style == "simple" && !sm.Explode:
@@ -495,7 +495,7 @@ type urlValuesDecoder struct {
 	values url.Values
 }
 
-func (d *urlValuesDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error) {
+func (d *urlValuesDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
 	if sm.Style != "form" {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -513,7 +513,7 @@ func (d *urlValuesDecoder) DecodePrimitive(param string, sm *openapi3.Serializat
 	return val, ok, err
 }
 
-func (d *urlValuesDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]interface{}, bool, error) {
+func (d *urlValuesDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]any, bool, error) {
 	if sm.Style == "deepObject" {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -542,14 +542,14 @@ func (d *urlValuesDecoder) DecodeArray(param string, sm *openapi3.SerializationM
 // parseArray returns an array that contains items from a raw array.
 // Every item is parsed as a primitive value.
 // The function returns an error when an error happened while parse array's items.
-func (d *urlValuesDecoder) parseArray(raw []string, sm *openapi3.SerializationMethod, schemaRef *openapi3.SchemaRef) ([]interface{}, error) {
-	var value []interface{}
+func (d *urlValuesDecoder) parseArray(raw []string, sm *openapi3.SerializationMethod, schemaRef *openapi3.SchemaRef) ([]any, error) {
+	var value []any
 
 	for i, v := range raw {
 		item, err := d.parseValue(v, schemaRef.Value.Items)
 		if err != nil {
 			if v, ok := err.(*ParseError); ok {
-				return nil, &ParseError{path: []interface{}{i}, Cause: v}
+				return nil, &ParseError{path: []any{i}, Cause: v}
 			}
 			return nil, fmt.Errorf("item %d: %w", i, err)
 		}
@@ -564,9 +564,9 @@ func (d *urlValuesDecoder) parseArray(raw []string, sm *openapi3.SerializationMe
 	return value, nil
 }
 
-func (d *urlValuesDecoder) parseValue(v string, schema *openapi3.SchemaRef) (interface{}, error) {
+func (d *urlValuesDecoder) parseValue(v string, schema *openapi3.SchemaRef) (any, error) {
 	if len(schema.Value.AllOf) > 0 {
-		var value interface{}
+		var value any
 		var err error
 		for _, sr := range schema.Value.AllOf {
 			value, err = d.parseValue(v, sr)
@@ -578,7 +578,7 @@ func (d *urlValuesDecoder) parseValue(v string, schema *openapi3.SchemaRef) (int
 	}
 
 	if len(schema.Value.AnyOf) > 0 {
-		var value interface{}
+		var value any
 		var err error
 		for _, sr := range schema.Value.AnyOf {
 			if value, err = d.parseValue(v, sr); err == nil {
@@ -591,7 +591,7 @@ func (d *urlValuesDecoder) parseValue(v string, schema *openapi3.SchemaRef) (int
 
 	if len(schema.Value.OneOf) > 0 {
 		isMatched := 0
-		var value interface{}
+		var value any
 		var err error
 		for _, sr := range schema.Value.OneOf {
 			result, err := d.parseValue(v, sr)
@@ -623,7 +623,7 @@ const (
 	urlDecoderDelimiter = "\x1F" // should not conflict with URL characters
 )
 
-func (d *urlValuesDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]interface{}, bool, error) {
+func (d *urlValuesDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]any, bool, error) {
 	var propsFn func(url.Values) (map[string]string, error)
 	switch sm.Style {
 	case "form":
@@ -714,7 +714,7 @@ type headerParamDecoder struct {
 	header http.Header
 }
 
-func (d *headerParamDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error) {
+func (d *headerParamDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
 	if sm.Style != "simple" {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -729,7 +729,7 @@ func (d *headerParamDecoder) DecodePrimitive(param string, sm *openapi3.Serializ
 	return val, ok, err
 }
 
-func (d *headerParamDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]interface{}, bool, error) {
+func (d *headerParamDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]any, bool, error) {
 	if sm.Style != "simple" {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -744,7 +744,7 @@ func (d *headerParamDecoder) DecodeArray(param string, sm *openapi3.Serializatio
 	return val, ok, err
 }
 
-func (d *headerParamDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]interface{}, bool, error) {
+func (d *headerParamDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]any, bool, error) {
 	if sm.Style != "simple" {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -771,7 +771,7 @@ type cookieParamDecoder struct {
 	req *http.Request
 }
 
-func (d *cookieParamDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (interface{}, bool, error) {
+func (d *cookieParamDecoder) DecodePrimitive(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
 	if sm.Style != "form" {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -790,7 +790,7 @@ func (d *cookieParamDecoder) DecodePrimitive(param string, sm *openapi3.Serializ
 	return val, found, err
 }
 
-func (d *cookieParamDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]interface{}, bool, error) {
+func (d *cookieParamDecoder) DecodeArray(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) ([]any, bool, error) {
 	if sm.Style != "form" || sm.Explode {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -808,7 +808,7 @@ func (d *cookieParamDecoder) DecodeArray(param string, sm *openapi3.Serializatio
 	return val, found, err
 }
 
-func (d *cookieParamDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]interface{}, bool, error) {
+func (d *cookieParamDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]any, bool, error) {
 	if sm.Style != "form" || sm.Explode {
 		return nil, false, invalidSerializationMethodErr(sm)
 	}
@@ -871,26 +871,26 @@ func propsFromString(src, propDelim, valueDelim string) (map[string]string, erro
 	return props, nil
 }
 
-func deepGet(m map[string]interface{}, keys ...string) (interface{}, bool) {
+func deepGet(m map[string]any, keys ...string) (any, bool) {
 	for _, key := range keys {
 		val, ok := m[key]
 		if !ok {
 			return nil, false
 		}
-		if m, ok = val.(map[string]interface{}); !ok {
+		if m, ok = val.(map[string]any); !ok {
 			return val, true
 		}
 	}
 	return m, true
 }
 
-func deepSet(m map[string]interface{}, keys []string, value interface{}) {
+func deepSet(m map[string]any, keys []string, value any) {
 	for i := 0; i < len(keys)-1; i++ {
 		key := keys[i]
 		if _, ok := m[key]; !ok {
-			m[key] = make(map[string]interface{})
+			m[key] = make(map[string]any)
 		}
-		m = m[key].(map[string]interface{})
+		m = m[key].(map[string]any)
 	}
 	m[keys[len(keys)-1]] = value
 }
@@ -916,8 +916,8 @@ func findNestedSchema(parentSchema *openapi3.SchemaRef, keys []string) (*openapi
 }
 
 // makeObject returns an object that contains properties from props.
-func makeObject(props map[string]string, schema *openapi3.SchemaRef) (map[string]interface{}, error) {
-	mobj := make(map[string]interface{})
+func makeObject(props map[string]string, schema *openapi3.SchemaRef) (map[string]any, error) {
+	mobj := make(map[string]any)
 
 	for kk, value := range props {
 		keys := strings.Split(kk, urlDecoderDelimiter)
@@ -932,7 +932,7 @@ func makeObject(props map[string]string, schema *openapi3.SchemaRef) (map[string
 	if err != nil {
 		return nil, err
 	}
-	result, ok := r.(map[string]interface{})
+	result, ok := r.(map[string]any)
 	if !ok {
 		return nil, &ParseError{Kind: KindOther, Reason: "invalid param object", Value: result}
 	}
@@ -941,8 +941,8 @@ func makeObject(props map[string]string, schema *openapi3.SchemaRef) (map[string
 }
 
 // example: map[0:map[key:true] 1:map[key:false]] -> [map[key:true] map[key:false]]
-func sliceMapToSlice(m map[string]interface{}) ([]interface{}, error) {
-	var result []interface{}
+func sliceMapToSlice(m map[string]any) ([]any, error) {
+	var result []any
 
 	keys := make([]int, 0, len(m))
 	for k := range m {
@@ -970,7 +970,7 @@ func sliceMapToSlice(m map[string]interface{}) ([]interface{}, error) {
 }
 
 // buildResObj constructs an object based on a given schema and param values
-func buildResObj(params map[string]interface{}, parentKeys []string, key string, schema *openapi3.SchemaRef) (interface{}, error) {
+func buildResObj(params map[string]any, parentKeys []string, key string, schema *openapi3.SchemaRef) (any, error) {
 	mapKeys := parentKeys
 	if key != "" {
 		mapKeys = append(mapKeys, key)
@@ -982,7 +982,7 @@ func buildResObj(params map[string]interface{}, parentKeys []string, key string,
 		if !ok {
 			return nil, nil
 		}
-		t, isMap := paramArr.(map[string]interface{})
+		t, isMap := paramArr.(map[string]any)
 		if !isMap {
 			return nil, &ParseError{path: pathFromKeys(mapKeys), Kind: KindInvalidFormat, Reason: "array items must be set with indexes"}
 		}
@@ -991,7 +991,7 @@ func buildResObj(params map[string]interface{}, parentKeys []string, key string,
 		if err != nil {
 			return nil, &ParseError{path: pathFromKeys(mapKeys), Kind: KindInvalidFormat, Reason: fmt.Sprintf("could not convert value map to array: %v", err)}
 		}
-		resultArr := make([]interface{} /*not 0,*/, len(arr))
+		resultArr := make([]any, len(arr))
 		for i := range arr {
 			r, err := buildResObj(params, mapKeys, strconv.Itoa(i), schema.Value.Items)
 			if err != nil {
@@ -1003,10 +1003,10 @@ func buildResObj(params map[string]interface{}, parentKeys []string, key string,
 		}
 		return resultArr, nil
 	case schema.Value.Type.Is("object"):
-		resultMap := make(map[string]interface{})
+		resultMap := make(map[string]any)
 		additPropsSchema := schema.Value.AdditionalProperties.Schema
 		pp, _ := deepGet(params, mapKeys...)
-		objectParams, ok := pp.(map[string]interface{})
+		objectParams, ok := pp.(map[string]any)
 		if !ok {
 			// not the expected type, but return it either way and leave validation up to ValidateParameter
 			return pp, nil
@@ -1060,20 +1060,20 @@ func buildResObj(params map[string]interface{}, parentKeys []string, key string,
 }
 
 // buildFromSchemas decodes params with anyOf, oneOf, allOf schemas.
-func buildFromSchemas(schemas openapi3.SchemaRefs, params map[string]interface{}, mapKeys []string, key string) (interface{}, error) {
-	resultMap := make(map[string]interface{})
+func buildFromSchemas(schemas openapi3.SchemaRefs, params map[string]any, mapKeys []string, key string) (any, error) {
+	resultMap := make(map[string]any)
 	for _, s := range schemas {
 		val, err := buildResObj(params, mapKeys, key, s)
 		if err == nil && val != nil {
 
-			if m, ok := val.(map[string]interface{}); ok {
+			if m, ok := val.(map[string]any); ok {
 				for k, v := range m {
 					resultMap[k] = v
 				}
 				continue
 			}
 
-			if a, ok := val.([]interface{}); ok {
+			if a, ok := val.([]any); ok {
 				if len(a) > 0 {
 					return a, nil
 				}
@@ -1099,8 +1099,8 @@ func handlePropParseError(path []string, err error) error {
 	return fmt.Errorf("property %q: %w", strings.Join(path, "."), err)
 }
 
-func pathFromKeys(kk []string) []interface{} {
-	path := make([]interface{}, 0, len(kk))
+func pathFromKeys(kk []string) []any {
+	path := make([]any, 0, len(kk))
 	for _, v := range kk {
 		path = append(path, v)
 	}
@@ -1110,13 +1110,13 @@ func pathFromKeys(kk []string) []interface{} {
 // parseArray returns an array that contains items from a raw array.
 // Every item is parsed as a primitive value.
 // The function returns an error when an error happened while parse array's items.
-func parseArray(raw []string, schemaRef *openapi3.SchemaRef) ([]interface{}, error) {
-	var value []interface{}
+func parseArray(raw []string, schemaRef *openapi3.SchemaRef) ([]any, error) {
+	var value []any
 	for i, v := range raw {
 		item, err := parsePrimitive(v, schemaRef.Value.Items)
 		if err != nil {
 			if v, ok := err.(*ParseError); ok {
-				return nil, &ParseError{path: []interface{}{i}, Cause: v}
+				return nil, &ParseError{path: []any{i}, Cause: v}
 			}
 			return nil, fmt.Errorf("item %d: %w", i, err)
 		}
@@ -1134,7 +1134,7 @@ func parseArray(raw []string, schemaRef *openapi3.SchemaRef) ([]interface{}, err
 // parsePrimitive returns a value that is created by parsing a source string to a primitive type
 // that is specified by a schema. The function returns nil when the source string is empty.
 // The function panics when a schema has a non-primitive type.
-func parsePrimitive(raw string, schema *openapi3.SchemaRef) (v interface{}, err error) {
+func parsePrimitive(raw string, schema *openapi3.SchemaRef) (v any, err error) {
 	if raw == "" {
 		return nil, nil
 	}
@@ -1146,7 +1146,7 @@ func parsePrimitive(raw string, schema *openapi3.SchemaRef) (v interface{}, err 
 	return
 }
 
-func parsePrimitiveCase(raw string, schema *openapi3.SchemaRef, typ string) (interface{}, error) {
+func parsePrimitiveCase(raw string, schema *openapi3.SchemaRef, typ string) (any, error) {
 	switch typ {
 	case "integer":
 		if schema.Value.Format == "int32" {
@@ -1185,7 +1185,7 @@ type EncodingFn func(partName string) *openapi3.Encoding
 
 // BodyDecoder is an interface to decode a body of a request or response.
 // An implementation must return a value that is a primitive, []interface{}, or map[string]interface{}.
-type BodyDecoder func(io.Reader, http.Header, *openapi3.SchemaRef, EncodingFn) (interface{}, error)
+type BodyDecoder func(io.Reader, http.Header, *openapi3.SchemaRef, EncodingFn) (any, error)
 
 // bodyDecoders contains decoders for supported content types of a body.
 // By default, there is content type "application/json" is supported only.
@@ -1233,7 +1233,7 @@ const prefixUnsupportedCT = "unsupported content type"
 // The function returns ParseError when a body is invalid.
 func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (
 	string,
-	interface{},
+	any,
 	error,
 ) {
 	contentType := header.Get(headerCT)
@@ -1271,7 +1271,7 @@ func init() {
 	RegisterBodyDecoder("text/plain", plainBodyDecoder)
 }
 
-func plainBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+func plainBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
 	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, &ParseError{Kind: KindInvalidFormat, Cause: err}
@@ -1281,8 +1281,8 @@ func plainBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Schem
 
 // JSONBodyDecoder decodes a JSON formatted body. It is public so that is easy
 // to register additional JSON based formats.
-func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
-	var value interface{}
+func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
+	var value any
 	dec := json.NewDecoder(body)
 	dec.UseNumber()
 	if err := dec.Decode(&value); err != nil {
@@ -1291,15 +1291,15 @@ func JSONBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Schema
 	return value, nil
 }
 
-func yamlBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
-	var value interface{}
+func yamlBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
+	var value any
 	if err := yaml.NewDecoder(body).Decode(&value); err != nil {
 		return nil, &ParseError{Kind: KindInvalidFormat, Cause: err}
 	}
 	return value, nil
 }
 
-func urlencodedBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+func urlencodedBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
 	// Validate schema of request body.
 	// By the OpenAPI 3 specification request body's schema must have type "object".
 	// Properties of the schema describes individual parts of request body.
@@ -1330,7 +1330,7 @@ func urlencodedBodyDecoder(body io.Reader, header http.Header, schema *openapi3.
 	}
 
 	// Make an object value from form values.
-	obj := make(map[string]interface{})
+	obj := make(map[string]any)
 	dec := &urlValuesDecoder{values: values}
 
 	// Decode schema constructs (allOf, anyOf, oneOf)
@@ -1354,7 +1354,7 @@ func urlencodedBodyDecoder(body io.Reader, header http.Header, schema *openapi3.
 
 // decodeSchemaConstructs tries to decode properties based on provided schemas.
 // This function is for decoding purposes only and not for validation.
-func decodeSchemaConstructs(dec *urlValuesDecoder, schemas []*openapi3.SchemaRef, obj map[string]interface{}, encFn EncodingFn) error {
+func decodeSchemaConstructs(dec *urlValuesDecoder, schemas []*openapi3.SchemaRef, obj map[string]any, encFn EncodingFn) error {
 	for _, schemaRef := range schemas {
 		for name, prop := range schemaRef.Value.Properties {
 			value, _, err := decodeProperty(dec, name, prop, encFn)
@@ -1371,11 +1371,11 @@ func decodeSchemaConstructs(dec *urlValuesDecoder, schemas []*openapi3.SchemaRef
 	return nil
 }
 
-func isEqual(value1, value2 interface{}) bool {
+func isEqual(value1, value2 any) bool {
 	return reflect.DeepEqual(value1, value2)
 }
 
-func decodeProperty(dec valueDecoder, name string, prop *openapi3.SchemaRef, encFn EncodingFn) (interface{}, bool, error) {
+func decodeProperty(dec valueDecoder, name string, prop *openapi3.SchemaRef, encFn EncodingFn) (any, bool, error) {
 	var enc *openapi3.Encoding
 	if encFn != nil {
 		enc = encFn(name)
@@ -1384,13 +1384,13 @@ func decodeProperty(dec valueDecoder, name string, prop *openapi3.SchemaRef, enc
 	return decodeValue(dec, name, sm, prop, false)
 }
 
-func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
 	if !schema.Value.Type.Is("object") {
 		return nil, errors.New("unsupported schema of request body")
 	}
 
 	// Parse form.
-	values := make(map[string][]interface{})
+	values := make(map[string][]any)
 	contentType := header.Get(headerCT)
 	_, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
@@ -1453,10 +1453,10 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 			}
 		}
 
-		var value interface{}
+		var value any
 		if _, value, err = decodeBody(part, http.Header(part.Header), valueSchema, subEncFn); err != nil {
 			if v, ok := err.(*ParseError); ok {
-				return nil, &ParseError{path: []interface{}{name}, Cause: v}
+				return nil, &ParseError{path: []any{name}, Cause: v}
 			}
 			return nil, fmt.Errorf("part %s: %w", name, err)
 		}
@@ -1487,7 +1487,7 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 	}
 
 	// Make an object value from form values.
-	obj := make(map[string]interface{})
+	obj := make(map[string]any)
 	for name, prop := range allTheProperties {
 		vv := values[name]
 		if len(vv) == 0 {
@@ -1504,7 +1504,7 @@ func multipartBodyDecoder(body io.Reader, header http.Header, schema *openapi3.S
 }
 
 // FileBodyDecoder is a body decoder that decodes a file body to a string.
-func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
 	data, err := io.ReadAll(body)
 	if err != nil {
 		return nil, err
@@ -1513,7 +1513,7 @@ func FileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Schema
 }
 
 // zipFileBodyDecoder is a body decoder that decodes a zip file body to a string.
-func zipFileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+func zipFileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
 	buff := bytes.NewBuffer([]byte{})
 	size, err := io.Copy(buff, body)
 	if err != nil {
@@ -1563,7 +1563,7 @@ func zipFileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Sch
 }
 
 // csvBodyDecoder is a body decoder that decodes a csv body to a string.
-func csvBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (interface{}, error) {
+func csvBodyDecoder(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (any, error) {
 	r := csv.NewReader(body)
 
 	var sb strings.Builder

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -991,7 +991,7 @@ func buildResObj(params map[string]any, parentKeys []string, key string, schema 
 		if err != nil {
 			return nil, &ParseError{path: pathFromKeys(mapKeys), Kind: KindInvalidFormat, Reason: fmt.Sprintf("could not convert value map to array: %v", err)}
 		}
-		resultArr := make([]any, len(arr))
+		resultArr := make([]any /*not 0,*/, len(arr))
 		for i := range arr {
 			r, err := buildResObj(params, mapKeys, strconv.Itoa(i), schema.Value.Items)
 			if err != nil {

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -27,7 +27,7 @@ var (
 	arrayOf   = func(items *openapi3.SchemaRef) *openapi3.SchemaRef {
 		return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}, Items: items}}
 	}
-	objectOf = func(args ...interface{}) *openapi3.SchemaRef {
+	objectOf = func(args ...any) *openapi3.SchemaRef {
 		s := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"object"}, Properties: make(map[string]*openapi3.SchemaRef)}}
 		if len(args)%2 != 0 {
 			panic("invalid arguments. must be an even number of arguments")
@@ -118,25 +118,25 @@ var (
 )
 
 func TestDeepGet(t *testing.T) {
-	iarray := map[string]interface{}{
-		"0": map[string]interface{}{
+	iarray := map[string]any{
+		"0": map[string]any{
 			"foo": 111,
 		},
-		"1": map[string]interface{}{
+		"1": map[string]any{
 			"bar": 222,
 		},
 	}
 
 	tests := []struct {
 		name       string
-		m          map[string]interface{}
+		m          map[string]any
 		keys       []string
-		expected   interface{}
+		expected   any
 		shouldFind bool
 	}{
 		{
 			name: "Simple map - key exists",
-			m: map[string]interface{}{
+			m: map[string]any{
 				"foo": "bar",
 			},
 			keys:       []string{"foo"},
@@ -145,8 +145,8 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Nested map - key exists",
-			m: map[string]interface{}{
-				"foo": map[string]interface{}{
+			m: map[string]any{
+				"foo": map[string]any{
 					"bar": "baz",
 				},
 			},
@@ -156,8 +156,8 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Nested map - key does not exist",
-			m: map[string]interface{}{
-				"foo": map[string]interface{}{
+			m: map[string]any{
+				"foo": map[string]any{
 					"bar": "baz",
 				},
 			},
@@ -167,8 +167,8 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Array - element exists",
-			m: map[string]interface{}{
-				"array": map[string]interface{}{"0": "a", "1": "b", "2": "c"},
+			m: map[string]any{
+				"array": map[string]any{"0": "a", "1": "b", "2": "c"},
 			},
 			keys:       []string{"array", "1"},
 			expected:   "b",
@@ -176,8 +176,8 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Array - element does not exist - invalid index",
-			m: map[string]interface{}{
-				"array": map[string]interface{}{"0": "a", "1": "b", "2": "c"},
+			m: map[string]any{
+				"array": map[string]any{"0": "a", "1": "b", "2": "c"},
 			},
 			keys:       []string{"array", "3"},
 			expected:   nil,
@@ -185,8 +185,8 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Array - element does not exist - invalid keys",
-			m: map[string]interface{}{
-				"array": map[string]interface{}{"0": "a", "1": "b", "2": "c"},
+			m: map[string]any{
+				"array": map[string]any{"0": "a", "1": "b", "2": "c"},
 			},
 			keys:       []string{"array", "a", "999"},
 			expected:   nil,
@@ -194,7 +194,7 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Array of objects - element exists 1",
-			m: map[string]interface{}{
+			m: map[string]any{
 				"array": iarray,
 			},
 			keys:       []string{"array", "1", "bar"},
@@ -203,18 +203,18 @@ func TestDeepGet(t *testing.T) {
 		},
 		{
 			name: "Array of objects - element exists 2",
-			m: map[string]interface{}{
+			m: map[string]any{
 				"array": iarray,
 			},
 			keys: []string{"array", "0"},
-			expected: map[string]interface{}{
+			expected: map[string]any{
 				"foo": 111,
 			},
 			shouldFind: true,
 		},
 		{
 			name: "Array of objects - element exists 3",
-			m: map[string]interface{}{
+			m: map[string]any{
 				"array": iarray,
 			},
 			keys:       []string{"array"},
@@ -237,26 +237,26 @@ func TestDeepGet(t *testing.T) {
 func TestDeepSet(t *testing.T) {
 	tests := []struct {
 		name     string
-		inputMap map[string]interface{}
+		inputMap map[string]any
 		keys     []string
-		value    interface{}
-		expected map[string]interface{}
+		value    any
+		expected map[string]any
 	}{
 		{
 			name:     "simple set",
-			inputMap: map[string]interface{}{},
+			inputMap: map[string]any{},
 			keys:     []string{"key"},
 			value:    "value",
-			expected: map[string]interface{}{"key": "value"},
+			expected: map[string]any{"key": "value"},
 		},
 		{
 			name:     "intermediate array of objects",
-			inputMap: map[string]interface{}{},
+			inputMap: map[string]any{},
 			keys:     []string{"nested", "0", "key"},
 			value:    true,
-			expected: map[string]interface{}{
-				"nested": map[string]interface{}{
-					"0": map[string]interface{}{
+			expected: map[string]any{
+				"nested": map[string]any{
+					"0": map[string]any{
 						"key": true,
 					},
 				},
@@ -264,12 +264,12 @@ func TestDeepSet(t *testing.T) {
 		},
 		{
 			name:     "existing nested array of objects",
-			inputMap: map[string]interface{}{"nested": map[string]interface{}{"0": map[string]interface{}{"existingKey": "existingValue"}}},
+			inputMap: map[string]any{"nested": map[string]any{"0": map[string]any{"existingKey": "existingValue"}}},
 			keys:     []string{"nested", "0", "newKey"},
 			value:    "newValue",
-			expected: map[string]interface{}{
-				"nested": map[string]interface{}{
-					"0": map[string]interface{}{
+			expected: map[string]any{
+				"nested": map[string]any{
+					"0": map[string]any{
 						"existingKey": "existingValue",
 						"newKey":      "newValue",
 					},
@@ -294,7 +294,7 @@ func TestDecodeParameter(t *testing.T) {
 		query  string
 		header string
 		cookie string
-		want   interface{}
+		want   any
 		found  bool
 		err    error
 	}
@@ -441,21 +441,21 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "simple",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "simple", Explode: noExplode, Schema: stringArraySchema},
 					path:  "/foo,bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "simple explode",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "simple", Explode: explode, Schema: stringArraySchema},
 					path:  "/foo,bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "label",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "label", Explode: noExplode, Schema: stringArraySchema},
 					path:  "/.foo,bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
@@ -469,7 +469,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "label explode",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "label", Explode: explode, Schema: stringArraySchema},
 					path:  "/.foo.bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
@@ -483,7 +483,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "matrix",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "matrix", Explode: noExplode, Schema: stringArraySchema},
 					path:  "/;param=foo,bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
@@ -497,7 +497,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "matrix explode",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "matrix", Explode: explode, Schema: stringArraySchema},
 					path:  "/;param=foo;param=bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
@@ -511,7 +511,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "default",
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: stringArraySchema},
 					path:  "/foo,bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
@@ -519,21 +519,21 @@ func TestDecodeParameter(t *testing.T) {
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: arrayOf(integerSchema)},
 					path:  "/1,foo",
 					found: true,
-					err:   &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:   &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:  "invalid number items",
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: arrayOf(numberSchema)},
 					path:  "/1.1,foo",
 					found: true,
-					err:   &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:   &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:  "invalid boolean items",
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: arrayOf(booleanSchema)},
 					path:  "/true,foo",
 					found: true,
-					err:   &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:   &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 			},
 		},
@@ -544,21 +544,21 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "simple",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "simple", Explode: noExplode, Schema: objectSchema},
 					path:  "/id,foo,name,bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
 					name:  "simple explode",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "simple", Explode: explode, Schema: objectSchema},
 					path:  "/id=foo,name=bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
 					name:  "label",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "label", Explode: noExplode, Schema: objectSchema},
 					path:  "/.id,foo,name,bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -572,7 +572,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "label explode",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "label", Explode: explode, Schema: objectSchema},
 					path:  "/.id=foo.name=bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -586,7 +586,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "matrix",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "matrix", Explode: noExplode, Schema: objectSchema},
 					path:  "/;param=id,foo,name,bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -600,7 +600,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "matrix explode",
 					param: &openapi3.Parameter{Name: "param", In: "path", Style: "matrix", Explode: explode, Schema: objectSchema},
 					path:  "/;id=foo;name=bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -614,7 +614,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "default",
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: objectSchema},
 					path:  "/id,foo,name,bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -622,21 +622,21 @@ func TestDecodeParameter(t *testing.T) {
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: objectOf("foo", integerSchema)},
 					path:  "/foo,bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:   &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:  "invalid number prop",
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: objectOf("foo", numberSchema)},
 					path:  "/foo,bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:   &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:  "invalid boolean prop",
 					param: &openapi3.Parameter{Name: "param", In: "path", Schema: objectOf("foo", booleanSchema)},
 					path:  "/foo,bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:   &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 			},
 		},
@@ -786,49 +786,49 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "form",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "form", Explode: noExplode, Schema: stringArraySchema},
 					query: "param=foo,bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "form explode",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "form", Explode: explode, Schema: stringArraySchema},
 					query: "param=foo&param=bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "spaceDelimited",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "spaceDelimited", Explode: noExplode, Schema: stringArraySchema},
 					query: "param=foo bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "spaceDelimited explode",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "spaceDelimited", Explode: explode, Schema: stringArraySchema},
 					query: "param=foo&param=bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "pipeDelimited",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "pipeDelimited", Explode: noExplode, Schema: stringArraySchema},
 					query: "param=foo|bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "pipeDelimited explode",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "pipeDelimited", Explode: explode, Schema: stringArraySchema},
 					query: "param=foo&param=bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
 					name:  "default",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: stringArraySchema},
 					query: "param=foo&param=bar",
-					want:  []interface{}{"foo", "bar"},
+					want:  []any{"foo", "bar"},
 					found: true,
 				},
 				{
@@ -836,21 +836,21 @@ func TestDecodeParameter(t *testing.T) {
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: arrayOf(integerSchema)},
 					query: "param=1&param=foo",
 					found: true,
-					err:   &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:   &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:  "invalid number items",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: arrayOf(numberSchema)},
 					query: "param=1.1&param=foo",
 					found: true,
-					err:   &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:   &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:  "invalid boolean items",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: arrayOf(booleanSchema)},
 					query: "param=true&param=foo",
 					found: true,
-					err:   &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:   &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 			},
 		},
@@ -861,21 +861,21 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "form",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "form", Explode: noExplode, Schema: objectSchema},
 					query: "param=id,foo,name,bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
 					name:  "form explode",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "form", Explode: explode, Schema: objectSchema},
 					query: "id=foo&name=bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
 					name:  "deepObject explode",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "deepObject", Explode: explode, Schema: objectSchema},
 					query: "param[id]=foo&param[name]=bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -888,20 +888,20 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][prop2][item2]=def",
-					err:   &ParseError{path: []interface{}{"obj", "prop2", "item2"}, Kind: KindInvalidFormat, Reason: "array items must be set with indexes"},
+					err:   &ParseError{path: []any{"obj", "prop2", "item2"}, Kind: KindInvalidFormat, Reason: "array items must be set with indexes"},
 				},
 				{
 					name:  "deepObject explode array - missing indexes",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "deepObject", Explode: explode, Schema: objectOf("items", stringArraySchema)},
 					query: "param[items]=f%26oo&param[items]=bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"items"}, Kind: KindInvalidFormat, Reason: "array items must be set with indexes"},
+					err:   &ParseError{path: []any{"items"}, Kind: KindInvalidFormat, Reason: "array items must be set with indexes"},
 				},
 				{
 					name:  "deepObject explode array",
 					param: &openapi3.Parameter{Name: "param", In: "query", Style: "deepObject", Explode: explode, Schema: objectOf("items", integerArraySchema)},
 					query: "param[items][1]=456&param[items][0]=123",
-					want:  map[string]interface{}{"items": []interface{}{int64(123), int64(456)}},
+					want:  map[string]any{"items": []any{int64(123), int64(456)}},
 					found: true,
 				},
 				{
@@ -915,8 +915,8 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][prop1]=bar&param[obj][prop2]=foo&param[objTwo]=string",
-					want: map[string]interface{}{
-						"obj":    map[string]interface{}{"prop1": "bar", "prop2": "foo"},
+					want: map[string]any{
+						"obj":    map[string]any{"prop1": "bar", "prop2": "foo"},
 						"objTwo": "string",
 					},
 					found: true,
@@ -931,8 +931,8 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][prop1][item1]=1&param[obj][prop1][item2]=abc",
-					want: map[string]interface{}{
-						"obj": map[string]interface{}{"prop1": map[string]interface{}{
+					want: map[string]any{
+						"obj": map[string]any{"prop1": map[string]any{
 							"item1": int64(1),
 							"item2": "abc",
 						}},
@@ -950,7 +950,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][prop1]=notbool&param[objTwo]=string",
-					err:   &ParseError{path: []interface{}{"obj", "prop1"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "notbool"}},
+					err:   &ParseError{path: []any{"obj", "prop1"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "notbool"}},
 				},
 				{
 					name: "deepObject explode nested object additionalProperties - bad index inside additionalProperties",
@@ -964,10 +964,10 @@ func TestDecodeParameter(t *testing.T) {
 					},
 					query: "param[obj][prop1]=bar&param[obj][prop2][badindex]=bad&param[objTwo]=string",
 					err: &ParseError{
-						path:   []interface{}{"obj", "prop2"},
+						path:   []any{"obj", "prop2"},
 						Reason: `path is not convertible to primitive`,
 						Kind:   KindInvalidFormat,
-						Value:  map[string]interface{}{"badindex": "bad"},
+						Value:  map[string]any{"badindex": "bad"},
 					},
 				},
 				{
@@ -981,8 +981,8 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne]=bar&param[obj][nestedObjTwo]=foo&param[objTwo]=string",
-					want: map[string]interface{}{
-						"obj":    map[string]interface{}{"nestedObjOne": "bar", "nestedObjTwo": "foo"},
+					want: map[string]any{
+						"obj":    map[string]any{"nestedObjOne": "bar", "nestedObjTwo": "foo"},
 						"objTwo": "string",
 					},
 					found: true,
@@ -996,7 +996,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "anotherparam=bar",
-					want:  map[string]interface{}(nil),
+					want:  map[string]any(nil),
 				},
 				{
 					name: "deepObject explode nested object - extraneous deep object param ignored",
@@ -1007,7 +1007,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "anotherparam[obj][nestedObjOne]=one&anotherparam[obj][nestedObjTwo]=two",
-					want:  map[string]interface{}(nil),
+					want:  map[string]any(nil),
 				},
 				{
 					name: "deepObject explode nested object - bad array item type",
@@ -1018,7 +1018,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[objTwo][0]=badint",
-					err:   &ParseError{path: []interface{}{"objTwo", "0"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "badint"}},
+					err:   &ParseError{path: []any{"objTwo", "0"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "badint"}},
 				},
 				{
 					name: "deepObject explode deeply nested object - bad array item type",
@@ -1029,7 +1029,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne][0]=badint",
-					err:   &ParseError{path: []interface{}{"obj", "nestedObjOne", "0"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "badint"}},
+					err:   &ParseError{path: []any{"obj", "nestedObjOne", "0"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "badint"}},
 				},
 				{
 					name: "deepObject explode deeply nested object - array index not an int",
@@ -1040,7 +1040,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne][badindex]=badint",
-					err:   &ParseError{path: []interface{}{"obj", "nestedObjOne"}, Kind: KindInvalidFormat, Reason: "could not convert value map to array: array indexes must be integers: strconv.Atoi: parsing \"badindex\": invalid syntax"},
+					err:   &ParseError{path: []any{"obj", "nestedObjOne"}, Kind: KindInvalidFormat, Reason: "could not convert value map to array: array indexes must be integers: strconv.Atoi: parsing \"badindex\": invalid syntax"},
 				},
 				{
 					name: "deepObject explode nested object with array",
@@ -1053,9 +1053,9 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne]=bar&param[obj][nestedObjTwo]=foo&param[objTwo][0]=f%26oo&param[objTwo][1]=bar",
-					want: map[string]interface{}{
-						"obj":    map[string]interface{}{"nestedObjOne": "bar", "nestedObjTwo": "foo"},
-						"objTwo": []interface{}{"f%26oo", "bar"},
+					want: map[string]any{
+						"obj":    map[string]any{"nestedObjOne": "bar", "nestedObjTwo": "foo"},
+						"objTwo": []any{"f%26oo", "bar"},
 					},
 					found: true,
 				},
@@ -1070,7 +1070,7 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne]=bar&param[obj][nestedObjTwo]=bad&param[objTwo][0]=f%26oo&param[objTwo][1]=bar",
-					err:   &ParseError{path: []interface{}{"obj", "nestedObjTwo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bad"}},
+					err:   &ParseError{path: []any{"obj", "nestedObjTwo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bad"}},
 				},
 				{
 					name: "deepObject explode nested object with nested array",
@@ -1083,9 +1083,9 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne]=bar&param[obj][nestedObjTwo]=foo&param[objTwo][items][0]=f%26oo&param[objTwo][items][1]=bar",
-					want: map[string]interface{}{
-						"obj":    map[string]interface{}{"nestedObjOne": "bar", "nestedObjTwo": "foo"},
-						"objTwo": map[string]interface{}{"items": []interface{}{"f%26oo", "bar"}},
+					want: map[string]any{
+						"obj":    map[string]any{"nestedObjOne": "bar", "nestedObjTwo": "foo"},
+						"objTwo": map[string]any{"items": []any{"f%26oo", "bar"}},
 					},
 					found: true,
 				},
@@ -1099,9 +1099,9 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[obj][nestedObjOne][items][0]=baz&param[objTwo][items][0]=foo&param[objTwo][items][1]=bar",
-					want: map[string]interface{}{
-						"obj":    map[string]interface{}{"nestedObjOne": map[string]interface{}{"items": []interface{}{"baz"}}},
-						"objTwo": map[string]interface{}{"items": []interface{}{"foo", "bar"}},
+					want: map[string]any{
+						"obj":    map[string]any{"nestedObjOne": map[string]any{"items": []any{"baz"}}},
+						"objTwo": map[string]any{"items": []any{"foo", "bar"}},
 					},
 					found: true,
 				},
@@ -1114,10 +1114,10 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[arr][1][1]=123&param[arr][1][2]=456",
-					want: map[string]interface{}{
-						"arr": []interface{}{
+					want: map[string]any{
+						"arr": []any{
 							nil,
-							[]interface{}{nil, int64(123), int64(456)},
+							[]any{nil, int64(123), int64(456)},
 						},
 					},
 					found: true,
@@ -1131,12 +1131,12 @@ func TestDecodeParameter(t *testing.T) {
 						),
 					},
 					query: "param[arr][3][key]=true&param[arr][0][key]=false",
-					want: map[string]interface{}{
-						"arr": []interface{}{
-							map[string]interface{}{"key": false},
+					want: map[string]any{
+						"arr": []any{
+							map[string]any{"key": false},
 							nil,
 							nil,
-							map[string]interface{}{"key": true},
+							map[string]any{"key": true},
 						},
 					},
 					found: true,
@@ -1151,10 +1151,10 @@ func TestDecodeParameter(t *testing.T) {
 					},
 					query: "param[arr][0][key]=true&param[arr][1][key]=false",
 					found: true,
-					want: map[string]interface{}{
-						"arr": []interface{}{
-							map[string]interface{}{"key": true},
-							map[string]interface{}{"key": false},
+					want: map[string]any{
+						"arr": []any{
+							map[string]any{"key": true},
+							map[string]any{"key": false},
 						},
 					},
 				},
@@ -1162,7 +1162,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:  "default",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: objectSchema},
 					query: "id=foo&name=bar",
-					want:  map[string]interface{}{"id": "foo", "name": "bar"},
+					want:  map[string]any{"id": "foo", "name": "bar"},
 					found: true,
 				},
 				{
@@ -1170,21 +1170,21 @@ func TestDecodeParameter(t *testing.T) {
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: objectOf("foo", integerSchema)},
 					query: "foo=bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:   &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:  "invalid number prop",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: objectOf("foo", numberSchema)},
 					query: "foo=bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:   &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:  "invalid boolean prop",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: objectOf("foo", booleanSchema)},
 					query: "foo=bar",
 					found: true,
-					err:   &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:   &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 			},
 		},
@@ -1270,21 +1270,21 @@ func TestDecodeParameter(t *testing.T) {
 					name:   "simple",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Style: "simple", Explode: noExplode, Schema: stringArraySchema},
 					header: "X-Param:foo,bar",
-					want:   []interface{}{"foo", "bar"},
+					want:   []any{"foo", "bar"},
 					found:  true,
 				},
 				{
 					name:   "simple explode",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Style: "simple", Explode: explode, Schema: stringArraySchema},
 					header: "X-Param:foo,bar",
-					want:   []interface{}{"foo", "bar"},
+					want:   []any{"foo", "bar"},
 					found:  true,
 				},
 				{
 					name:   "default",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: stringArraySchema},
 					header: "X-Param:foo,bar",
-					want:   []interface{}{"foo", "bar"},
+					want:   []any{"foo", "bar"},
 					found:  true,
 				},
 				{
@@ -1292,21 +1292,21 @@ func TestDecodeParameter(t *testing.T) {
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: arrayOf(integerSchema)},
 					header: "X-Param:1,foo",
 					found:  true,
-					err:    &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:    &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:   "invalid number items",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: arrayOf(numberSchema)},
 					header: "X-Param:1.1,foo",
 					found:  true,
-					err:    &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:    &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:   "invalid boolean items",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: arrayOf(booleanSchema)},
 					header: "X-Param:true,foo",
 					found:  true,
-					err:    &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:    &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 			},
 		},
@@ -1317,21 +1317,21 @@ func TestDecodeParameter(t *testing.T) {
 					name:   "simple",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Style: "simple", Explode: noExplode, Schema: objectSchema},
 					header: "X-Param:id,foo,name,bar",
-					want:   map[string]interface{}{"id": "foo", "name": "bar"},
+					want:   map[string]any{"id": "foo", "name": "bar"},
 					found:  true,
 				},
 				{
 					name:   "simple explode",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Style: "simple", Explode: explode, Schema: objectSchema},
 					header: "X-Param:id=foo,name=bar",
-					want:   map[string]interface{}{"id": "foo", "name": "bar"},
+					want:   map[string]any{"id": "foo", "name": "bar"},
 					found:  true,
 				},
 				{
 					name:   "default",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: objectSchema},
 					header: "X-Param:id,foo,name,bar",
-					want:   map[string]interface{}{"id": "foo", "name": "bar"},
+					want:   map[string]any{"id": "foo", "name": "bar"},
 					found:  true,
 				},
 				{
@@ -1346,21 +1346,21 @@ func TestDecodeParameter(t *testing.T) {
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: objectOf("foo", integerSchema)},
 					header: "X-Param:foo,bar",
 					found:  true,
-					err:    &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:    &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:   "invalid number prop",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: objectOf("foo", numberSchema)},
 					header: "X-Param:foo,bar",
 					found:  true,
-					err:    &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:    &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:   "invalid boolean prop",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "header", Schema: objectOf("foo", booleanSchema)},
 					header: "X-Param:foo,bar",
 					found:  true,
-					err:    &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:    &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 			},
 		},
@@ -1446,7 +1446,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:   "form",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: stringArraySchema},
 					cookie: "X-Param:foo,bar",
-					want:   []interface{}{"foo", "bar"},
+					want:   []any{"foo", "bar"},
 					found:  true,
 				},
 				{
@@ -1454,21 +1454,21 @@ func TestDecodeParameter(t *testing.T) {
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: arrayOf(integerSchema)},
 					cookie: "X-Param:1,foo",
 					found:  true,
-					err:    &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:    &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:   "invalid number items",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: arrayOf(numberSchema)},
 					cookie: "X-Param:1.1,foo",
 					found:  true,
-					err:    &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:    &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 				{
 					name:   "invalid boolean items",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: arrayOf(booleanSchema)},
 					cookie: "X-Param:true,foo",
 					found:  true,
-					err:    &ParseError{path: []interface{}{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
+					err:    &ParseError{path: []any{1}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "foo"}},
 				},
 			},
 		},
@@ -1479,7 +1479,7 @@ func TestDecodeParameter(t *testing.T) {
 					name:   "form",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: objectSchema},
 					cookie: "X-Param:id,foo,name,bar",
-					want:   map[string]interface{}{"id": "foo", "name": "bar"},
+					want:   map[string]any{"id": "foo", "name": "bar"},
 					found:  true,
 				},
 				{
@@ -1487,21 +1487,21 @@ func TestDecodeParameter(t *testing.T) {
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: objectOf("foo", integerSchema)},
 					cookie: "X-Param:foo,bar",
 					found:  true,
-					err:    &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:    &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:   "invalid number prop",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: objectOf("foo", numberSchema)},
 					cookie: "X-Param:foo,bar",
 					found:  true,
-					err:    &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:    &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 				{
 					name:   "invalid boolean prop",
 					param:  &openapi3.Parameter{Name: "X-Param", In: "cookie", Style: "form", Explode: noExplode, Schema: objectOf("foo", booleanSchema)},
 					cookie: "X-Param:foo,bar",
 					found:  true,
-					err:    &ParseError{path: []interface{}{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
+					err:    &ParseError{path: []any{"foo"}, Cause: &ParseError{Kind: KindInvalidFormat, Value: "bar"}},
 				},
 			},
 		},
@@ -1595,7 +1595,7 @@ func TestDecodeBody(t *testing.T) {
 	urlencodedPipeDelim.Set("b", "10")
 	urlencodedPipeDelim.Add("c", "c1|c2")
 
-	d, err := json.Marshal(map[string]interface{}{"d1": "d1"})
+	d, err := json.Marshal(map[string]any{"d1": "d1"})
 	require.NoError(t, err)
 	multipartForm, multipartFormMime, err := newTestMultipartForm([]*testFormPart{
 		{name: "a", contentType: "text/plain", data: strings.NewReader("a1")},
@@ -1639,7 +1639,7 @@ func TestDecodeBody(t *testing.T) {
 		body     io.Reader
 		schema   *openapi3.Schema
 		encoding map[string]*openapi3.Encoding
-		want     interface{}
+		want     any
 		wantErr  error
 	}{
 		{
@@ -1685,7 +1685,7 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("a", openapi3.NewStringSchema()).
 				WithProperty("b", openapi3.NewIntegerSchema()).
 				WithProperty("c", openapi3.NewArraySchema().WithItems(openapi3.NewStringSchema())),
-			want: map[string]interface{}{"a": "a1", "b": int64(10), "c": []interface{}{"c1", "c2"}},
+			want: map[string]any{"a": "a1", "b": int64(10), "c": []any{"c1", "c2"}},
 		},
 		{
 			name: "urlencoded space delimited",
@@ -1698,7 +1698,7 @@ func TestDecodeBody(t *testing.T) {
 			encoding: map[string]*openapi3.Encoding{
 				"c": {Style: openapi3.SerializationSpaceDelimited, Explode: openapi3.BoolPtr(false)},
 			},
-			want: map[string]interface{}{"a": "a1", "b": int64(10), "c": []interface{}{"c1", "c2"}},
+			want: map[string]any{"a": "a1", "b": int64(10), "c": []any{"c1", "c2"}},
 		},
 		{
 			name: "urlencoded pipe delimited",
@@ -1711,7 +1711,7 @@ func TestDecodeBody(t *testing.T) {
 			encoding: map[string]*openapi3.Encoding{
 				"c": {Style: openapi3.SerializationPipeDelimited, Explode: openapi3.BoolPtr(false)},
 			},
-			want: map[string]interface{}{"a": "a1", "b": int64(10), "c": []interface{}{"c1", "c2"}},
+			want: map[string]any{"a": "a1", "b": int64(10), "c": []any{"c1", "c2"}},
 		},
 		{
 			name: "multipart",
@@ -1724,7 +1724,7 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("d", openapi3.NewObjectSchema().WithProperty("d1", openapi3.NewStringSchema())).
 				WithProperty("f", openapi3.NewStringSchema().WithFormat("binary")).
 				WithProperty("g", openapi3.NewStringSchema()),
-			want: map[string]interface{}{"a": "a1", "b": json.Number("10"), "c": []interface{}{"c1", "c2"}, "d": map[string]interface{}{"d1": "d1"}, "f": "foo", "g": "g1"},
+			want: map[string]any{"a": "a1", "b": json.Number("10"), "c": []any{"c1", "c2"}, "d": map[string]any{"d1": "d1"}, "f": "foo", "g": "g1"},
 		},
 		{
 			name: "multipartExtraPart",
@@ -1732,7 +1732,7 @@ func TestDecodeBody(t *testing.T) {
 			body: multipartFormExtraPart,
 			schema: openapi3.NewObjectSchema().
 				WithProperty("a", openapi3.NewStringSchema()),
-			want:    map[string]interface{}{"a": "a1"},
+			want:    map[string]any{"a": "a1"},
 			wantErr: &ParseError{Kind: KindOther},
 		},
 		{
@@ -1742,7 +1742,7 @@ func TestDecodeBody(t *testing.T) {
 			schema: openapi3.NewObjectSchema().
 				WithAnyAdditionalProperties().
 				WithProperty("a", openapi3.NewStringSchema()),
-			want: map[string]interface{}{"a": "a1"},
+			want: map[string]any{"a": "a1"},
 		},
 		{
 			name: "multipartWithAdditionalProperties",
@@ -1752,7 +1752,7 @@ func TestDecodeBody(t *testing.T) {
 				WithAdditionalProperties(openapi3.NewObjectSchema().
 					WithProperty("x", openapi3.NewStringSchema())).
 				WithProperty("a", openapi3.NewStringSchema()),
-			want: map[string]interface{}{"a": "a1", "x": "x1"},
+			want: map[string]any{"a": "a1", "x": "x1"},
 		},
 		{
 			name: "multipartWithAdditionalPropertiesError",
@@ -1762,7 +1762,7 @@ func TestDecodeBody(t *testing.T) {
 				WithAdditionalProperties(openapi3.NewObjectSchema().
 					WithProperty("x", openapi3.NewStringSchema())).
 				WithProperty("a", openapi3.NewStringSchema()),
-			want:    map[string]interface{}{"a": "a1", "x": "x1"},
+			want:    map[string]any{"a": "a1", "x": "x1"},
 			wantErr: &ParseError{Kind: KindOther},
 		},
 		{
@@ -1836,7 +1836,7 @@ func newTestMultipartForm(parts []*testFormPart) (io.Reader, string, error) {
 
 func TestRegisterAndUnregisterBodyDecoder(t *testing.T) {
 	var decoder BodyDecoder
-	decoder = func(body io.Reader, h http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (decoded interface{}, err error) {
+	decoder = func(body io.Reader, h http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (decoded any, err error) {
 		var data []byte
 		if data, err = io.ReadAll(body); err != nil {
 			return

--- a/openapi3filter/req_resp_encoder.go
+++ b/openapi3filter/req_resp_encoder.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-func encodeBody(body interface{}, mediaType string) ([]byte, error) {
+func encodeBody(body any, mediaType string) ([]byte, error) {
 	if encoder := RegisteredBodyEncoder(mediaType); encoder != nil {
 		return encoder(body)
 	}
@@ -17,7 +17,7 @@ func encodeBody(body interface{}, mediaType string) ([]byte, error) {
 }
 
 // BodyEncoder really is an (encoding/json).Marshaler
-type BodyEncoder func(body interface{}) ([]byte, error)
+type BodyEncoder func(body any) ([]byte, error)
 
 var bodyEncodersM sync.RWMutex
 var bodyEncoders = map[string]BodyEncoder{

--- a/openapi3filter/req_resp_encoder_test.go
+++ b/openapi3filter/req_resp_encoder_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestRegisterAndUnregisterBodyEncoder(t *testing.T) {
 	var encoder BodyEncoder
-	encoder = func(body interface{}) (data []byte, err error) {
+	encoder = func(body any) (data []byte, err error) {
 		return []byte(strings.Join(body.([]string), ",")), nil
 	}
 	contentType := "text/csv"

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -121,7 +121,7 @@ func ValidateParameter(ctx context.Context, input *RequestValidationInput, param
 		options = &Options{}
 	}
 
-	var value interface{}
+	var value any
 	var err error
 	var found bool
 	var schema *openapi3.Schema

--- a/openapi3filter/validate_request_input.go
+++ b/openapi3filter/validate_request_input.go
@@ -17,7 +17,7 @@ import (
 // If a query parameter appears multiple times, values[] will have more
 // than one  value, but for all other parameter types it should have just
 // one.
-type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (interface{}, *openapi3.Schema, error)
+type ContentParameterDecoder func(param *openapi3.Parameter, values []string) (any, *openapi3.Schema, error)
 
 type RequestValidationInput struct {
 	Request      *http.Request

--- a/openapi3filter/validate_request_test.go
+++ b/openapi3filter/validate_request_test.go
@@ -228,7 +228,7 @@ func TestValidateQueryParams(t *testing.T) {
 		name  string
 		param *openapi3.Parameter
 		query string
-		want  map[string]interface{}
+		want  map[string]any
 		err   *openapi3.SchemaError // test ParseError in decoder tests
 	}
 
@@ -267,9 +267,9 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj][prop1][inexistent]=1",
-			want: map[string]interface{}{
-				"obj": map[string]interface{}{
-					"prop1": map[string]interface{}{},
+			want: map[string]any{
+				"obj": map[string]any{
+					"prop1": map[string]any{},
 				},
 			},
 		},
@@ -286,9 +286,9 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj][prop1][item1]=1.123",
-			want: map[string]interface{}{
-				"obj": map[string]interface{}{
-					"prop1": map[string]interface{}{
+			want: map[string]any{
+				"obj": map[string]any{
+					"prop1": map[string]any{
 						"item1": float64(1.123),
 					},
 				},
@@ -316,7 +316,7 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "anotherparam=bar",
-			want:  map[string]interface{}(nil),
+			want:  map[string]any(nil),
 		},
 		{
 			name: "deepObject explode additionalProperties with object properties - multiple properties",
@@ -328,15 +328,15 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj][prop1][item1]=1&param[obj][prop1][item2][0]=abc&param[obj][prop2][item1]=2&param[obj][prop2][item2][0]=def",
-			want: map[string]interface{}{
-				"obj": map[string]interface{}{
-					"prop1": map[string]interface{}{
+			want: map[string]any{
+				"obj": map[string]any{
+					"prop1": map[string]any{
 						"item1": int64(1),
-						"item2": []interface{}{"abc"},
+						"item2": []any{"abc"},
 					},
-					"prop2": map[string]interface{}{
+					"prop2": map[string]any{
 						"item1": int64(2),
-						"item2": []interface{}{"def"},
+						"item2": []any{"def"},
 					},
 				},
 			},
@@ -353,7 +353,7 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj]=1",
-			want: map[string]interface{}{
+			want: map[string]any{
 				"obj": int64(1),
 			},
 		},
@@ -366,7 +366,7 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj]=1",
-			want: map[string]interface{}{
+			want: map[string]any{
 				"obj": int64(1),
 			},
 		},
@@ -379,7 +379,7 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj]=true",
-			want: map[string]interface{}{
+			want: map[string]any{
 				"obj": true,
 			},
 		},
@@ -392,8 +392,8 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj][id2]=1&param[obj][name2]=abc",
-			want: map[string]interface{}{
-				"obj": map[string]interface{}{
+			want: map[string]any{
+				"obj": map[string]any{
 					"id2":   "1",
 					"name2": "abc",
 				},
@@ -410,7 +410,7 @@ func TestValidateQueryParams(t *testing.T) {
 			query: "param[obj][id]=1&param[obj][id2]=2",
 			err: &openapi3.SchemaError{
 				SchemaField: "oneOf",
-				Value:       map[string]interface{}{"id": "1", "id2": "2"},
+				Value:       map[string]any{"id": "1", "id2": "2"},
 				Reason:      "value matches more than one schema from \"oneOf\" (matches schemas at indices [0 1])",
 				Schema:      oneofSchemaObject.Value,
 			},
@@ -424,8 +424,8 @@ func TestValidateQueryParams(t *testing.T) {
 				),
 			},
 			query: "param[obj][0]=a&param[obj][1]=b",
-			want: map[string]interface{}{
-				"obj": []interface{}{
+			want: map[string]any{
+				"obj": []any{
 					"a",
 					"b",
 				},

--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -162,7 +162,7 @@ func ValidateResponse(ctx context.Context, input *ResponseValidationInput) error
 
 func validateResponseHeader(headerName string, headerRef *openapi3.HeaderRef, input *ResponseValidationInput, opts []openapi3.SchemaValidationOption) error {
 	var err error
-	var decodedValue interface{}
+	var decodedValue any
 	var found bool
 	var sm *openapi3.SerializationMethod
 	dec := &headerParamDecoder{header: input.Header}

--- a/openapi3filter/validation_error_test.go
+++ b/openapi3filter/validation_error_test.go
@@ -43,14 +43,14 @@ type validationTest struct {
 	wantErrReason             string
 	wantErrSchemaReason       string
 	wantErrSchemaPath         string
-	wantErrSchemaValue        interface{}
+	wantErrSchemaValue        any
 	wantErrSchemaOriginReason string
 	wantErrSchemaOriginPath   string
-	wantErrSchemaOriginValue  interface{}
+	wantErrSchemaOriginValue  any
 	wantErrParam              string
 	wantErrParamIn            string
 	wantErrParseKind          ParseErrorKind
-	wantErrParseValue         interface{}
+	wantErrParseValue         any
 	wantErrParseReason        string
 	wantErrResponse           *ValidationError
 }

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -23,13 +23,13 @@ type ExampleRequest struct {
 	Method      string
 	URL         string
 	ContentType string
-	Body        interface{}
+	Body        any
 }
 
 type ExampleResponse struct {
 	Status      int
 	ContentType string
-	Body        interface{}
+	Body        any
 }
 
 type ExampleSecurityScheme struct {
@@ -333,8 +333,8 @@ func TestFilter(t *testing.T) {
 	require.IsType(t, &RequestError{}, err)
 
 	// Now, repeat the above two test cases using a custom parameter decoder.
-	customDecoder := func(param *openapi3.Parameter, values []string) (interface{}, *openapi3.Schema, error) {
-		var value interface{}
+	customDecoder := func(param *openapi3.Parameter, values []string) (any, *openapi3.Schema, error) {
+		var value any
 		err := json.Unmarshal([]byte(values[0]), &value)
 		schema := param.Content.Get("application/something_funny").Schema.Value
 		return value, schema, err
@@ -356,7 +356,7 @@ func TestFilter(t *testing.T) {
 	require.IsType(t, &RequestError{}, err)
 }
 
-func marshalReader(value interface{}) io.ReadCloser {
+func marshalReader(value any) io.ReadCloser {
 	if value == nil {
 		return nil
 	}
@@ -464,7 +464,7 @@ func matchReqBodyError(want, got error) bool {
 	return false
 }
 
-func toJSON(v interface{}) io.Reader {
+func toJSON(v any) io.Reader {
 	data, err := json.Marshal(v)
 	if err != nil {
 		panic(err)

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -89,7 +89,7 @@ func CreateComponentSchemas(exso ExportComponentSchemasOptions) Option {
 }
 
 // NewSchemaRefForValue is a shortcut for NewGenerator(...).NewSchemaRefForValue(...)
-func NewSchemaRefForValue(value interface{}, schemas openapi3.Schemas, opts ...Option) (*openapi3.SchemaRef, error) {
+func NewSchemaRefForValue(value any, schemas openapi3.Schemas, opts ...Option) (*openapi3.SchemaRef, error) {
 	g := NewGenerator(opts...)
 	return g.NewSchemaRefForValue(value, schemas)
 }
@@ -128,7 +128,7 @@ func (g *Generator) GenerateSchemaRef(t reflect.Type) (*openapi3.SchemaRef, erro
 }
 
 // NewSchemaRefForValue uses reflection on the given value to produce a SchemaRef, and updates a supplied map with any dependent component schemas if they lead to cycles
-func (g *Generator) NewSchemaRefForValue(value interface{}, schemas openapi3.Schemas) (*openapi3.SchemaRef, error) {
+func (g *Generator) NewSchemaRefForValue(value any, schemas openapi3.Schemas) (*openapi3.SchemaRef, error) {
 	ref, err := g.GenerateSchemaRef(reflect.TypeOf(value))
 	if err != nil {
 		return nil, err

--- a/openapi3gen/openapi3gen_newschemarefforvalue_test.go
+++ b/openapi3gen/openapi3gen_newschemarefforvalue_test.go
@@ -366,10 +366,10 @@ func ExampleNewSchemaRefForValue_withExportingSchemasWithMap() {
 		Age string `json:"age"`
 	}
 	type MyType struct {
-		Field1 string                 `json:"field1"`
-		Field2 string                 `json:"field2"`
-		Map1   map[string]interface{} `json:"anymap"`
-		Map2   map[string]Child       `json:"anymapChild"`
+		Field1 string           `json:"field1"`
+		Field2 string           `json:"field2"`
+		Map1   map[string]any   `json:"anymap"`
+		Map2   map[string]Child `json:"anymapChild"`
 	}
 
 	schemas := make(openapi3.Schemas)

--- a/routers/legacy/pathpattern/node.go
+++ b/routers/legacy/pathpattern/node.go
@@ -55,7 +55,7 @@ func PathFromHost(host string, specialDashes bool) string {
 
 type Node struct {
 	VariableNames []string
-	Value         interface{}
+	Value         any
 	Suffixes      SuffixList
 }
 
@@ -153,7 +153,7 @@ func (list SuffixList) Swap(i, j int) {
 	list[i], list[j] = b, a
 }
 
-func (currentNode *Node) MustAdd(path string, value interface{}, options *Options) {
+func (currentNode *Node) MustAdd(path string, value any, options *Options) {
 	node, err := currentNode.CreateNode(path, options)
 	if err != nil {
 		panic(err)
@@ -161,7 +161,7 @@ func (currentNode *Node) MustAdd(path string, value interface{}, options *Option
 	node.Value = value
 }
 
-func (currentNode *Node) Add(path string, value interface{}, options *Options) error {
+func (currentNode *Node) Add(path string, value any, options *Options) error {
 	node, err := currentNode.CreateNode(path, options)
 	if err != nil {
 		return err

--- a/routers/legacy/validate_request_test.go
+++ b/routers/legacy/validate_request_test.go
@@ -78,7 +78,7 @@ func Example() {
 		panic(err)
 	}
 
-	p, err := json.Marshal(map[string]interface{}{
+	p, err := json.Marshal(map[string]any{
 		"pet_type": "Cat",
 		"breed":    "Dingo",
 		"bark":     true,


### PR DESCRIPTION
Go 1.18 introduced any which is prefered over interface{}, they are equivalent (type alias).

https://github.com/golang/go/commit/2580d0e08d5e9f979b943758d3c49877fb2324cb

The go.mod currently targets Go 1.20+