### PR TITLE
openapi3filter: feat(multipart-ct-decoder): default body decoder on binary schema

### DIFF
--- a/openapi3filter/zip_file_upload_test.go
+++ b/openapi3filter/zip_file_upload_test.go
@@ -42,6 +42,9 @@ paths:
                 file:
                   type: string
                   format: binary
+            encoding:
+              file:
+                contentType: application/zip
       responses:
         '200':
           description: Created


### PR DESCRIPTION
based on the discussion in https://github.com/getkin/kin-openapi/pull/1088#issuecomment-3253767549

when i try to pass `type: string format: binary` file of a [registered type](https://github.com/getkin/kin-openapi/blob/2baea3d16906f92e241304527137592a8251afc9/openapi3filter/req_resp_decoder.go#L1256) in a multipart part, it fails on validation

on binary i expect it to use FileBodyDecoder

- added validation on content-type from encoding.contentType string
- using FileBodyDecoder as default when schema is type: string format: binary AND strict content-type is not specified in the encoding object