### PR TITLE
openapi3: resolve refs in parameter examples

### DIFF
--- a/openapi3/issue_ref_in_example_test.go
+++ b/openapi3/issue_ref_in_example_test.go
@@ -1,0 +1,28 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRefinExample(t *testing.T) {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromFile("testdata/issue_ref_in_example.yml")
+	require.NoError(t, err)
+
+	err = doc.Validate(loader.Context)
+	require.NoError(t, err)
+
+	param := doc.Components.Parameters["SortBy"].Value
+	require.NotNil(t, param, "Parameter should not be nil")
+
+	exampleRef := param.Examples["NiceExample"]
+	require.NotNil(t, exampleRef, "Example ref should not be nil")
+
+	// Before the fix, this would be nil
+	require.NotNil(t, exampleRef.Value, "Example value should not be nil after loading")
+	require.Equal(t, "Just a nice example.", exampleRef.Value.Summary)
+	require.Equal(t, "fooBar", exampleRef.Value.Value)
+}

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -657,6 +657,11 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 			return err
 		}
 	}
+	for _, example := range value.Examples {
+		if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -716,9 +721,19 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 				return err
 			}
 		}
+		for _, example := range contentType.Examples {
+			if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
+				return err
+			}
+		}
 	}
 	if schema := value.Schema; schema != nil {
 		if err := loader.resolveSchemaRef(doc, schema, documentPath, []string{}); err != nil {
+			return err
+		}
+	}
+	for _, example := range value.Examples {
+		if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
 			return err
 		}
 	}

--- a/openapi3/testdata/issue_ref_in_example.yml
+++ b/openapi3/testdata/issue_ref_in_example.yml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Example with references API
+  version: 1.0.0
+paths:
+  /items:
+    get:
+      parameters:
+        - $ref: '#/components/parameters/SortBy'
+      responses:
+        '200':
+          description: OK
+components:
+  parameters:
+    SortBy:
+      name: sortBy
+      in: query
+      description: This is where it all goes downhill
+      schema:
+        type: string
+      examples:
+        NiceExample:
+          $ref: '#/components/examples/NiceExample'
+  examples:
+    NiceExample:
+      summary: Just a nice example.
+      value: fooBar


### PR DESCRIPTION
This commit fixes a bug where `$ref`s in parameter examples were not being resolved during the loading of an OpenAPI 3 document. This would cause a validation error when the document was validated.

The fix ensures that all `ExampleRef`s are properly resolved in `resolveParameterRef`, `resolveHeaderRef`, and `resolveRequestBodyRef` in `openapi3/loader.go`.

A new test case is added to verify that the fix is working correctly.

This will fix: https://github.com/oasdiff/oasdiff/issues/730