### PR TITLE
openapi3,openapi3filter: replace interface{} with any

### DIFF
--- a/openapi3/issue82_test.go
+++ b/openapi3/issue82_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIssue82(t *testing.T) {
-	payload := map[string]interface{}{
+	payload := map[string]any{
 		"prop1": "val",
 		"prop3": "val",
 	}

--- a/openapi3/refs_issue247_test.go
+++ b/openapi3/refs_issue247_test.go
@@ -120,7 +120,7 @@ components:
 	require.NoError(t, err)
 
 	var ptr jsonpointer.Pointer
-	var v interface{}
+	var v any
 	var kind reflect.Kind
 
 	ptr, err = jsonpointer.New("/paths")

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -114,7 +114,7 @@ func appendToQueryValues[T any](q url.Values, parameterName string, v []T) {
 // populateDefaultQueryParameters populates default values inside query parameters, while ensuring types are respected
 func populateDefaultQueryParameters(q url.Values, parameterName string, value any) {
 	switch t := value.(type) {
-	case []interface{}:
+	case []any:
 		appendToQueryValues(q, parameterName, t)
 	default:
 		q.Add(parameterName, fmt.Sprintf("%v", value))


### PR DESCRIPTION
The PR replaces `interface{}` with `any` for consistency across the project.

Follows #966