### PR TITLE
openapi3: Serialize Extensions when using $ref

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -1229,6 +1229,7 @@ func URIMapCache(reader ReadFromURIFunc) ReadFromURIFunc
 
 type Ref struct {
 	Ref string `json:"$ref" yaml:"$ref"`
+	Extensions map[string]any `json:"extensions,omitempty" yaml:"$ref,omitempty"`
 }
     Ref is specified by OpenAPI/Swagger 3.0 standard. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#reference-object

--- a/openapi3/ref.go
+++ b/openapi3/ref.go
@@ -5,5 +5,6 @@ package openapi3
 // Ref is specified by OpenAPI/Swagger 3.0 standard.
 // See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#reference-object
 type Ref struct {
-	Ref string `json:"$ref" yaml:"$ref"`
+	Ref        string         `json:"$ref" yaml:"$ref"`
+	Extensions map[string]any `json:"extensions,omitempty" yaml:"$ref,omitempty"`
 }

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -53,7 +53,7 @@ func (x *CallbackRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of CallbackRef.
 func (x CallbackRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -189,7 +189,7 @@ func (x *ExampleRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of ExampleRef.
 func (x ExampleRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -325,7 +325,7 @@ func (x *HeaderRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of HeaderRef.
 func (x HeaderRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -461,7 +461,7 @@ func (x *LinkRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of LinkRef.
 func (x LinkRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -597,7 +597,7 @@ func (x *ParameterRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of ParameterRef.
 func (x ParameterRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -733,7 +733,7 @@ func (x *RequestBodyRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of RequestBodyRef.
 func (x RequestBodyRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -869,7 +869,7 @@ func (x *ResponseRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of ResponseRef.
 func (x ResponseRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -1005,7 +1005,7 @@ func (x *SchemaRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of SchemaRef.
 func (x SchemaRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -1141,7 +1141,7 @@ func (x *SecuritySchemeRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of SecuritySchemeRef.
 func (x SecuritySchemeRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }

--- a/openapi3/refs.tmpl
+++ b/openapi3/refs.tmpl
@@ -53,7 +53,7 @@ func (x *{{ $type.Name }}Ref) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of {{ $type.Name }}Ref.
 func (x {{ $type.Name }}Ref) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref}, nil
+		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
 	}
 	return x.Value.MarshalYAML()
 }


### PR DESCRIPTION
I was pleased to see the recent merging of #901, and this is a minor follow-on to that PR.

901 added support for reading `x-` extensions when using `$ref`. This extends this by round-tripping `x-` extensions back out to JSON / YAML.

I followed 901 to see what changes to make, since much of the code is auto-generated. I will open this as a Draft PR; if maintainers are OK with the basic idea, I will finish adding tests for the round-trip behavior and ask for formal review.

