### PR TITLE
style: Use fmt.Sprint without formating

### DIFF
--- a/openapi3/issue376_test.go
+++ b/openapi3/issue376_test.go
@@ -139,7 +139,7 @@ info:
 					}
 					apaStr := ""
 					if apa != nil {
-						apaStr = fmt.Sprintf("%v", *apa)
+						apaStr = fmt.Sprint(apa)
 					}
 
 					encoded, err := propSchema.MarshalJSON()

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -53,7 +53,7 @@ func (e *ParseError) Error() string {
 	if p := e.Path(); len(p) > 0 {
 		var arr []string
 		for _, v := range p {
-			arr = append(arr, fmt.Sprintf("%v", v))
+			arr = append(arr, fmt.Sprint(v))
 		}
 		msg = append(msg, fmt.Sprintf("path %v", strings.Join(arr, ".")))
 	}

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -1859,7 +1859,7 @@ func TestRegisterAndUnregisterBodyDecoder(t *testing.T) {
 		}
 		return strings.Split(string(data), ","), nil
 	}
-	contentType := "application/csv"
+	const contentType = "application/csv"
 	h := make(http.Header)
 	h.Set(headerCT, contentType)
 
@@ -1867,7 +1867,7 @@ func TestRegisterAndUnregisterBodyDecoder(t *testing.T) {
 	require.Nil(t, originalDecoder)
 
 	RegisterBodyDecoder(contentType, decoder)
-	require.Equal(t, fmt.Sprintf("%v", decoder), fmt.Sprintf("%v", RegisteredBodyDecoder(contentType)))
+	require.Equal(t, fmt.Sprint(decoder), fmt.Sprint(RegisteredBodyDecoder(contentType)))
 
 	body := strings.NewReader("foo,bar")
 	schema := openapi3.NewArraySchema().WithItems(openapi3.NewStringSchema()).NewRef()

--- a/openapi3filter/req_resp_encoder_test.go
+++ b/openapi3filter/req_resp_encoder_test.go
@@ -2,7 +2,6 @@ package openapi3filter
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -14,15 +13,13 @@ func TestRegisterAndUnregisterBodyEncoder(t *testing.T) {
 	encoder = func(body any) (data []byte, err error) {
 		return []byte(strings.Join(body.([]string), ",")), nil
 	}
-	contentType := "text/csv"
-	h := make(http.Header)
-	h.Set(headerCT, contentType)
+	const contentType = "text/csv"
 
 	originalEncoder := RegisteredBodyEncoder(contentType)
 	require.Nil(t, originalEncoder)
 
 	RegisterBodyEncoder(contentType, encoder)
-	require.Equal(t, fmt.Sprintf("%v", encoder), fmt.Sprintf("%v", RegisteredBodyEncoder(contentType)))
+	require.Equal(t, fmt.Sprint(encoder), fmt.Sprint(RegisteredBodyEncoder(contentType)))
 
 	body := []string{"foo", "bar"}
 	got, err := encodeBody(body, contentType)

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -108,14 +108,14 @@ func ValidateRequest(ctx context.Context, input *RequestValidationInput) error {
 // appendToQueryValues adds to query parameters each value in the provided slice
 func appendToQueryValues[T any](q url.Values, parameterName string, v []T) {
 	for _, i := range v {
-		q.Add(parameterName, fmt.Sprintf("%v", i))
+		q.Add(parameterName, fmt.Sprint(i))
 	}
 }
 
 func joinValues(values []any, sep string) string {
 	strValues := make([]string, 0, len(values))
 	for _, v := range values {
-		strValues = append(strValues, fmt.Sprintf("%v", v))
+		strValues = append(strValues, fmt.Sprint(v))
 	}
 	return strings.Join(strValues, sep)
 }
@@ -130,7 +130,7 @@ func populateDefaultQueryParameters(q url.Values, parameterName string, value an
 			q.Add(parameterName, joinValues(t, ","))
 		}
 	default:
-		q.Add(parameterName, fmt.Sprintf("%v", value))
+		q.Add(parameterName, fmt.Sprint(value))
 	}
 }
 
@@ -139,7 +139,7 @@ func populateDefaultQueryParameters(q url.Values, parameterName string, value an
 // The function returns RequestError with ErrInvalidRequired cause when a value of a required parameter is not defined.
 // The function returns RequestError with ErrInvalidEmptyValue cause when a value of a required parameter is not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
-func ValidateParameter(ctx context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
+func ValidateParameter(_ context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
 	if parameter.Schema == nil && parameter.Content == nil {
 		// We have no schema for the parameter. Assume that everything passes
 		// a schema-less check, but this could also be an error. The OpenAPI
@@ -191,11 +191,11 @@ func ValidateParameter(ctx context.Context, input *RequestValidationInput, param
 				populateDefaultQueryParameters(q, parameter.Name, value, explode)
 				req.URL.RawQuery = q.Encode()
 			case openapi3.ParameterInHeader:
-				req.Header.Add(parameter.Name, fmt.Sprintf("%v", value))
+				req.Header.Add(parameter.Name, fmt.Sprint(value))
 			case openapi3.ParameterInCookie:
 				req.AddCookie(&http.Cookie{
 					Name:  parameter.Name,
-					Value: fmt.Sprintf("%v", value),
+					Value: fmt.Sprint(value),
 				})
 			}
 		}
@@ -237,7 +237,7 @@ const prefixInvalidCT = "header Content-Type has unexpected value"
 //
 // The function returns RequestError with ErrInvalidRequired cause when a value is required but not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
-func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, requestBody *openapi3.RequestBody) error {
+func ValidateRequestBody(_ context.Context, input *RequestValidationInput, requestBody *openapi3.RequestBody) error {
 	var (
 		req  = input.Request
 		data []byte

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -139,7 +139,7 @@ func populateDefaultQueryParameters(q url.Values, parameterName string, value an
 // The function returns RequestError with ErrInvalidRequired cause when a value of a required parameter is not defined.
 // The function returns RequestError with ErrInvalidEmptyValue cause when a value of a required parameter is not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
-func ValidateParameter(_ context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
+func ValidateParameter(ctx context.Context, input *RequestValidationInput, parameter *openapi3.Parameter) error {
 	if parameter.Schema == nil && parameter.Content == nil {
 		// We have no schema for the parameter. Assume that everything passes
 		// a schema-less check, but this could also be an error. The OpenAPI
@@ -237,7 +237,7 @@ const prefixInvalidCT = "header Content-Type has unexpected value"
 //
 // The function returns RequestError with ErrInvalidRequired cause when a value is required but not defined.
 // The function returns RequestError with a openapi3.SchemaError cause when a value is invalid by JSON schema.
-func ValidateRequestBody(_ context.Context, input *RequestValidationInput, requestBody *openapi3.RequestBody) error {
+func ValidateRequestBody(ctx context.Context, input *RequestValidationInput, requestBody *openapi3.RequestBody) error {
 	var (
 		req  = input.Request
 		data []byte

--- a/openapi3filter/validation_error_encoder.go
+++ b/openapi3filter/validation_error_encoder.go
@@ -160,13 +160,13 @@ func convertSchemaError(e *RequestError, innerErr *openapi3.SchemaError) *Valida
 	if innerErr.SchemaField == "enum" {
 		enums := make([]string, 0, len(innerErr.Schema.Enum))
 		for _, enum := range innerErr.Schema.Enum {
-			enums = append(enums, fmt.Sprintf("%v", enum))
+			enums = append(enums, fmt.Sprint(enum))
 		}
 		cErr.Detail = fmt.Sprintf("value %v at %s must be one of: %s",
 			innerErr.Value,
 			toJSONPointer(innerErr.JSONPointer()),
 			strings.Join(enums, ", "))
-		value := fmt.Sprintf("%v", innerErr.Value)
+		value := fmt.Sprint(innerErr.Value)
 		if e.Parameter != nil &&
 			(e.Parameter.Explode == nil || *e.Parameter.Explode) &&
 			(e.Parameter.Style == "" || e.Parameter.Style == "form") &&

--- a/openapi3filter/validation_error_test.go
+++ b/openapi3filter/validation_error_test.go
@@ -592,13 +592,13 @@ func TestValidationHandler_validateRequest(t *testing.T) {
 					req.Equal(tt.wantErrSchemaReason, innerErr.Reason)
 					pointer := toJSONPointer(innerErr.JSONPointer())
 					req.Equal(tt.wantErrSchemaPath, pointer)
-					req.Equal(fmt.Sprintf("%v", tt.wantErrSchemaValue), fmt.Sprintf("%v", innerErr.Value))
+					req.Equal(fmt.Sprint(tt.wantErrSchemaValue), fmt.Sprint(innerErr.Value))
 
 					if originErr, ok := innerErr.Origin.(*openapi3.SchemaError); ok {
 						req.Equal(tt.wantErrSchemaOriginReason, originErr.Reason)
 						pointer := toJSONPointer(originErr.JSONPointer())
 						req.Equal(tt.wantErrSchemaOriginPath, pointer)
-						req.Equal(fmt.Sprintf("%v", tt.wantErrSchemaOriginValue), fmt.Sprintf("%v", originErr.Value))
+						req.Equal(fmt.Sprint(tt.wantErrSchemaOriginValue), fmt.Sprint(originErr.Value))
 					}
 				} else {
 					req.False(tt.wantErrSchemaReason != "" || tt.wantErrSchemaPath != "",


### PR DESCRIPTION
`fmt.Sprintf("%v", somthing)` can be safely simplified by `fmt.Sprint(something)`