### PR TITLE
openapi3: fix deprecation comments

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -128,13 +128,16 @@ func DefineNumberFormatValidator(name string, validator NumberFormatValidator)
     number format.
 
 func DefineStringFormat(name string, pattern string)
-    DefineStringFormat defines a regexp pattern for a given string
-    format Deprecated: Use openapi3.DefineStringFormatValidator(name,
+    DefineStringFormat defines a regexp pattern for a given string format
+
+    Deprecated: Use openapi3.DefineStringFormatValidator(name,
     NewRegexpFormatValidator(pattern)) instead.
 
 func DefineStringFormatCallback(name string, callback func(string) error)
-    DefineStringFormatCallback defines a callback function for a given
-    string format Deprecated: Use openapi3.DefineStringFormatValidator(name,
+    DefineStringFormatCallback defines a callback function for a given string
+    format
+
+    Deprecated: Use openapi3.DefineStringFormatValidator(name,
     NewCallbackValidator(fn)) instead.
 
 func DefineStringFormatValidator(name string, validator StringFormatValidator)

--- a/openapi3/schema_formats.go
+++ b/openapi3/schema_formats.go
@@ -131,12 +131,14 @@ func DefineIntegerFormatValidator(name string, validator IntegerFormatValidator)
 }
 
 // DefineStringFormat defines a regexp pattern for a given string format
+//
 // Deprecated: Use openapi3.DefineStringFormatValidator(name, NewRegexpFormatValidator(pattern)) instead.
 func DefineStringFormat(name string, pattern string) {
 	DefineStringFormatValidator(name, NewRegexpFormatValidator(pattern))
 }
 
 // DefineStringFormatCallback defines a callback function for a given string format
+//
 // Deprecated: Use openapi3.DefineStringFormatValidator(name, NewCallbackValidator(fn)) instead.
 func DefineStringFormatCallback(name string, callback func(string) error) {
 	DefineStringFormatValidator(name, NewCallbackValidator(callback))


### PR DESCRIPTION
This PR fixes deprecation comments for `openapi3.DefineStringFormat` and `openapi3.DefineStringFormatCallback`.

According to https://github.com/golang/go/issues/10909#issuecomment-136492606, must be empty line before `// Deprecated: ...`