### PR TITLE
openapi3: include local reference parts in refPath saved

### DIFF
--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -288,6 +288,31 @@ func resolvePathWithRef(ref string, rootPath *url.URL) (*url.URL, error) {
 	return resolvedPath, nil
 }
 
+func (loader *Loader) resolveRefPath(ref string, path *url.URL) (*url.URL, error) {
+	if ref != "" && ref[0] == '#' {
+		path = copyURI(path)
+		// Resolving internal refs of a doc loaded from memory
+		// has no path, so just set the Fragment.
+		if path == nil {
+			path = new(url.URL)
+		}
+
+		path.Fragment = ref
+		return path, nil
+	}
+
+	if err := loader.allowsExternalRefs(ref); err != nil {
+		return nil, err
+	}
+
+	resolvedPath, err := resolvePathWithRef(ref, path)
+	if err != nil {
+		return nil, err
+	}
+
+	return resolvedPath, nil
+}
+
 func isSingleRefElement(ref string) bool {
 	return !strings.Contains(ref, "#")
 }
@@ -325,7 +350,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 	componentPath *url.URL,
 	err error,
 ) {
-	if componentDoc, ref, componentPath, err = loader.resolveRef(doc, ref, path); err != nil {
+	if componentDoc, ref, componentPath, err = loader.resolveRefAndDocument(doc, ref, path); err != nil {
 		return nil, nil, err
 	}
 
@@ -406,21 +431,25 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		err = nil
 	}
 
-	setComponent := func(target any) {
-		if componentPath != nil {
-			if i, ok := target.(interface {
-				setRefPath(*url.URL)
-			}); ok {
-				copy := *componentPath
-				copy.Fragment = parsedURL.Fragment
-				i.setRefPath(&copy)
+	setPathRef := func(target any) {
+		if i, ok := target.(interface {
+			setRefPath(*url.URL)
+		}); ok {
+			pathRef := copyURI(componentPath)
+			// Resolving internal refs of a doc loaded from memory
+			// has no path, so just set the Fragment.
+			if pathRef == nil {
+				pathRef = new(url.URL)
 			}
+			pathRef.Fragment = fragment
+
+			i.setRefPath(pathRef)
 		}
 	}
 
 	switch {
 	case reflect.TypeOf(cursor) == reflect.TypeOf(resolved):
-		setComponent(cursor)
+		setPathRef(cursor)
 
 		reflect.ValueOf(resolved).Elem().Set(reflect.ValueOf(cursor).Elem())
 		return componentDoc, componentPath, nil
@@ -435,7 +464,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 				return err
 			}
 
-			setComponent(expect)
+			setPathRef(expect)
 			return nil
 		}
 		if err := codec(cursor, resolved); err != nil {
@@ -531,12 +560,12 @@ func drillIntoField(cursor any, fieldName string) (any, error) {
 	}
 }
 
-func (loader *Loader) resolveRef(doc *T, ref string, path *url.URL) (*T, string, *url.URL, error) {
+func (loader *Loader) resolveRefAndDocument(doc *T, ref string, path *url.URL) (*T, string, *url.URL, error) {
 	if ref != "" && ref[0] == '#' {
 		return doc, ref, path, nil
 	}
 
-	fragment, resolvedPath, err := loader.resolveRefPath(ref, path)
+	fragment, resolvedPath, err := loader.resolveRef(ref, path)
 	if err != nil {
 		return nil, "", nil, err
 	}
@@ -548,23 +577,15 @@ func (loader *Loader) resolveRef(doc *T, ref string, path *url.URL) (*T, string,
 	return doc, fragment, resolvedPath, nil
 }
 
-func (loader *Loader) resolveRefPath(ref string, path *url.URL) (string, *url.URL, error) {
-	if ref != "" && ref[0] == '#' {
-		return ref, path, nil
-	}
-
-	if err := loader.allowsExternalRefs(ref); err != nil {
-		return "", nil, err
-	}
-
-	resolvedPath, err := resolvePathWithRef(ref, path)
+func (loader *Loader) resolveRef(ref string, path *url.URL) (string, *url.URL, error) {
+	resolvedPathRef, err := loader.resolveRefPath(ref, path)
 	if err != nil {
 		return "", nil, err
 	}
 
-	fragment := "#" + resolvedPath.Fragment
-	resolvedPath.Fragment = ""
-	return fragment, resolvedPath, nil
+	fragment := "#" + resolvedPathRef.Fragment
+	resolvedPathRef.Fragment = ""
+	return fragment, resolvedPathRef, nil
 }
 
 var (
@@ -591,8 +612,8 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Header)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -645,8 +666,8 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Parameter)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -710,8 +731,8 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*RequestBody)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -777,8 +798,8 @@ func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documen
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Response)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -857,8 +878,8 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Schema)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -943,8 +964,8 @@ func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecurityScheme
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*SecurityScheme)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -983,8 +1004,8 @@ func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentP
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Example)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -1027,8 +1048,8 @@ func (loader *Loader) resolveCallbackRef(doc *T, component *CallbackRef, documen
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Callback)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}
@@ -1083,8 +1104,8 @@ func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *u
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
 			component.Value = value.(*Link)
-			_, refDocPath, _ := loader.resolveRefPath(ref, documentPath)
-			component.setRefPath(refDocPath)
+			refPath, _ := loader.resolveRefPath(ref, documentPath)
+			component.setRefPath(refPath)
 		}) {
 			return nil
 		}

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -24,7 +24,7 @@ type CallbackRef struct {
 	Value *Callback
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*CallbackRef)(nil)
@@ -38,17 +38,16 @@ func (x *CallbackRef) RefString() string { return x.Ref }
 func (x *CallbackRef) CollectionName() string { return "callbacks" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *CallbackRef) RefPath() *url.URL { return &x.refPath }
