### PR TITLE
openapi3filter: fix bug where absent optional properties fail validation in form-urlencoded requests

### DIFF
--- a/openapi3filter/issue1110_test.go
+++ b/openapi3filter/issue1110_test.go
@@ -1,0 +1,101 @@
+package openapi3filter
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+func TestIssue1110(t *testing.T) {
+	// Test case: POST with application/x-www-form-urlencoded
+	// Schema has two optional properties (not required)
+	// Sending only one param should be valid since no fields are required
+	spec := `
+openapi: 3.0.3
+info:
+  version: 1.0.0
+  title: Test API
+paths:
+  /test:
+    post:
+      summary: Test endpoint with optional form parameters
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                param1:
+                  type: string
+                param2:
+                  type: string
+      responses:
+        '200':
+          description: OK
+`[1:]
+
+	loader := openapi3.NewLoader()
+	ctx := loader.Context
+
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	err = doc.Validate(ctx)
+	require.NoError(t, err)
+
+	router, err := gorillamux.NewRouter(doc)
+	require.NoError(t, err)
+
+	for _, testcase := range []struct {
+		name       string
+		data       string
+		shouldFail bool
+	}{
+		{
+			name:       "empty body should be valid (no required fields)",
+			data:       "",
+			shouldFail: false,
+		},
+		{
+			name:       "only param1 present, param2 absent - should be valid",
+			data:       "param1=value1",
+			shouldFail: false,
+		},
+		{
+			name:       "only param2 present, param1 absent - should be valid",
+			data:       "param2=value2",
+			shouldFail: false,
+		},
+		{
+			name:       "both params present - should be valid",
+			data:       "param1=value1&param2=value2",
+			shouldFail: false,
+		},
+	} {
+		t.Run(testcase.name, func(t *testing.T) {
+			req, err := http.NewRequest("POST", "/test", strings.NewReader(testcase.data))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+			route, pathParams, err := router.FindRoute(req)
+			require.NoError(t, err)
+
+			validationInput := &RequestValidationInput{
+				Request:    req,
+				PathParams: pathParams,
+				Route:      route,
+			}
+			err = ValidateRequest(ctx, validationInput)
+			if testcase.shouldFail {
+				require.Error(t, err, "This test should fail: "+testcase.name)
+			} else {
+				require.NoError(t, err, "This test should pass: "+testcase.name)
+			}
+		})
+	}
+}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1364,8 +1364,8 @@ func decodeSchemaConstructs(dec *urlValuesDecoder, schemas []*openapi3.SchemaRef
 		}
 
 		for name, prop := range schemaRef.Value.Properties {
-			value, _, err := decodeProperty(dec, name, prop, encFn)
-			if err != nil {
+			value, present, err := decodeProperty(dec, name, prop, encFn)
+			if err != nil || !present {
 				continue
 			}
 			if existingValue, exists := obj[name]; exists && !isEqual(existingValue, value) {


### PR DESCRIPTION
# openapi3filter: fix bug where absent optional properties fail validation in form-urlencoded requests

## Summary

Fix validation of absent optional properties in `application/x-www-form-urlencoded` request bodies.

## The Bug

When a form-urlencoded request body has multiple optional properties defined in the schema, and only some of them are sent in the request, the validation incorrectly fails with:

```
Error at "/param2": Value is not nullable
```

**Reproduction case:**
- Schema defines two optional string properties: `param1` and `param2`
- Request sends only `param1=value1`
- Expected: validation passes (param2 is optional)
- Actual: validation fails because absent `param2` is treated as `null`

Note: the bug only manifests when at least one property is present. An empty body passes validation.

## The Fix

When decoding properties, skip absent ones entirely instead of adding them as `null` to the decoded object:

```go
value, present, err := decodeProperty(dec, name, prop, encFn)
if err != nil || !present {
    continue
}
```

## Specification Analysis

### Absent vs Null: Two Distinct Concepts

According to [OpenAPI Specification discussions](https://github.com/OAI/OpenAPI-Specification/issues/2037):

> "Basically null has the meaning of 'this property existed before, and I want to nullify its value'. If there's no value, or the value needs not change, it just shouldn't be sent."

This clearly distinguishes:
- **Absent**: property not sent ‚Üí should not be validated
- **Null**: property explicitly set to null ‚Üí should be validated against `nullable`

### No Native Null in form-urlencoded

[RFC 1866](https://www.freesoft.org/CIE/RFC/1866/88.htm) defines form-urlencoded as key=value pairs where:
- `param=value` ‚Üí string value
- `param=` ‚Üí empty string `""`
- absence of param ‚Üí not sent

The RFC states: "Fields with null values may be omitted" ‚Äî but here "null" means "no value" in HTML form semantics, not the JSON `null` type.

**There is no native way to represent JSON `null` in form-urlencoded.**

### Ambiguity: `nullable` in form-urlencoded

The [OpenAPI 3.0.3 specification](https://spec.openapis.org/oas/v3.0.3.html) does not define how `nullable: true` should behave for form-urlencoded content. It only references RFC 1866 for serialization rules.

This means `nullable` is arguably meaningless for form-urlencoded bodies, since there's no standard way to send an explicit null value. This is a spec ambiguity, not something this PR attempts to resolve.

## What This PR Does

- Fixes the immediate bug: absent optional properties no longer cause validation errors
- Adds a regression test for this case
- Does NOT change behavior for `required` validation or `nullable` semantics (separate concerns)
