### PR TITLE
openapifilter: Add support for RFC 7396 application/merge-patch+json

### DIFF
--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1264,6 +1264,7 @@ func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, 
 func init() {
 	RegisterBodyDecoder("application/json", JSONBodyDecoder)
 	RegisterBodyDecoder("application/json-patch+json", JSONBodyDecoder)
+	RegisterBodyDecoder("application/merge-patch+json", JSONBodyDecoder)
 	RegisterBodyDecoder("application/ld+json", JSONBodyDecoder)
 	RegisterBodyDecoder("application/hal+json", JSONBodyDecoder)
 	RegisterBodyDecoder("application/vnd.api+json", JSONBodyDecoder)


### PR DESCRIPTION
One-liner to add support for RFC 7396. It is fairly well-known and it took me some time to figure out how to register it manually so this hopefully saves somebody some time.