### PR TITLE
test: fix expected-actual parameters in require.Equal

### DIFF
--- a/openapi2conv/issue187_test.go
+++ b/openapi2conv/issue187_test.go
@@ -104,7 +104,7 @@ func TestIssue187(t *testing.T) {
 	spec3, err := json.Marshal(doc3)
 	require.NoError(t, err)
 	const expected = `{"components":{"schemas":{"model.ProductSearchAttributeRequest":{"properties":{"filterField":{"type":"string"},"filterKey":{"type":"string"},"type":{"type":"string"},"values":{"$ref":"#/components/schemas/model.ProductSearchAttributeValueRequest"}},"title":"model.ProductSearchAttributeRequest","type":"object"},"model.ProductSearchAttributeValueRequest":{"properties":{"imageUrl":{"type":"string"},"text":{"type":"string"}},"title":"model.ProductSearchAttributeValueRequest","type":"object"}}},"info":{"contact":{"email":"test@test.com","name":"Test"},"description":"Test Golang Application","title":"Test","version":"1.0"},"openapi":"3.0.3","paths":{"/me":{"get":{"operationId":"someTest","responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/model.ProductSearchAttributeRequest"}}},"description":"successful operation"}},"summary":"Some test","tags":["probe"]}}}}`
-	require.JSONEq(t, string(spec3), expected)
+	require.JSONEq(t, expected, string(spec3))
 
 	err = doc3.Validate(context.Background())
 	require.NoError(t, err)
@@ -163,7 +163,7 @@ paths:
         "200":
           description: description
 `
-	require.YAMLEq(t, string(spec3), expected)
+	require.YAMLEq(t, expected, string(spec3))
 
 	err = doc3.Validate(context.Background())
 	require.NoError(t, err)
@@ -190,5 +190,5 @@ securityDefinitions:
 
 	doc2, err := FromV3(doc3)
 	require.NoError(t, err)
-	require.Equal(t, doc2.SecurityDefinitions["OAuth2Application"].Flow, "application")
+	require.Equal(t, "application", doc2.SecurityDefinitions["OAuth2Application"].Flow)
 }

--- a/openapi3/encoding_test.go
+++ b/openapi3/encoding_test.go
@@ -91,7 +91,7 @@ func TestEncodingSerializationMethod(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.enc.SerializationMethod()
-			require.EqualValues(t, got, tc.want, "got %#v, want %#v", got, tc.want)
+			require.EqualValues(t, tc.want, got, "got %#v, want %#v", got, tc.want)
 		})
 	}
 }

--- a/openapi3/issue652_test.go
+++ b/openapi3/issue652_test.go
@@ -23,7 +23,7 @@ func TestIssue652(t *testing.T) {
 		require.Contains(t, spec.Components.Schemas, schemaName)
 
 		schema := spec.Components.Schemas[schemaName]
-		assert.Equal(t, schema.Ref, "../definitions.yml#/components/schemas/TestSchema")
-		assert.Equal(t, schema.Value.Type, &openapi3.Types{"string"})
+		assert.Equal(t, "../definitions.yml#/components/schemas/TestSchema", schema.Ref)
+		assert.Equal(t, &openapi3.Types{"string"}, schema.Value.Type)
 	})
 }

--- a/openapi3/loader_relative_refs_test.go
+++ b/openapi3/loader_relative_refs_test.go
@@ -927,7 +927,7 @@ func TestLoadSpecWithRelativeDocumentRefs2(t *testing.T) {
 	require.Equal(t, "example request", nestedDirPath.Patch.RequestBody.Value.Description)
 
 	// check response schema and example
-	require.Equal(t, nestedDirPath.Patch.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type, &Types{"string"})
+	require.Equal(t, &Types{"string"}, nestedDirPath.Patch.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type)
 	expectedExample := "hello"
 	require.Equal(t, expectedExample, nestedDirPath.Patch.Responses.Value("200").Value.Content["application/json"].Examples["CustomTestExample"].Value.Value)
 
@@ -948,5 +948,5 @@ func TestLoadSpecWithRelativeDocumentRefs2(t *testing.T) {
 
 	// check response schema and example
 	require.Equal(t, &Types{"string"}, moreNestedDirPath.Patch.Responses.Value("200").Value.Content["application/json"].Schema.Value.Type)
-	require.Equal(t, moreNestedDirPath.Patch.Responses.Value("200").Value.Content["application/json"].Examples["CustomTestExample"].Value.Value, expectedExample)
+	require.Equal(t, expectedExample, moreNestedDirPath.Patch.Responses.Value("200").Value.Content["application/json"].Examples["CustomTestExample"].Value.Value)
 }

--- a/openapi3/response_issue224_test.go
+++ b/openapi3/response_issue224_test.go
@@ -458,7 +458,7 @@ func TestEmptyResponsesAreInvalid(t *testing.T) {
 	doc, err := loader.LoadFromData(spec)
 	require.NoError(t, err)
 
-	require.Equal(t, doc.ExternalDocs.Description, "See AsyncAPI example")
+	require.Equal(t, "See AsyncAPI example", doc.ExternalDocs.Description)
 
 	err = doc.Validate(context.Background())
 	require.EqualError(t, err, `invalid paths: invalid path /pet: invalid operation POST: the responses object MUST contain at least one response code`)

--- a/openapi3filter/validate_request_test.go
+++ b/openapi3filter/validate_request_test.go
@@ -212,7 +212,7 @@ components:
 			assert.NoError(t, err, "unable to read request body: %v", err)
 			assert.Equal(t, contentLen, bodySize, "expect ContentLength %d to equal body size %d", contentLen, bodySize)
 			bodyModified := originalBodySize != bodySize
-			assert.Equal(t, bodyModified, tc.expectedModification, "expect request body modification happened: %t, expected %t", bodyModified, tc.expectedModification)
+			assert.Equal(t, tc.expectedModification, bodyModified, "expect request body modification happened: %t, expected %t", bodyModified, tc.expectedModification)
 
 			validationInput.Request.Body, err = validationInput.Request.GetBody()
 			assert.NoError(t, err, "unable to re-generate body by GetBody(): %v", err)


### PR DESCRIPTION
This PR fixes the order of parameters in `assert.Equal/require.Equal` statements. According to the [doc](https://pkg.go.dev/github.com/stretchr/testify/require#Equal), the first parameter is `expected`, the second is `actual`.

It is planned [to change the order of assertion arguments](https://github.com/stretchr/testify/issues/1089#Argument_order) to more natural `(actual, expected)` in `v2` of `testify`.