+func (x *CallbackRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *CallbackRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of CallbackRef.
@@ -161,7 +160,7 @@ type ExampleRef struct {
 	Value *Example
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*ExampleRef)(nil)
@@ -175,17 +174,16 @@ func (x *ExampleRef) RefString() string { return x.Ref }
 func (x *ExampleRef) CollectionName() string { return "examples" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *ExampleRef) RefPath() *url.URL { return &x.refPath }
+func (x *ExampleRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *ExampleRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of ExampleRef.
@@ -298,7 +296,7 @@ type HeaderRef struct {
 	Value *Header
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*HeaderRef)(nil)
@@ -312,17 +310,16 @@ func (x *HeaderRef) RefString() string { return x.Ref }
 func (x *HeaderRef) CollectionName() string { return "headers" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *HeaderRef) RefPath() *url.URL { return &x.refPath }
+func (x *HeaderRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *HeaderRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of HeaderRef.
@@ -435,7 +432,7 @@ type LinkRef struct {
 	Value *Link
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*LinkRef)(nil)
@@ -449,17 +446,16 @@ func (x *LinkRef) RefString() string { return x.Ref }
 func (x *LinkRef) CollectionName() string { return "links" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *LinkRef) RefPath() *url.URL { return &x.refPath }
+func (x *LinkRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *LinkRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of LinkRef.
@@ -572,7 +568,7 @@ type ParameterRef struct {
 	Value *Parameter
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*ParameterRef)(nil)
@@ -586,17 +582,16 @@ func (x *ParameterRef) RefString() string { return x.Ref }
 func (x *ParameterRef) CollectionName() string { return "parameters" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *ParameterRef) RefPath() *url.URL { return &x.refPath }
+func (x *ParameterRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *ParameterRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of ParameterRef.
@@ -709,7 +704,7 @@ type RequestBodyRef struct {
 	Value *RequestBody
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*RequestBodyRef)(nil)
@@ -723,17 +718,16 @@ func (x *RequestBodyRef) RefString() string { return x.Ref }
 func (x *RequestBodyRef) CollectionName() string { return "requestBodies" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *RequestBodyRef) RefPath() *url.URL { return &x.refPath }
+func (x *RequestBodyRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *RequestBodyRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of RequestBodyRef.
@@ -846,7 +840,7 @@ type ResponseRef struct {
 	Value *Response
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*ResponseRef)(nil)
@@ -860,17 +854,16 @@ func (x *ResponseRef) RefString() string { return x.Ref }
 func (x *ResponseRef) CollectionName() string { return "responses" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *ResponseRef) RefPath() *url.URL { return &x.refPath }
+func (x *ResponseRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *ResponseRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of ResponseRef.
@@ -983,7 +976,7 @@ type SchemaRef struct {
 	Value *Schema
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*SchemaRef)(nil)
@@ -997,17 +990,16 @@ func (x *SchemaRef) RefString() string { return x.Ref }
 func (x *SchemaRef) CollectionName() string { return "schemas" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *SchemaRef) RefPath() *url.URL { return &x.refPath }
+func (x *SchemaRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *SchemaRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of SchemaRef.
@@ -1120,7 +1112,7 @@ type SecuritySchemeRef struct {
 	Value *SecurityScheme
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*SecuritySchemeRef)(nil)
@@ -1134,17 +1126,16 @@ func (x *SecuritySchemeRef) RefString() string { return x.Ref }
 func (x *SecuritySchemeRef) CollectionName() string { return "securitySchemes" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *SecuritySchemeRef) RefPath() *url.URL { return &x.refPath }
+func (x *SecuritySchemeRef) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *SecuritySchemeRef) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of SecuritySchemeRef.

--- a/openapi3/refs.tmpl
+++ b/openapi3/refs.tmpl
@@ -24,7 +24,7 @@ type {{ $type.Name }}Ref struct {
 	Value *{{ $type.Name }}
 	extra []string
 
-	refPath url.URL
+	refPath *url.URL
 }
 
 var _ jsonpointer.JSONPointable = (*{{ $type.Name }}Ref)(nil)
@@ -38,17 +38,16 @@ func (x *{{ $type.Name }}Ref) RefString() string { return x.Ref }
 func (x *{{ $type.Name }}Ref) CollectionName() string { return "{{ $type.CollectionName }}" }
 
 // RefPath returns the path of the $ref relative to the root document.
-func (x *{{ $type.Name }}Ref) RefPath() *url.URL { return &x.refPath }
+func (x *{{ $type.Name }}Ref) RefPath() *url.URL { return copyURI(x.refPath) }
 
 func (x *{{ $type.Name }}Ref) setRefPath(u *url.URL) {
-	// Do not set to null or override a path already set.
-	// References can be loaded multiple times not all with access
-	// to the correct path info.
-	if u == nil || x.refPath != (url.URL{}) {
+	// Once the refPath is set don't override. References can be loaded
+	// multiple times not all with access to the correct path info.
+	if x.refPath != nil {
 		return
 	}
 
-	x.refPath = *u
+	x.refPath = copyURI(u)
 }
 
 // MarshalYAML returns the YAML encoding of {{ $type.Name }}Ref.


### PR DESCRIPTION
A bug fix for code added in https://github.com/getkin/kin-openapi/pull/955 for a seldom run code path with recursive refs

* The local part was not included when visiting components during recursion
* Also handles the case when base path is null when loading files data in memory
* Copy uri.URL elements to avoid manipulation from outside source