### PR TITLE
openapi2conv: nil-guard components lookup in FromV3SchemaRef

### DIFF
--- a/openapi2conv/issue1062_test.go
+++ b/openapi2conv/issue1062_test.go
@@ -1,0 +1,80 @@
+package openapi2conv
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/oasdiff/yaml"
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for #1062.
+//
+// FromV3RequestBodyFormData iterates the properties of a form-data schema
+// and, for any property typed as an array, recurses into the items via
+// FromV3SchemaRef(val.Items, nil) — passing the components table as nil.
+// With the old code, an items entry that was a $ref into
+// #/components/schemas/... nil-dereferenced on `components.Schemas[name]`
+// before the lookup could even happen.
+//
+// The minified spec below reproduces the OpenAI OpenAPI 3 shape that
+// triggered the original report: a multipart/form-data request body whose
+// `documents` field is an array of $ref-ed component schemas. This must
+// convert cleanly without a panic.
+func TestIssue1062_FormDataArrayOfRefDoesNotPanic(t *testing.T) {
+	const v3Spec = `
+openapi: 3.0.3
+info:
+  title: issue 1062 minified
+  version: 1.0.0
+paths:
+  /v1/upload:
+    post:
+      operationId: uploadDocuments
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                documents:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/Document'
+      responses:
+        '200':
+          description: ok
+components:
+  schemas:
+    Document:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+`
+
+	var doc3 openapi3.T
+	require.NoError(t, yaml.Unmarshal([]byte(v3Spec), &doc3), "unmarshal v3 spec")
+
+	// Pre-fix: this call panicked with
+	//   "runtime error: invalid memory reference or nil pointer dereference"
+	// inside FromV3SchemaRef when it deref'd nil components.Schemas.
+	v2, err := FromV3(&doc3)
+	require.NoError(t, err, "FromV3 must not error on form-data array of $refs")
+	require.NotNil(t, v2)
+
+	// Sanity: the operation made it through to v2 with a formData parameter.
+	op := v2.Paths["/v1/upload"].Post
+	require.NotNil(t, op, "POST /v1/upload should be present after conversion")
+	var sawDocuments bool
+	for _, p := range op.Parameters {
+		if p.In == "formData" && p.Name == "documents" {
+			sawDocuments = true
+			break
+		}
+	}
+	require.True(t, sawDocuments, "expected a formData parameter named 'documents'")
+}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -847,11 +847,21 @@ func FromV3Schemas(schemas map[string]*openapi3.SchemaRef, components *openapi3.
 
 func FromV3SchemaRef(schema *openapi3.SchemaRef, components *openapi3.Components) (*openapi2.SchemaRef, *openapi2.Parameter) {
 	if ref := schema.Ref; ref != "" {
+		// FromV3RequestBodyFormData (and other recursive call sites in
+		// this file) pass components=nil when recursing into array
+		// items and nested refs. Without guarding, components.Schemas
+		// nil-derefs before we even have a chance to look up the
+		// component, so a ref like '#/components/schemas/CreateEmbeddingRequest'
+		// inside an array schema crashes the converter (#1062).
+		// Treat a missing components table the same as 'the target
+		// schema is not known locally': emit a plain $ref and move on.
 		name := getParameterNameFromNewRef(ref)
-		if val, ok := components.Schemas[name]; ok {
-			if val.Value.Format == "binary" {
-				v2Ref := strings.Replace(ref, "#/components/schemas/", "#/parameters/", 1)
-				return nil, &openapi2.Parameter{Ref: v2Ref}
+		if components != nil {
+			if val, ok := components.Schemas[name]; ok {
+				if val.Value.Format == "binary" {
+					v2Ref := strings.Replace(ref, "#/components/schemas/", "#/parameters/", 1)
+					return nil, &openapi2.Parameter{Ref: v2Ref}
+				}
 			}
 		}
 


### PR DESCRIPTION
## What

Fixes #1062.

`FromV3SchemaRef` indexes `components.Schemas[name]` whenever the input schema has a `$ref`. Several recursive call sites in this file (`FromV3RequestBodyFormData` most notably) already pass `components=nil` when descending into array items and nested refs, so hitting a `$ref` from that path nil-dereferenced the `components` argument and took down the whole V3→V2 conversion.

In practice this fires on real-world inputs like the [OpenAI OpenAPI 3.0 spec](https://github.com/openai/openai-openapi/blob/master/openapi.yaml), where `CreateEmbeddingRequest` references a sub-schema inside an array of formData items:

```
FromV3SchemaRef (openapi2_conv.go:851)
FromV3RequestBodyFormData (openapi2_conv.go:1028)
fromV3RequestBodies (openapi2_conv.go:799)
```

## Fix

Guard the components lookup with a `components != nil` check. When the components table is not available we fall through to the same 'return the plain `$ref`' branch that already handles non-binary schema refs - semantically 'the target schema is not known locally, emit a pass-through ref' - instead of panicking. Runtime behaviour for callers that do pass a non-nil `Components` is unchanged.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l openapi2conv/openapi2_conv.go`: clean
- `go vet ./...`: clean
- `go test -race -count=1 ./openapi2conv/...`: pass

Closes #1062