### PR TITLE
openapi3: delete origin keys only when IncludeOrigin=true

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -90,6 +90,11 @@ var ErrURINotSupported = errors.New("unsupported URI")
     ErrURINotSupported indicates the ReadFromURIFunc does not know how to handle
     a given URI.
 
+var IncludeOrigin = false
+    IncludeOrigin specifies whether to include the origin of the OpenAPI
+    elements Set this to true before loading a spec to include the origin of the
+    OpenAPI elements Note it is global and affects all loaders
+
 
 FUNCTIONS
 
@@ -789,9 +794,6 @@ func (links *Links) UnmarshalJSON(data []byte) (err error)
 type Loader struct {
 	// IsExternalRefsAllowed enables visiting other files
 	IsExternalRefsAllowed bool
-
-	// IncludeOrigin specifies whether to include the origin of the OpenAPI elements
-	IncludeOrigin bool
 
 	// ReadFromURIFunc allows overriding the any file/URL reading func
 	ReadFromURIFunc ReadFromURIFunc

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -15,6 +15,11 @@ import (
 	"strings"
 )
 
+// IncludeOrigin specifies whether to include the origin of the OpenAPI elements
+// Set this to true before loading a spec to include the origin of the OpenAPI elements
+// Note it is global and affects all loaders
+var IncludeOrigin = false
+
 func foundUnresolvedRef(ref string) error {
 	return fmt.Errorf("found unresolved ref: %q", ref)
 }
@@ -27,9 +32,6 @@ func failedToResolveRefFragmentPart(value, what string) error {
 type Loader struct {
 	// IsExternalRefsAllowed enables visiting other files
 	IsExternalRefsAllowed bool
-
-	// IncludeOrigin specifies whether to include the origin of the OpenAPI elements
-	IncludeOrigin bool
 
 	// ReadFromURIFunc allows overriding the any file/URL reading func
 	ReadFromURIFunc ReadFromURIFunc
@@ -106,7 +108,7 @@ func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, el
 	if err != nil {
 		return nil, err
 	}
-	if err := unmarshal(data, element, loader.IncludeOrigin); err != nil {
+	if err := unmarshal(data, element, IncludeOrigin); err != nil {
 		return nil, err
 	}
 
@@ -142,7 +144,7 @@ func (loader *Loader) LoadFromIoReader(reader io.Reader) (*T, error) {
 func (loader *Loader) LoadFromData(data []byte) (*T, error) {
 	loader.resetVisitedPathItemRefs()
 	doc := &T{}
-	if err := unmarshal(data, doc, loader.IncludeOrigin); err != nil {
+	if err := unmarshal(data, doc, IncludeOrigin); err != nil {
 		return nil, err
 	}
 	if err := loader.ResolveRefsIn(doc, nil); err != nil {
@@ -171,7 +173,7 @@ func (loader *Loader) loadFromDataWithPathInternal(data []byte, location *url.UR
 	doc := &T{}
 	loader.visitedDocuments[uri] = doc
 
-	if err := unmarshal(data, doc, loader.IncludeOrigin); err != nil {
+	if err := unmarshal(data, doc, IncludeOrigin); err != nil {
 		return nil, err
 	}
 
@@ -425,7 +427,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		if err2 != nil {
 			return nil, nil, err
 		}
-		if err2 = unmarshal(data, &cursor, loader.IncludeOrigin); err2 != nil {
+		if err2 = unmarshal(data, &cursor, IncludeOrigin); err2 != nil {
 			return nil, nil, err
 		}
 		if cursor, err2 = drill(cursor); err2 != nil || cursor == nil {

--- a/openapi3/origin_test.go
+++ b/openapi3/origin_test.go
@@ -348,3 +348,32 @@ func TestOrigin_XML(t *testing.T) {
 		},
 		base.Origin.Fields["prefix"])
 }
+
+// TestOrigin_OriginFieldInMap replicates https://github.com/getkin/kin-openapi/issues/1051
+func TestOrigin_OriginFieldInMap(t *testing.T) {
+	var data = `
+paths:
+  /foo:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Foo"
+components:
+  schemas:
+    Foo:
+      type: object
+      properties:
+        origin:
+          type: string
+`
+
+	loader := NewLoader()
+	doc, err := loader.LoadFromData([]byte(data))
+	require.NoError(t, err)
+
+	require.NotEmpty(t, doc.Paths.Find("/foo").Get.Responses.Status(200).Value.Content.Get("application/json").Schema.Value.Properties["origin"])
+}

--- a/openapi3/origin_test.go
+++ b/openapi3/origin_test.go
@@ -469,5 +469,6 @@ components:
 	defer unsetIncludeOrigin()
 
 	_, err := loader.LoadFromData([]byte(data))
-	require.Equal(t, "failed to unmarshal data: json error: invalid character 'p' looking for beginning of value, yaml error: error converting YAML to JSON: yaml: unmarshal errors:\n  line 0: mapping key \"origin\" already defined at line 17", err.Error())
+	require.Equal(t, `failed to unmarshal data: json error: invalid character 'p' looking for beginning of value, yaml error: error converting YAML to JSON: yaml: unmarshal errors:
+  line 0: mapping key "origin" already defined at line 17`, err.Error())
 }

--- a/openapi3/stringmap.go
+++ b/openapi3/stringmap.go
@@ -18,11 +18,10 @@ func unmarshalStringMapP[V any](data []byte) (map[string]*V, *Origin, error) {
 		return nil, nil, err
 	}
 
-	origin, err := deepCast[Origin](m[originKey])
+	origin, err := popOrigin(m, originKey)
 	if err != nil {
 		return nil, nil, err
 	}
-	delete(m, originKey)
 
 	result := make(map[string]*V, len(m))
 	for k, v := range m {
@@ -43,11 +42,10 @@ func unmarshalStringMap[V any](data []byte) (map[string]V, *Origin, error) {
 		return nil, nil, err
 	}
 
-	origin, err := deepCast[Origin](m[originKey])
+	origin, err := popOrigin(m, originKey)
 	if err != nil {
 		return nil, nil, err
 	}
-	delete(m, originKey)
 
 	result := make(map[string]V, len(m))
 	for k, v := range m {
@@ -73,4 +71,18 @@ func deepCast[V any](value any) (*V, error) {
 		return nil, err
 	}
 	return &result, nil
+}
+
+// popOrigin removes the origin from the map and returns it.
+func popOrigin(m map[string]any, key string) (*Origin, error) {
+	if !IncludeOrigin {
+		return nil, nil
+	}
+
+	origin, err := deepCast[Origin](m[key])
+	if err != nil {
+		return nil, err
+	}
+	delete(m, key)
+	return origin, nil
 }


### PR DESCRIPTION
This PR fixes https://github.com/getkin/kin-openapi/issues/1051.
The problem was caused because openapi3 removed `origin` keys from `Schema.Properties` and other map-based types including all `Components` types.
To fix this I changed the behavior to only delete `origin` keys when `IncludeOrigin` is set to true.
Note that this required moving `Loader.IncludeOrigin` to the global scope so that map unmarshalling functions can access it.
For example: `Schemas.UnmarshalJSON` -> `unmarshalStringMapP` -> `popOrigin` which accesses `IncludeOrigin`