### PR TITLE
openapi3gen: Fix issue with separate component generated for time.Time

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -429,6 +429,11 @@ func (g *Generator) generateWithoutSaving(parents []*theTypeInfo, t reflect.Type
 
 	// For structs we add the schemas to the component schemas
 	if len(parents) > 1 || g.opts.exportComponentSchemas.ExportTopLevelSchema {
+		// If struct is a time.Time instance, separate component shouldn't be generated
+		if t == timeType {
+			return openapi3.NewSchemaRef(t.Name(), schema), nil
+		}
+
 		typeName := g.generateTypeName(t)
 
 		g.componentSchemaRefs[typeName] = struct{}{}

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"reflect"
 	"strconv"
 	"strings"
@@ -640,4 +641,29 @@ func ExampleSetSchemar() {
 	//   },
 	//   "type": "object"
 	// }
+}
+
+func TestExportComponentSchemasForTimeProp(t *testing.T) {
+	type Some struct {
+		Name      string
+		CreatedAt time.Time
+	}
+
+	schemas := make(openapi3.Schemas)
+	g := openapi3gen.NewGenerator(
+		openapi3gen.UseAllExportedFields(),
+		openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
+			ExportComponentSchemas: true,
+		}),
+	)
+
+	ref, err := g.NewSchemaRefForValue(&Some{}, schemas)
+	require.NoError(t, err)
+
+	schema, err := json.MarshalIndent(ref, "", "  ")
+	require.NoError(t, err)
+
+	assert.Condition(t, func() bool {
+		return !strings.Contains(string(schema), "#/components/schemas/Time")
+	}, "Expected no schema for time.Time property but got one: %s", schema)
 }


### PR DESCRIPTION
openapi3gen generates separate schema component for time.Time properies, when ExportComponentSchemas opt provided.
Here is a small example:
```go
type Some struct {
	Name      string
	CreatedAt time.Time
}

func main() {
	schemas := make(openapi3.Schemas)
	g := openapi3gen.NewGenerator(
		openapi3gen.UseAllExportedFields(),
		openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
			ExportComponentSchemas: true,
		}),
	)

	ref, err := g.NewSchemaRefForValue(&Some{}, schemas)
	if err != nil {
		panic(err)
	}

	schema, _ := json.MarshalIndent(ref, "", "  ")
	fmt.Println(string(schema))
}
```

Expected output is:
```json
{
  "properties": {
    "CreatedAt": {
      "format": "date-time",
      "type": "string"
    },
    "Name": {
      "type": "string"
    }
  },
  "type": "object"
}
```

But for now generator produces following:
```json
{
  "properties": {
    "CreatedAt": {
      "$ref": "#/components/schemas/Time"
    },
    "Name": {
      "type": "string"
    }
  },
  "type": "object"
}
```