### PR TITLE
Introduce an option to override the regex implementation

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -1240,6 +1240,12 @@ type RefNameResolver func(*T, ComponentRef) string
     The function should avoid name collisions (i.e. be a injective mapping). It
     must only contain characters valid for fixed field names: IdentifierRegExp.
 
+type RegexCompilerFunc func(expr string) (RegexMatcher, error)
+
+type RegexMatcher interface {
+	MatchString(s string) bool
+}
+
 type RequestBodies map[string]*RequestBodyRef
 
 func (m RequestBodies) JSONLookup(token string) (any, error)
@@ -1764,6 +1770,10 @@ func SetSchemaErrorMessageCustomizer(f func(err *SchemaError) string) SchemaVali
     If the passed function returns an empty string, it returns to the previous
     Error() implementation.
 
+func SetSchemaRegexCompiler(c RegexCompilerFunc) SchemaValidationOption
+    SetSchemaRegexCompiler allows to override the regex implementation used to
+    validate field "pattern".
+
 func VisitAsRequest() SchemaValidationOption
 
 func VisitAsResponse() SchemaValidationOption
@@ -2127,6 +2137,10 @@ func ProhibitExtensionsWithRef() ValidationOption
     extensions (fields starting with 'x-') are found as siblings for $ref
     fields. Non-extension fields are prohibited unless allowed explicitly with
     the AllowExtraSiblingFields option.
