### PR TITLE
openapi3filter: Remove redundant ExcludeResponseBody check

### DIFF
--- a/openapi3filter/validate_response.go
+++ b/openapi3filter/validate_response.go
@@ -94,7 +94,7 @@ func ValidateResponse(ctx context.Context, input *ResponseValidationInput) error
 	}
 
 	content := response.Content
-	if len(content) == 0 || options.ExcludeResponseBody {
+	if len(content) == 0 {
 		// An operation does not contains a validation schema for responses with this status code.
 		return nil
 	}


### PR DESCRIPTION
This PR removes a redundant condition check in the ValidateResponse function.

Currently, there are two checks for `options.ExcludeResponseBody`:

```go
// First check at line 91
if options.ExcludeResponseBody {
    // A user turned off validation of a response's body.
    return nil
}

// Second check at line 97 (redundant)
if len(content) == 0 || options.ExcludeResponseBody {
    // An operation does not contains a validation schema for responses with this status code.
    return nil
}
```

The second check is redundant because if `options.ExcludeResponseBody` is true, the function would have already returned at the first check. This PR removes the redundant condition to improve code clarity.
