### PR TITLE
openapi3: fail to load spec because of schema names in mapping 

### DIFF
--- a/openapi3/mapping_test.go
+++ b/openapi3/mapping_test.go
@@ -1,0 +1,58 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMapping(t *testing.T) {
+
+	schema := `
+openapi: 3.0.0
+info:
+  title: ACME
+  version: 1.0.0
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+      - petType
+      properties:
+        petType:
+          type: string
+      discriminator:
+        propertyName: petType
+        mapping:
+          dog: Dog
+    Cat:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        # all other properties specific to a Cat
+        properties:
+          name:
+            type: string
+    Dog:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        # all other properties specific to a Dog
+        properties:
+          bark:
+            type: string
+    Lizard:
+      allOf:
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        # all other properties specific to a Lizard
+        properties:
+          lovesRocks:
+            type: boolean
+`
+	loader := NewLoader()
+	loader.IsExternalRefsAllowed = true
+	_, err := loader.LoadFromData([]byte(schema))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
This PR consists of a unit test demonstrating a problem with the latest mapping PR: https://github.com/getkin/kin-openapi/pull/1022
The problem is due to the new logic not handling schema names anymore.
The example in the unit test is taken from here: https://spec.openapis.org/oas/v3.0.0#fixed-fields-20
The table in this page states that mapping is "An object to hold mappings between payload values and **schema names** or references."