### PR TITLE
openapi3filter: Remove inconsistency for arrays in queries

### DIFF
--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -320,6 +320,10 @@ func decodeValue(dec valueDecoder, param string, sm *openapi3.SerializationMetho
 		switch {
 		case schema.Value.Type.Is("array"):
 			decodeFn = func(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (any, bool, error) {
+				res, b, e := dec.DecodeArray(param, sm, schema)
+				if len(res) == 0 {
+					return nil, b, e
+				}
 				return dec.DecodeArray(param, sm, schema)
 			}
 		case schema.Value.Type.Is("object"):

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -879,6 +879,22 @@ func TestDecodeParameter(t *testing.T) {
 					found: true,
 				},
 				{
+					name:  "no param, for arrays",
+					param: &openapi3.Parameter{Name: "something", In: "query", Schema: stringArraySchema},
+					query: "",
+					want:  nil,
+					found: false,
+					err:   nil,
+				},
+				{
+					name:  "missing param, for arrays",
+					param: &openapi3.Parameter{Name: "something", In: "query", Schema: stringArraySchema},
+					query: "foo=bar",
+					want:  nil,
+					found: false,
+					err:   nil,
+				},
+				{
 					name: "deepObject explode additionalProperties with object properties - missing index on nested array",
 					param: &openapi3.Parameter{
 						Name: "param", In: "query", Style: "deepObject", Explode: explode,


### PR DESCRIPTION
See #989 for details, but in a nutshell:

- DecodeArray returns a []any, which means that whenever DecodeArray returns nil, it will actually return a []interface{nil}
- Viewed from decodeStyledParameter, this is an inconsistent behaviour, since decodeStyledParameter returns nil when the query parameters are empty, AND []interface{nil} when there is at least another parameter set.

I am unsure as to whether this is the best way to fix that issue, and am open to suggestions.

Thanks