### PR TITLE
replicate circular refs issue

### DIFF
--- a/openapi3/loader_circular_test.go
+++ b/openapi3/loader_circular_test.go
@@ -1,0 +1,14 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadCircular(t *testing.T) {
+	loader := NewLoader()
+	loader.IsExternalRefsAllowed = true
+	_, err := loader.LoadFromFile("testdata/circularRef2/circular2.yaml")
+	require.NoError(t, err)
+}

--- a/openapi3/testdata/circularRef2/AwsEnvironmentSettings.yaml
+++ b/openapi3/testdata/circularRef2/AwsEnvironmentSettings.yaml
@@ -1,0 +1,7 @@
+type: object
+properties:
+    children:
+        type: array
+        items:
+            $ref: './AWSEnvironmentSettings.yaml'
+description: test

--- a/openapi3/testdata/circularRef2/circular2.yaml
+++ b/openapi3/testdata/circularRef2/circular2.yaml
@@ -1,0 +1,16 @@
+openapi: 3.0.0
+info:
+    title: Circular Reference Example
+    version: 1.0.0
+paths:
+    /sample:
+        put:
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            $ref: './AwsEnvironmentSettings.yaml'
+            responses:
+                '200':
+                    description: Ok


### PR DESCRIPTION
This PR contains a unit test that demonstrates the circular refs problem that was reported [here](https://github.com/Tufin/oasdiff/issues/442).
Unfortunately https://github.com/getkin/kin-openapi/pull/970 doesn't seem to resolve this.