### PR TITLE
feat(openapi3gen): Customize json.RawMessage

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -290,11 +290,10 @@ func (g *Generator) generateWithoutSaving(parents []*theTypeInfo, t reflect.Type
 
 	case reflect.Slice:
 		if t.Elem().Kind() == reflect.Uint8 {
-			if t == rawMessageType {
-				return &openapi3.SchemaRef{Value: schema}, nil
+			if t != rawMessageType {
+				schema.Type = &openapi3.Types{"string"}
+				schema.Format = "byte"
 			}
-			schema.Type = &openapi3.Types{"string"}
-			schema.Format = "byte"
 		} else {
 			schema.Type = &openapi3.Types{"array"}
 			items, err := g.generateSchemaRefFor(parents, t.Elem(), name, tag)

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -407,7 +407,8 @@ func ExampleSchemaCustomizer() {
 			InnerFieldWithTag    int `mymintag:"-1" mymaxtag:"50"`
 			NestedInnerBla
 		}
-		Enum2Field string `json:"enum2" myenumtag:"c,d"`
+		Enum2Field string          `json:"enum2" myenumtag:"c,d"`
+		JsonField  json.RawMessage `json:"rawmsg" myjsontag:"raw"`
 	}
 
 	type Bla struct {
@@ -434,6 +435,9 @@ func ExampleSchemaCustomizer() {
 			for _, s := range strings.Split(tag.Get("myenumtag"), ",") {
 				schema.Enum = append(schema.Enum, s)
 			}
+		}
+		if tag.Get("myjsontag") != "" {
+			schema.Description = "description"
 		}
 		return nil
 	})
@@ -487,6 +491,9 @@ func ExampleSchemaCustomizer() {
 	//         "f"
 	//       ],
 	//       "type": "string"
+	//     },
+	//     "rawmsg": {
+	//       "description": "description"
 	//     }
 	//   },
 	//   "type": "object"


### PR DESCRIPTION
Using a SchemaCustomizer, I can't configure schemas for `json.RawMessage` fields. If I have the following struct

```go
type Foo struct {
    Bar string `json:"bar"`
    Output json.RawMessage `json:"output"`
}
```

The schema customization function will only be called for the Bar field, not the Output field.