### PR TITLE
openapi3: ensure SchemaErrors get the correct path for allOf schemas

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -2144,6 +2144,9 @@ func markSchemaErrorKey(err error, key string) error {
 				if me, ok := unwrapped.(multiErrorForOneOf); ok {
 					_ = markSchemaErrorKey(MultiError(me), key)
 				}
+				if me, ok := unwrapped.(multiErrorForAllOf); ok {
+					_ = markSchemaErrorKey(MultiError(me), key)
+				}
 			}
 		}
 		return v

--- a/openapi3/schema_allof_test.go
+++ b/openapi3/schema_allof_test.go
@@ -1,0 +1,85 @@
+package openapi3
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAllOfErrorPreserved(t *testing.T) {
+
+	SchemaErrorDetailsDisabled = true
+	defer func() { SchemaErrorDetailsDisabled = false }()
+
+	// language=json
+	raw := `
+{
+	"foo": {
+		"key1": "foo",
+		"key2": 1
+	}
+}
+`
+
+	// language=json
+	schema := `
+{
+	"type": "object",
+	"properties": {
+		"foo": {
+			"allOf": [
+				{
+					"type": "object",
+					"properties": {
+						"key1": {
+							"type": "number"
+						}
+					}
+				},
+				{
+					"type": "object",
+					"properties": {
+						"key2": {
+							"type": "string"
+						}
+					}
+				}
+			]
+		}
+	}
+}
+`
+
+	s := NewSchema()
+	err := s.UnmarshalJSON([]byte(schema))
+	require.NoError(t, err)
+	err = s.Validate(context.Background())
+	require.NoError(t, err)
+
+	obj := make(map[string]any)
+	err = json.Unmarshal([]byte(raw), &obj)
+	require.NoError(t, err)
+
+	err = s.VisitJSON(obj, MultiErrors())
+	require.Error(t, err)
+
+	var multiError MultiError
+	ok := errors.As(err, &multiError)
+	require.True(t, ok)
+	var schemaErr *SchemaError
+	ok = errors.As(multiError[0], &schemaErr)
+	require.True(t, ok)
+
+	require.Equal(t, "allOf", schemaErr.SchemaField)
+	require.Equal(t, `doesn't match all schemas from "allOf"`, schemaErr.Reason)
+	require.Equal(t, `Error at "/foo": doesn't match schema due to: Error at "/key1": value must be a number And Error at "/key2": value must be a string`, schemaErr.Error())
+
+	var me multiErrorForAllOf
+	ok = errors.As(err, &me)
+	require.True(t, ok)
+	require.Equal(t, `Error at "/foo/key1": value must be a number`, me[0].Error())
+	require.Equal(t, `Error at "/foo/key2": value must be a string`, me[1].Error())
+}


### PR DESCRIPTION
Since #1087, `SchemaError`s raised from a child of an allOf schemas did not get the correct paths.