### PR TITLE
openapi3filter: Simplify ValidateRequest implementation

### DIFF
--- a/.github/docs/openapi3filter.txt
+++ b/.github/docs/openapi3filter.txt
@@ -93,7 +93,7 @@ func ValidateParameter(ctx context.Context, input *RequestValidationInput, param
     defined. The function returns RequestError with a openapi3.SchemaError cause
     when a value is invalid by JSON schema.
 
-func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err error)
+func ValidateRequest(ctx context.Context, input *RequestValidationInput) error
     ValidateRequest is used to validate the given input according to previous
     loaded OpenAPIv3 spec. If the input does not match the OpenAPIv3 spec,
     a non-nil error will be returned.

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -29,7 +29,7 @@ var ErrInvalidEmptyValue = errors.New("empty value is not allowed")
 //
 // Note: One can tune the behavior of uniqueItems: true verification
 // by registering a custom function with openapi3.RegisterArrayUniqueItemsChecker
-func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err error) {
+func ValidateRequest(ctx context.Context, input *RequestValidationInput) error {
 	var me openapi3.MultiError
 
 	options := input.Options
@@ -49,10 +49,10 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 		security = &route.Spec.Security
 	}
 	if security != nil {
-		if err = ValidateSecurityRequirements(ctx, input, *security); err != nil && !options.MultiError {
-			return
-		}
-		if err != nil {
+		if err := ValidateSecurityRequirements(ctx, input, *security); err != nil {
+			if !options.MultiError {
+				return err
+			}
 			me = append(me, err)
 		}
 	}
@@ -66,10 +66,10 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 			}
 		}
 
-		if err = ValidateParameter(ctx, input, parameter); err != nil && !options.MultiError {
-			return
-		}
-		if err != nil {
+		if err := ValidateParameter(ctx, input, parameter); err != nil {
+			if !options.MultiError {
+				return err
+			}
 			me = append(me, err)
 		}
 	}
@@ -79,10 +79,10 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 		if options.ExcludeRequestQueryParams && parameter.Value.In == openapi3.ParameterInQuery {
 			continue
 		}
-		if err = ValidateParameter(ctx, input, parameter.Value); err != nil && !options.MultiError {
-			return
-		}
-		if err != nil {
+		if err := ValidateParameter(ctx, input, parameter.Value); err != nil {
+			if !options.MultiError {
+				return err
+			}
 			me = append(me, err)
 		}
 	}
@@ -90,10 +90,10 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 	// RequestBody
 	requestBody := operation.RequestBody
 	if requestBody != nil && !options.ExcludeRequestBody {
-		if err = ValidateRequestBody(ctx, input, requestBody.Value); err != nil && !options.MultiError {
-			return
-		}
-		if err != nil {
+		if err := ValidateRequestBody(ctx, input, requestBody.Value); err != nil {
+			if !options.MultiError {
+				return err
+			}
 			me = append(me, err)
 		}
 	}
@@ -101,7 +101,7 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) (err er
 	if len(me) > 0 {
 		return me
 	}
-	return
+	return nil
 }
 
 // appendToQueryValues adds to query parameters each value in the provided slice


### PR DESCRIPTION
The PR refactors `openapi3filter.ValidateRequest`. If `options.MultiError == true`, the function compares `err != nil` twice instead of once.