### PR TITLE
openapi2conv: convert schemaRef for additional props

### DIFF
--- a/openapi2conv/issue1016_test.go
+++ b/openapi2conv/issue1016_test.go
@@ -1,0 +1,81 @@
+package openapi2conv
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue1016(t *testing.T) {
+	v2 := []byte(`
+{
+    "basePath": "/v2",
+    "host": "test.example.com",
+    "info": {
+        "title": "MyAPI",
+        "version": "0.1",
+        "x-info": "info extension"
+    },
+    "paths": {
+        "/foo": {
+            "get": {
+                "operationId": "getFoo",
+                "responses": {
+                    "200": {
+                        "description": "returns all information",
+                        "schema": {
+                            "$ref": "#/definitions/PetDirectory"
+                        }
+                    },
+                    "default": {
+                        "description": "OK"
+                    }
+                },
+                "summary": "get foo"
+            }
+        }
+    },
+    "schemes": [
+        "http"
+    ],
+    "swagger": "2.0",
+    "definitions": {
+		"Pet": {
+			"type": "object",
+			"required": ["petType"],
+			"properties": {
+				"petType": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"age": {
+					"type": "integer"
+				}
+			}
+		},
+		"PetDirectory":{
+			"type": "object",
+			"additionalProperties": {
+				"$ref": "#/definitions/Pet"
+			}
+		}
+    }
+}
+`)
+
+	var doc2 openapi2.T
+	err := json.Unmarshal(v2, &doc2)
+	require.NoError(t, err)
+
+	doc3, err := v2v3YAML(v2)
+	require.NoError(t, err)
+
+	err = doc3.Validate(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, "#/components/schemas/Pet", doc3.Components.Schemas["PetDirectory"].Value.AdditionalProperties.Schema.Ref)
+}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -516,6 +516,10 @@ func ToV3SchemaRef(schema *openapi2.SchemaRef) *openapi3.SchemaRef {
 		AdditionalProperties: schema.Value.AdditionalProperties,
 	}
 
+	if schema.Value.AdditionalProperties.Schema != nil {
+		v3Schema.AdditionalProperties.Schema.Ref = ToV3Ref(schema.Value.AdditionalProperties.Schema.Ref)
+	}
+
 	if schema.Value.Discriminator != "" {
 		v3Schema.Discriminator = &openapi3.Discriminator{
 			PropertyName: schema.Value.Discriminator,


### PR DESCRIPTION
Fixes Issue: https://github.com/getkin/kin-openapi/issues/1016.
 
Not sure why additionProperties field is of type openapi3.Schema .Doing a conversion on the ref field 