### PR TITLE
openapi3: resolve Snyk security warning with path traversal

### DIFF
--- a/openapi3/loader_uri_reader.go
+++ b/openapi3/loader_uri_reader.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"sync"
 )
@@ -79,7 +80,7 @@ func ReadFromFile(loader *Loader, location *url.URL) ([]byte, error) {
 	if !is_file(location) {
 		return nil, ErrURINotSupported
 	}
-	return os.ReadFile(filepath.FromSlash(location.Path))
+	return os.ReadFile(path.Clean(filepath.FromSlash(location.Path)))
 }
 
 // URIMapCache returns a ReadFromURIFunc that caches the contents read from URI


### PR DESCRIPTION
I am using kin-openapi on a project and Snyk blocked me with an error:

> **Path Traversal**
> Unsanitized input from the request URL flows into os.ReadFile, where it is used as a path. This may result in a Path Traversal vulnerability and allow an attacker to read arbitrary files.

This PR proposes a remediation.

Thank for this really useful library!