### PR TITLE
openapi3filter: Fix empty string handling in parameter validation

### DIFF
--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -565,6 +565,12 @@ func (d *urlValuesDecoder) parseArray(raw []string, sm *openapi3.SerializationMe
 		}
 		value = append(value, item)
 	}
+	// If the array has only one element and that element is an empty string, it means no value exists, so return nil.
+	if len(value) == 1 {
+		if str, ok := value[0].(string); ok && str == "" {
+			return nil, nil
+		}
+	}
 	return value, nil
 }
 
@@ -1116,13 +1122,13 @@ func parseArray(raw []string, schemaRef *openapi3.SchemaRef) ([]any, error) {
 }
 
 // parsePrimitive returns a value that is created by parsing a source string to a primitive type
-// that is specified by a schema. The function returns nil when the source string is empty.
+// that is specified by a schema. The function returns nil when the source string is empty and the type is not "string".
 // The function panics when a schema has a non-primitive type.
 func parsePrimitive(raw string, schema *openapi3.SchemaRef) (v any, err error) {
-	if raw == "" {
-		return nil, nil
-	}
 	for _, typ := range schema.Value.Type.Slice() {
+		if raw == "" && typ != "string" {
+			return nil, nil
+		}
 		if v, err = parsePrimitiveCase(raw, schema, typ); err == nil {
 			return
 		}

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -672,10 +672,24 @@ func TestDecodeParameter(t *testing.T) {
 					found: true,
 				},
 				{
+					name:  "string empty",
+					param: &openapi3.Parameter{Name: "param", In: "query", Schema: stringSchema},
+					query: "param=",
+					want:  "",
+					found: true,
+				},
+				{
 					name:  "integer",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: integerSchema},
 					query: "param=1",
 					want:  int64(1),
+					found: true,
+				},
+				{
+					name:  "integer empty",
+					param: &openapi3.Parameter{Name: "param", In: "query", Schema: integerSchema},
+					query: "param=",
+					want:  nil,
 					found: true,
 				},
 				{
@@ -693,6 +707,13 @@ func TestDecodeParameter(t *testing.T) {
 					found: true,
 				},
 				{
+					name:  "number empty",
+					param: &openapi3.Parameter{Name: "param", In: "query", Schema: numberSchema},
+					query: "param=",
+					want:  nil,
+					found: true,
+				},
+				{
 					name:  "number invalid",
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: numberSchema},
 					query: "param=foo",
@@ -704,6 +725,13 @@ func TestDecodeParameter(t *testing.T) {
 					param: &openapi3.Parameter{Name: "param", In: "query", Schema: booleanSchema},
 					query: "param=true",
 					want:  true,
+					found: true,
+				},
+				{
+					name:  "boolean empty",
+					param: &openapi3.Parameter{Name: "param", In: "query", Schema: booleanSchema},
+					query: "param=",
+					want:  nil,
 					found: true,
 				},
 				{

--- a/openapi3filter/validate_response_test.go
+++ b/openapi3filter/validate_response_test.go
@@ -42,8 +42,7 @@ func Test_validateResponseHeader(t *testing.T) {
 			},
 			isHeaderPresent: true,
 			headerVals:      []string{""},
-			wantErr:         true,
-			wantErrMsg:      `response header "X-Blab" doesn't match schema: Value is not nullable`,
+			wantErr:         false,
 		},
 		{
 			name: "test optional string header with single string value",


### PR DESCRIPTION
Since v0.133.0, empty string values have been incorrectly treated as `nil`. This caused validation to fail for required (non-nullable) parameters that should accept an empty string.

This PR fixes this behavior:
* Empty strings (`""`) are no longer converted to `nil` during parameter decoding.
* Validation for non-nullable parameters now passes correctly when an empty string is provided.
