### PR TITLE
openapi3: use Ptr instead of BoolPtr,Float64Ptr,Int64Ptr,Uint64Ptr

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -96,6 +96,8 @@ FUNCTIONS
 func BoolPtr(value bool) *bool
     BoolPtr is a helper for defining OpenAPI schemas.
 
+    Deprecated: Use Ptr instead.
+
 func DefaultRefNameResolver(doc *T, ref ComponentRef) string
     DefaultRefResolver is a default implementation of refNameResolver for the
     InternalizeRefs function.
@@ -147,8 +149,15 @@ func DefineStringFormatValidator(name string, validator StringFormatValidator)
 func Float64Ptr(value float64) *float64
     Float64Ptr is a helper for defining OpenAPI schemas.
 
+    Deprecated: Use Ptr instead.
+
 func Int64Ptr(value int64) *int64
     Int64Ptr is a helper for defining OpenAPI schemas.
+
+    Deprecated: Use Ptr instead.
+
+func Ptr[T any](value T) *T
+    Ptr is a helper for defining OpenAPI schemas.
 
 func ReadFromFile(loader *Loader, location *url.URL) ([]byte, error)
     ReadFromFile is a ReadFromURIFunc which reads local file URIs.
@@ -201,6 +210,8 @@ func RegisterArrayUniqueItemsChecker(fn SliceUniqueItemsChecker)
 
 func Uint64Ptr(value uint64) *uint64
     Uint64Ptr is a helper for defining OpenAPI schemas.
+
+    Deprecated: Use Ptr instead.
 
 func ValidateIdentifier(value string) error
     ValidateIdentifier returns an error if the given component name does not

--- a/openapi3/encoding_test.go
+++ b/openapi3/encoding_test.go
@@ -52,7 +52,7 @@ func encoding() *Encoding {
 			},
 		},
 		Style:         "form",
-		Explode:       BoolPtr(true),
+		Explode:       Ptr(true),
 		AllowReserved: true,
 	}
 }
@@ -74,17 +74,17 @@ func TestEncodingSerializationMethod(t *testing.T) {
 		},
 		{
 			name: "encoding with explode",
-			enc:  &Encoding{Explode: BoolPtr(true)},
+			enc:  &Encoding{Explode: Ptr(true)},
 			want: &SerializationMethod{Style: SerializationForm, Explode: true},
 		},
 		{
 			name: "encoding with no explode",
-			enc:  &Encoding{Explode: BoolPtr(false)},
+			enc:  &Encoding{Explode: Ptr(false)},
 			want: &SerializationMethod{Style: SerializationForm, Explode: false},
 		},
 		{
 			name: "encoding with style and explode ",
-			enc:  &Encoding{Style: SerializationSpaceDelimited, Explode: BoolPtr(false)},
+			enc:  &Encoding{Style: SerializationSpaceDelimited, Explode: Ptr(false)},
 			want: &SerializationMethod{Style: SerializationSpaceDelimited, Explode: false},
 		},
 	}

--- a/openapi3/helpers.go
+++ b/openapi3/helpers.go
@@ -31,22 +31,35 @@ func ValidateIdentifier(value string) error {
 	return fmt.Errorf("identifier %q is not supported by OpenAPIv3 standard (charset: [%q])", value, identifierChars)
 }
 
+// Ptr is a helper for defining OpenAPI schemas.
+func Ptr[T any](value T) *T {
+	return &value
+}
+
 // Float64Ptr is a helper for defining OpenAPI schemas.
+//
+// Deprecated: Use Ptr instead.
 func Float64Ptr(value float64) *float64 {
 	return &value
 }
 
 // BoolPtr is a helper for defining OpenAPI schemas.
+//
+// Deprecated: Use Ptr instead.
 func BoolPtr(value bool) *bool {
 	return &value
 }
 
 // Int64Ptr is a helper for defining OpenAPI schemas.
+//
+// Deprecated: Use Ptr instead.
 func Int64Ptr(value int64) *int64 {
 	return &value
 }
 
 // Uint64Ptr is a helper for defining OpenAPI schemas.
+//
+// Deprecated: Use Ptr instead.
 func Uint64Ptr(value uint64) *uint64 {
 	return &value
 }

