### PR TITLE
make form required field order deterministic

### DIFF
--- a/openapi2conv/issue1008_test.go
+++ b/openapi2conv/issue1008_test.go
@@ -1,0 +1,49 @@
+package openapi2conv
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1008(t *testing.T) {
+	v2 := []byte(`
+swagger: '2.0'
+info:
+  version: '1.10'
+  title: title
+paths:
+  "/ping":
+    post:
+      consumes:
+      - multipart/form-data
+      parameters:
+      - name: zebra
+        in: formData
+        description: stripes
+        required: true
+        type: string
+      - name: alpaca
+        in: formData
+        description: chewy
+        required: true
+        type: string
+      - name: bee
+        in: formData
+        description: buzz
+        required: true
+        type: string
+      responses:
+        '200':
+          description: OK
+`)
+
+	v3, err := v2v3YAML(v2)
+	require.NoError(t, err)
+
+	err = v3.Validate(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpaca", "bee", "zebra"}, v3.Paths.Value("/ping").Post.RequestBody.Value.Content.Get("multipart/form-data").Schema.Value.Required)
+}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -346,6 +346,7 @@ func formDataBody(bodies map[string]*openapi3.SchemaRef, reqs map[string]bool, c
 			bodies[s] = ref
 		}
 	}
+	sort.Strings(requireds)
 	schema := &openapi3.Schema{
 		Type:       &openapi3.Types{"object"},
 		Properties: ToV3Schemas(bodies),


### PR DESCRIPTION
The required fields list of a form was generated by iterating over a map, but in Go maps do not seem to have a natural order.  This causes the list of fields to have some randomness to it.  

Everything else so far is deterministic, and we rely on this to determine if the openapi spec needs to be updated