### PR TITLE
openapi2conv: convert references in nested additionalProperties schemas

### DIFF
--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -513,7 +513,7 @@ func ToV3SchemaRef(schema *openapi2.SchemaRef) *openapi3.SchemaRef {
 		MaxProps:             schema.Value.MaxProps,
 		AllOf:                make(openapi3.SchemaRefs, len(schema.Value.AllOf)),
 		Properties:           make(openapi3.Schemas),
-		AdditionalProperties: ToV3AdditionalProperties(schema.Value.AdditionalProperties),
+		AdditionalProperties: toV3AdditionalProperties(schema.Value.AdditionalProperties),
 	}
 
 	if schema.Value.Discriminator != "" {
@@ -547,7 +547,7 @@ func ToV3SchemaRef(schema *openapi2.SchemaRef) *openapi3.SchemaRef {
 	}
 }
 
-func ToV3AdditionalProperties(from openapi3.AdditionalProperties) openapi3.AdditionalProperties {
+func toV3AdditionalProperties(from openapi3.AdditionalProperties) openapi3.AdditionalProperties {
 	return openapi3.AdditionalProperties{
 		Has:    from.Has,
 		Schema: convertRefsInV3SchemaRef(from.Schema),
@@ -563,7 +563,7 @@ func convertRefsInV3SchemaRef(from *openapi3.SchemaRef) *openapi3.SchemaRef {
 	if to.Value != nil {
 		v := *from.Value
 		to.Value = &v
-		to.Value.AdditionalProperties = ToV3AdditionalProperties(to.Value.AdditionalProperties)
+		to.Value.AdditionalProperties = toV3AdditionalProperties(to.Value.AdditionalProperties)
 	}
 	return &to
 }

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -513,11 +513,7 @@ func ToV3SchemaRef(schema *openapi2.SchemaRef) *openapi3.SchemaRef {
 		MaxProps:             schema.Value.MaxProps,
 		AllOf:                make(openapi3.SchemaRefs, len(schema.Value.AllOf)),
 		Properties:           make(openapi3.Schemas),
-		AdditionalProperties: schema.Value.AdditionalProperties,
-	}
-
-	if schema.Value.AdditionalProperties.Schema != nil {
-		v3Schema.AdditionalProperties.Schema.Ref = ToV3Ref(schema.Value.AdditionalProperties.Schema.Ref)
+		AdditionalProperties: ToV3AdditionalProperties(schema.Value.AdditionalProperties),
 	}
 
 	if schema.Value.Discriminator != "" {
@@ -549,6 +545,27 @@ func ToV3SchemaRef(schema *openapi2.SchemaRef) *openapi3.SchemaRef {
 		Extensions: schema.Extensions,
 		Value:      v3Schema,
 	}
+}
+
+func ToV3AdditionalProperties(from openapi3.AdditionalProperties) openapi3.AdditionalProperties {
+	return openapi3.AdditionalProperties{
+		Has:    from.Has,
+		Schema: convertRefsInV3SchemaRef(from.Schema),
+	}
+}
+
+func convertRefsInV3SchemaRef(from *openapi3.SchemaRef) *openapi3.SchemaRef {
+	if from == nil {
+		return nil
+	}
+	to := *from
+	to.Ref = ToV3Ref(to.Ref)
+	if to.Value != nil {
+		v := *from.Value
+		to.Value = &v
+		to.Value.AdditionalProperties = ToV3AdditionalProperties(to.Value.AdditionalProperties)
+	}
+	return &to
 }
 
 var ref2To3 = map[string]string{


### PR DESCRIPTION
When the schema specified in `additionalProperties` contains another nested schema with `additionalProperties`, the schema references must be converted at all of levels of the nested schemas.

The following examples illustrate the problem.  This pull request fixes the issue by traversing all of the nested schemas in `additionalProperties`, making copies of the objects that are modified by the conversion.

Prior to this change, a schema reference is specified in a top-level `additionalProperties` was being converted correctly.  In the following example OpenAPI 2.0 definition, the reference to "#/definitions/Foo" is correctly converted to "#/components/schemas/Foo" in the OpenAPI 3.0 definition that is produced.

```
{
    "basePath": "/v2",
    "host": "test.example.com",
    "info": {
        "title": "MyAPI",
        "version": "0.1"
    },
    "paths": {
        "/foo": {
            "get": {
                "operationId": "getFoo",
                "produces": [
                    "application/json"
                ],
                "responses": {
                    "200": {
                        "description": "returns all information",
                        "schema":{
                            "type":"object",
                            "additionalProperties":{
                               "$ref":"#/definitions/Foo"
                            }
                        }
                    }
                },
                "summary": "get foo"
            }
        }
    },
        "definitions": {
            "Foo": {
                    "type": "object",
                        "properties": {
                            "a": {
                                    "type": "string"
                                }
                        }
                }
        },
    "schemes": [
        "http"
    ],
    "swagger": "2.0"
}
```

When there is a schema reference in an `additionalProperties` that is nested in the schema of another `additionalProperties`, then the conversion from OpenAPI 2.0 to OpenAPI 3.0 did not convert the schema reference to "#/components/schema/Foo".  This case is fixed by this pull request.

```
{
    "basePath": "/v2",
    "host": "test.example.com",
    "info": {
        "title": "MyAPI",
        "version": "0.1"
    },
    "paths": {
        "/foo": {
            "get": {
                "operationId": "getFoo",
                "produces": [
                    "application/json"
                ],
                "responses": {
                    "200": {
                        "description": "returns all information",
                        "schema":{
                            "type":"object",
                            "additionalProperties":{
                               "type":"object",
                               "additionalProperties":{
                                   "$ref":"#/definitions/Foo"
                               }
                            }
                        }
                    }
                },
                "summary": "get foo"
            }
        }
    },
        "definitions": {
            "Foo": {
                    "type": "object",
                        "properties": {
                            "a": {
                                    "type": "string"
                                }
                        }
                }
        },
    "schemes": [
        "http"
    ],
    "swagger": "2.0"
}
```