### PR TITLE
fix: update type: file to type: string and format: binary

### DIFF
--- a/openapi2conv/issue979_test.go
+++ b/openapi2conv/issue979_test.go
@@ -1,0 +1,67 @@
+package openapi2conv
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue979(t *testing.T) {
+	v2 := []byte(`
+{
+    "basePath": "/v2",
+    "host": "test.example.com",
+    "info": {
+        "title": "MyAPI",
+        "version": "0.1",
+        "x-info": "info extension"
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "getFoo",
+                "produces": [
+                    "application/pdf",
+                    "application/json"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "returns all information",
+                        "schema": {
+                            "type": "file"
+                        }
+                    },
+                    "default": {
+                        "description": "OK"
+                    }
+                },
+                "summary": "get foo"
+            }
+        }
+    },
+    "schemes": [
+        "http"
+    ],
+    "swagger": "2.0"
+}
+`)
+
+	var doc2 openapi2.T
+	err := json.Unmarshal(v2, &doc2)
+	require.NoError(t, err)
+
+	doc3, err := ToV3(&doc2)
+	require.NoError(t, err)
+	err = doc3.Validate(context.Background())
+	require.NoError(t, err)
+
+	require.Equal(t, &openapi3.Types{"string"}, doc3.Paths.Value("/foo").Get.Responses.Value("200").Value.Content.Get("application/json").Schema.Value.Type)
+	require.Equal(t, "binary", doc3.Paths.Value("/foo").Get.Responses.Value("200").Value.Content.Get("application/json").Schema.Value.Format)
+
+	require.Equal(t, &openapi3.Types{"string"}, doc3.Paths.Value("/foo").Get.Responses.Value("200").Value.Content.Get("application/pdf").Schema.Value.Type)
+	require.Equal(t, "binary", doc3.Paths.Value("/foo").Get.Responses.Value("200").Value.Content.Get("application/pdf").Schema.Value.Format)
+}

--- a/openapi2conv/issue979_test.go
+++ b/openapi2conv/issue979_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/getkin/kin-openapi/openapi2"
 	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/stretchr/testify/require"
 )
 
 func TestIssue979(t *testing.T) {

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -4,9 +4,10 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"slices"
 	"sort"
 	"strings"
+
+	"slices"
 
 	"github.com/getkin/kin-openapi/openapi2"
 	"github.com/getkin/kin-openapi/openapi3"

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 
@@ -472,6 +473,9 @@ func ToV3SchemaRef(schema *openapi3.SchemaRef) *openapi3.SchemaRef {
 	}
 	if schema.Value.Items != nil {
 		schema.Value.Items = ToV3SchemaRef(schema.Value.Items)
+	}
+	if slices.Equal(schema.Value.Type.Slice(), openapi3.Types{"file"}) {
+		schema.Value.Format, schema.Value.Type = "binary", &openapi3.Types{"string"}
 	}
 	for k, v := range schema.Value.Properties {
 		schema.Value.Properties[k] = ToV3SchemaRef(v)

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -7,8 +7,6 @@ import (
 	"sort"
 	"strings"
 
-	"slices"
-
 	"github.com/getkin/kin-openapi/openapi2"
 	"github.com/getkin/kin-openapi/openapi3"
 )
@@ -475,7 +473,7 @@ func ToV3SchemaRef(schema *openapi3.SchemaRef) *openapi3.SchemaRef {
 	if schema.Value.Items != nil {
 		schema.Value.Items = ToV3SchemaRef(schema.Value.Items)
 	}
-	if slices.Equal(schema.Value.Type.Slice(), openapi3.Types{"file"}) {
+	if schema.Value.Type.Is("file") {
 		schema.Value.Format, schema.Value.Type = "binary", &openapi3.Types{"string"}
 	}
 	for k, v := range schema.Value.Properties {


### PR DESCRIPTION
This PR addresses issue #979. It updates the "type: file" to "type: string" and "format: binary" when converting from V2 to V3 document. 