+
+func SetRegexCompiler(c RegexCompilerFunc) ValidationOption
+    SetRegexCompiler allows to override the regex implementation used to
+    validate field "pattern".
 
 type ValidationOptions struct {
 	// Has unexported fields.

--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -223,6 +223,9 @@ type Options struct {
 
 	MultiError bool
 
+	// Set RegexCompiler to override the regex implementation
+	RegexCompiler openapi3.RegexCompilerFunc
+
 	// A document with security schemes defined will not pass validation
 	// unless an AuthenticationFunc is defined.
 	// See NoopAuthenticationFunc

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -9,7 +9,6 @@ import (
 	"math"
 	"math/big"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -1019,7 +1018,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 				}
 			}
 			if !validationOpts.schemaPatternValidationDisabled && schema.Pattern != "" {
-				if _, err := schema.compilePattern(); err != nil {
+				if _, err := schema.compilePattern(validationOpts.regexCompilerFunc); err != nil {
 					return stack, err
 				}
 			}
@@ -1729,10 +1728,10 @@ func (schema *Schema) visitJSONString(settings *schemaValidationSettings, value 
 	// "pattern"
 	if !settings.patternValidationDisabled && schema.Pattern != "" {
 		cpiface, _ := compiledPatterns.Load(schema.Pattern)
-		cp, _ := cpiface.(*regexp.Regexp)
+		cp, _ := cpiface.(RegexMatcher)
 		if cp == nil {
 			var err error
-			if cp, err = schema.compilePattern(); err != nil {
+			if cp, err = schema.compilePattern(settings.regexCompiler); err != nil {
 				if !settings.multiError {
 					return err
 				}

--- a/openapi3/schema_pattern.go
+++ b/openapi3/schema_pattern.go
@@ -13,9 +13,14 @@ func intoGoRegexp(re string) string {
 }
 
 // NOTE: racey WRT [writes to schema.Pattern] vs [reads schema.Pattern then writes to compiledPatterns]
-func (schema *Schema) compilePattern() (cp *regexp.Regexp, err error) {
+func (schema *Schema) compilePattern(c RegexCompilerFunc) (cp RegexMatcher, err error) {
 	pattern := schema.Pattern
-	if cp, err = regexp.Compile(intoGoRegexp(pattern)); err != nil {
+	if c != nil {
+		cp, err = c(pattern)
+	} else {
+		cp, err = regexp.Compile(intoGoRegexp(pattern))
+	}
+	if err != nil {
 		err = &SchemaError{
 			Schema:      schema,
 			SchemaField: "pattern",
@@ -24,6 +29,7 @@ func (schema *Schema) compilePattern() (cp *regexp.Regexp, err error) {
 		}
 		return
 	}
+
 	var _ bool = compiledPatterns.CompareAndSwap(pattern, nil, cp)
 	return
 }

--- a/openapi3/schema_validation_settings.go
+++ b/openapi3/schema_validation_settings.go
@@ -7,6 +7,12 @@ import (
 // SchemaValidationOption describes options a user has when validating request / response bodies.
 type SchemaValidationOption func(*schemaValidationSettings)
 
+type RegexCompilerFunc func(expr string) (RegexMatcher, error)
+
+type RegexMatcher interface {
+	MatchString(s string) bool
+}
+
 type schemaValidationSettings struct {
 	failfast                    bool
 	multiError                  bool
@@ -15,6 +21,8 @@ type schemaValidationSettings struct {
 	patternValidationDisabled   bool
 	readOnlyValidationDisabled  bool
 	writeOnlyValidationDisabled bool
+
+	regexCompiler RegexCompilerFunc
 
 	onceSettingDefaults sync.Once
 	defaultsSet         func()
@@ -68,6 +76,11 @@ func DefaultsSet(f func()) SchemaValidationOption {
 // If the passed function returns an empty string, it returns to the previous Error() implementation.
 func SetSchemaErrorMessageCustomizer(f func(err *SchemaError) string) SchemaValidationOption {
 	return func(s *schemaValidationSettings) { s.customizeMessageError = f }
+}
+
+// SetSchemaRegexCompiler allows to override the regex implementation used to validate field "pattern".
+func SetSchemaRegexCompiler(c RegexCompilerFunc) SchemaValidationOption {
+	return func(s *schemaValidationSettings) { s.regexCompiler = c }
 }
 
 func newSchemaValidationSettings(opts ...SchemaValidationOption) *schemaValidationSettings {

--- a/openapi3/validation_options.go
+++ b/openapi3/validation_options.go
@@ -13,6 +13,7 @@ type ValidationOptions struct {
 	schemaFormatValidationEnabled                    bool
 	schemaPatternValidationDisabled                  bool
 	schemaExtensionsInRefProhibited                  bool
+	regexCompilerFunc                                RegexCompilerFunc
 	extraSiblingFieldsAllowed                        map[string]struct{}
 }
 
@@ -110,6 +111,14 @@ func AllowExtensionsWithRef() ValidationOption {
 func ProhibitExtensionsWithRef() ValidationOption {
 	return func(options *ValidationOptions) {
 		options.schemaExtensionsInRefProhibited = true
+	}
+}
+
+// SetRegexCompiler allows to override the regex implementation used to validate
+// field "pattern".
+func SetRegexCompiler(c RegexCompilerFunc) ValidationOption {
+	return func(options *ValidationOptions) {
+		options.regexCompilerFunc = c
 	}
 }
 

--- a/openapi3filter/options.go
+++ b/openapi3filter/options.go
@@ -25,6 +25,9 @@ type Options struct {
 
 	MultiError bool
 
+	// Set RegexCompiler to override the regex implementation
+	RegexCompiler openapi3.RegexCompilerFunc
+
 	// A document with security schemes defined will not pass validation
 	// unless an AuthenticationFunc is defined.
 	// See NoopAuthenticationFunc

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -316,6 +316,9 @@ func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, req
 	if options.ExcludeReadOnlyValidations {
 		opts = append(opts, openapi3.DisableReadOnlyValidation())
 	}
+	if options.RegexCompiler != nil {
+		opts = append(opts, openapi3.SetSchemaRegexCompiler(options.RegexCompiler))
+	}
 
 	// Validate JSON with the schema
 	if err := contentType.Schema.Value.VisitJSON(value, opts...); err != nil {


### PR DESCRIPTION
This allows use of a different (more featureful) regex implementation to do validation of fields that have a "pattern" defined.