--- a/openapi3/issue376_test.go
+++ b/openapi3/issue376_test.go
@@ -46,7 +46,7 @@ info:
 func TestExclusiveValuesOfValuesAdditionalProperties(t *testing.T) {
 	schema := &Schema{
 		AdditionalProperties: AdditionalProperties{
-			Has:    BoolPtr(false),
+			Has:    Ptr(false),
 			Schema: NewSchemaRef("", &Schema{}),
 		},
 	}
@@ -55,7 +55,7 @@ func TestExclusiveValuesOfValuesAdditionalProperties(t *testing.T) {
 
 	schema = &Schema{
 		AdditionalProperties: AdditionalProperties{
-			Has: BoolPtr(false),
+			Has: Ptr(false),
 		},
 	}
 	err = schema.Validate(context.Background())

--- a/openapi3/issue735_test.go
+++ b/openapi3/issue735_test.go
@@ -74,7 +74,7 @@ func TestIssue735(t *testing.T) {
 		},
 		{
 			name:   "multiple of",
-			schema: &Schema{MultipleOf: Float64Ptr(5.0)},
+			schema: &Schema{MultipleOf: Ptr(5.0)},
 			value:  42,
 		},
 		{
@@ -142,7 +142,7 @@ func TestIssue735(t *testing.T) {
 		{
 			name: "additional properties false",
 			schema: &Schema{AdditionalProperties: AdditionalProperties{
-				Has: BoolPtr(false),
+				Has: Ptr(false),
 			}},
 			value:            map[string]any{"foo": 42},
 			extraNotContains: []any{42},
@@ -188,40 +188,40 @@ func TestIssue735(t *testing.T) {
 		{
 			name: "one of (matches more then one)",
 			schema: NewOneOfSchema(
-				&Schema{MultipleOf: Float64Ptr(6)},
-				&Schema{MultipleOf: Float64Ptr(7)},
+				&Schema{MultipleOf: Ptr(6.0)},
+				&Schema{MultipleOf: Ptr(7.0)},
 			),
 			value: 42,
 		},
 		{
 			name: "one of (no matches)",
 			schema: NewOneOfSchema(
-				&Schema{MultipleOf: Float64Ptr(5)},
-				&Schema{MultipleOf: Float64Ptr(10)},
+				&Schema{MultipleOf: Ptr(5.0)},
+				&Schema{MultipleOf: Ptr(10.0)},
 			),
 			value: 42,
 		},
 		{
 			name: "any of",
 			schema: NewAnyOfSchema(
-				&Schema{MultipleOf: Float64Ptr(5)},
-				&Schema{MultipleOf: Float64Ptr(10)},
+				&Schema{MultipleOf: Ptr(5.0)},
+				&Schema{MultipleOf: Ptr(10.0)},
 			),
 			value: 42,
 		},
 		{
 			name: "all of (match some)",
 			schema: NewAllOfSchema(
-				&Schema{MultipleOf: Float64Ptr(6)},
-				&Schema{MultipleOf: Float64Ptr(5)},
+				&Schema{MultipleOf: Ptr(6.0)},
+				&Schema{MultipleOf: Ptr(5.0)},
 			),
 			value: 42,
 		},
 		{
 			name: "all of (no match)",
 			schema: NewAllOfSchema(
-				&Schema{MultipleOf: Float64Ptr(10)},
-				&Schema{MultipleOf: Float64Ptr(5)},
+				&Schema{MultipleOf: Ptr(10.0)},
+				&Schema{MultipleOf: Ptr(5.0)},
 			),
 			value: 42,
 		},

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -837,12 +837,12 @@ func (schema *Schema) WithMaxProperties(i int64) *Schema {
 }
 
 func (schema *Schema) WithAnyAdditionalProperties() *Schema {
-	schema.AdditionalProperties = AdditionalProperties{Has: BoolPtr(true)}
+	schema.AdditionalProperties = AdditionalProperties{Has: Ptr(true)}
 	return schema
 }
 
 func (schema *Schema) WithoutAdditionalProperties() *Schema {
-	schema.AdditionalProperties = AdditionalProperties{Has: BoolPtr(false)}
+	schema.AdditionalProperties = AdditionalProperties{Has: Ptr(false)}
 	return schema
 }
 

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -542,7 +542,7 @@ var schemaExamples = []schemaExample{
 		Schema: &Schema{
 			Type:        &Types{"array"},
 			MinItems:    2,
-			MaxItems:    Uint64Ptr(3),
+			MaxItems:    Ptr[uint64](3),
 			UniqueItems: true,
 			Items:       NewFloat64Schema().NewRef(),
 		},
@@ -872,7 +872,7 @@ var schemaExamples = []schemaExample{
 		Title: "OBJECT",
 		Schema: &Schema{
 			Type:     &Types{"object"},
-			MaxProps: Uint64Ptr(2),
+			MaxProps: Ptr[uint64](2),
 			Properties: Schemas{
 				"numberProperty": NewFloat64Schema().NewRef(),
 			},
@@ -944,7 +944,7 @@ var schemaExamples = []schemaExample{
 	{
 		Schema: &Schema{
 			Type:                 &Types{"object"},
-			AdditionalProperties: AdditionalProperties{Has: BoolPtr(true)},
+			AdditionalProperties: AdditionalProperties{Has: Ptr(true)},
 		},
 		Serialization: map[string]any{
 			"type":                 "object",

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	explode   = openapi3.BoolPtr(true)
-	noExplode = openapi3.BoolPtr(false)
+	explode   = openapi3.Ptr(true)
+	noExplode = openapi3.Ptr(false)
 	arrayOf   = func(items *openapi3.SchemaRef) *openapi3.SchemaRef {
 		return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"array"}, Items: items}}
 	}
@@ -1712,7 +1712,7 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("b", openapi3.NewIntegerSchema()).
 				WithProperty("c", openapi3.NewArraySchema().WithItems(openapi3.NewStringSchema())),
 			encoding: map[string]*openapi3.Encoding{
-				"c": {Style: openapi3.SerializationSpaceDelimited, Explode: openapi3.BoolPtr(false)},
+				"c": {Style: openapi3.SerializationSpaceDelimited, Explode: openapi3.Ptr(false)},
 			},
 			want: map[string]any{"a": "a1", "b": int64(10), "c": []any{"c1", "c2"}},
 		},
@@ -1725,7 +1725,7 @@ func TestDecodeBody(t *testing.T) {
 				WithProperty("b", openapi3.NewIntegerSchema()).
 				WithProperty("c", openapi3.NewArraySchema().WithItems(openapi3.NewStringSchema())),
 			encoding: map[string]*openapi3.Encoding{
-				"c": {Style: openapi3.SerializationPipeDelimited, Explode: openapi3.BoolPtr(false)},
+				"c": {Style: openapi3.SerializationPipeDelimited, Explode: openapi3.Ptr(false)},
 			},
 			want: map[string]any{"a": "a1", "b": int64(10), "c": []any{"c1", "c2"}},
 		},


### PR DESCRIPTION
This adds generic `openapi3.Ptr` function to be used instead of `openapi3.BoolPtr, openapi3.Float64Ptr, openapi3.Int64Ptr, openapi3.Uint64Ptr`.