### PR TITLE
feat(openapi3conv): canonicalization pass for 3.0 -> 3.x

### DIFF
--- a/.github/docs/openapi3conv.txt
+++ b/.github/docs/openapi3conv.txt
@@ -1,0 +1,59 @@
+package openapi3conv // import "github.com/getkin/kin-openapi/openapi3conv"
+
+Package openapi3conv canonicalizes an OpenAPI 3.x document into the latest 3.x
+representation in place. Schema-level constructs serialize differently between
+OpenAPI 3.0 and 3.1, but represent the same semantics; this package rewrites the
+3.0 forms into their 3.1 equivalents and bumps the version string to the latest
+3.x patch release the package knows about.
+
+The OAI commits to strict compatibility for 3.x going forward (see the 3.2.1
+and 3.3.0 milestones), so a tool that handles the 3.1+ form correctly handles
+all later 3.x versions correctly too. The 3.0 → 3.1 transition — the only break
+in the 3.x line — is the gap this package exists to bridge. 3.1 → 3.2 (and any
+future 3.x) is purely additive and requires no rewrites; the package handles
+those as a version-string bump.
+
+Use this when a downstream consumer (diff tools, validators, code generators)
+needs a single canonical representation regardless of the source spec's declared
+version.
+
+Scope:
+  - In scope: 3.x → latest 3.x.
+  - Out of scope: any → 3.0 (downgrade is lossy by nature).
+  - Out of scope: cross-major upgrades (3 → 4 if/when v4 ships). Those belong
+    in a dedicated package mirroring openapi2conv (which converts Swagger 2.0
+    documents to OpenAPI 3.0).
+
+Documents must be Validate()'d before calling Upgrade — passing an invalid
+document is undefined behaviour.
+
+FUNCTIONS
+
+func Upgrade(doc *openapi3.T, opts ...Option)
+    Upgrade canonicalizes doc into the latest 3.x representation in place.
+
+    The schema-level rewrites the walker applies (nullable → type array,
+    boolean exclusive bounds → numeric, example → examples) are idempotent and
+    convergent on the 3.1+ form. Calling Upgrade on an already-3.1 (or later)
+    document is a no-op aside from the version string bump.
+
+    Cross-major upgrades (3 → 4 if/when v4 ships) are not handled here; that
+    belongs in a dedicated package mirroring the openapi2conv pattern.
+
+    doc must be Validate()'d before calling Upgrade; passing an invalid document
+    is undefined behaviour.
+
+func UpgradeSchema(s *openapi3.Schema)
+    UpgradeSchema canonicalizes a single schema (and its descendants) in place.
+    Exposed for callers that need to upgrade a sub-tree rather than a full
+    document — e.g., a diff tool comparing isolated schemas.
+
+
+TYPES
+
+type Option func(*upgradeOptions)
+    Option configures an Upgrade pass. See WithWriter.
+
+func WithWriter(w io.Writer) Option
+    WithWriter routes one debug line per applied rewrite to w.
+

--- a/openapi3conv/doc.go
+++ b/openapi3conv/doc.go
@@ -1,20 +1,27 @@
-// Package openapi3conv canonicalizes an OpenAPI 3.x document into the
-// representation of a chosen target version. Schema-level constructs serialize
-// differently between OpenAPI 3.0 and 3.1, but represent the same semantics;
-// this package rewrites the 3.0 forms into their 3.1 equivalents in place.
-// The transformation is mechanical and lossless — every 3.0 construct has a
-// direct 3.1 form. OpenAPI 3.2 is purely additive over 3.1, so 3.1 → 3.2 is
-// a version-string change with no further rewrites.
+// Package openapi3conv canonicalizes an OpenAPI 3.x document into the latest
+// 3.x representation in place. Schema-level constructs serialize differently
+// between OpenAPI 3.0 and 3.1, but represent the same semantics; this package
+// rewrites the 3.0 forms into their 3.1 equivalents and bumps the version
+// string to the latest 3.x patch release the package knows about.
+//
+// The OAI commits to strict compatibility for 3.x going forward (see the
+// 3.2.1 and 3.3.0 milestones), so a tool that handles the 3.1+ form
+// correctly handles all later 3.x versions correctly too. The 3.0 → 3.1
+// transition — the only break in the 3.x line — is the gap this package
+// exists to bridge. 3.1 → 3.2 (and any future 3.x) is purely additive and
+// requires no rewrites; the package handles those as a version-string bump.
 //
 // Use this when a downstream consumer (diff tools, validators, code
 // generators) needs a single canonical representation regardless of the
 // source spec's declared version.
 //
 // Scope:
-//   - In scope: 3.0 ↔ 3.1 ↔ 3.2 ↔ any future 3.x where representational
-//     differences are rewritable in place.
-//   - Out of scope: 3.x → 3.0 (lossy by nature).
+//   - In scope: 3.x → latest 3.x.
+//   - Out of scope: any → 3.0 (downgrade is lossy by nature).
 //   - Out of scope: cross-major upgrades (3 → 4 if/when v4 ships). Those
 //     belong in a dedicated package mirroring openapi2conv (which converts
 //     Swagger 2.0 documents to OpenAPI 3.0).
+//
+// Documents must be Validate()'d before calling Upgrade — passing an
+// invalid document is undefined behaviour.
 package openapi3conv

--- a/openapi3conv/doc.go
+++ b/openapi3conv/doc.go
@@ -1,12 +1,20 @@
-// Package openapi3conv canonicalizes an OpenAPI 3.0 document into the OpenAPI 3.1
-// representation. Schema-level constructs serialize differently between the two
-// versions but represent the same semantics; this package rewrites the 3.0 forms
-// into their 3.1 equivalents in place. The transformation is mechanical and
-// lossless — every 3.0 construct has a direct 3.1 form.
+// Package openapi3conv canonicalizes an OpenAPI 3.x document into the
+// representation of a chosen target version. Schema-level constructs serialize
+// differently between OpenAPI 3.0 and 3.1, but represent the same semantics;
+// this package rewrites the 3.0 forms into their 3.1 equivalents in place.
+// The transformation is mechanical and lossless — every 3.0 construct has a
+// direct 3.1 form. OpenAPI 3.2 is purely additive over 3.1, so 3.1 → 3.2 is
+// a version-string change with no further rewrites.
 //
-// Use this when a downstream consumer (diff tools, validators, code generators)
-// needs a single canonical representation regardless of the source spec's
-// declared version.
+// Use this when a downstream consumer (diff tools, validators, code
+// generators) needs a single canonical representation regardless of the
+// source spec's declared version.
 //
-// The opposite direction (3.1 → 3.0) is lossy by nature and out of scope.
+// Scope:
+//   - In scope: 3.0 ↔ 3.1 ↔ 3.2 ↔ any future 3.x where representational
+//     differences are rewritable in place.
+//   - Out of scope: 3.x → 3.0 (lossy by nature).
+//   - Out of scope: cross-major upgrades (3 → 4 if/when v4 ships). Those
+//     belong in a dedicated package mirroring openapi2conv (which converts
+//     Swagger 2.0 documents to OpenAPI 3.0).
 package openapi3conv

--- a/openapi3conv/doc.go
+++ b/openapi3conv/doc.go
@@ -1,0 +1,12 @@
+// Package openapi3conv canonicalizes an OpenAPI 3.0 document into the OpenAPI 3.1
+// representation. Schema-level constructs serialize differently between the two
+// versions but represent the same semantics; this package rewrites the 3.0 forms
+// into their 3.1 equivalents in place. The transformation is mechanical and
+// lossless — every 3.0 construct has a direct 3.1 form.
+//
+// Use this when a downstream consumer (diff tools, validators, code generators)
+// needs a single canonical representation regardless of the source spec's
+// declared version.
+//
+// The opposite direction (3.1 → 3.0) is lossy by nature and out of scope.
+package openapi3conv

--- a/openapi3conv/openapi3_conv.go
+++ b/openapi3conv/openapi3_conv.go
@@ -3,64 +3,93 @@ package openapi3conv
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // DefaultTargetVersion is the OpenAPI version string written when bumping the
-// document version. Set to the current 3.1 patch release; the OAI upgrade
-// guide uses the same.
+// document version. The OAI upgrade guide uses the current 3.1 patch release.
 const DefaultTargetVersion = "3.1.1"
 
 // UpgradeOptions controls per-pass behaviour.
 type UpgradeOptions struct {
+	// Target is the version string written when SkipVersionBump is false.
+	// Defaults to DefaultTargetVersion. Currently any 3.x version is accepted;
+	// representational rewrites only exist for 3.0 → 3.1, since 3.1 → 3.2 is
+	// purely additive (no breaking changes). Future minor versions that
+	// introduce representational changes can extend the dispatch in Upgrade.
+	Target string
+
 	// SkipVersionBump leaves doc.OpenAPI unchanged. Useful for consumers
 	// that want representations canonicalized while preserving the stated
 	// version (e.g., a pre-diff normalization step).
 	SkipVersionBump bool
 
-	// TargetVersion is the version string written when SkipVersionBump is
-	// false. Defaults to DefaultTargetVersion.
-	TargetVersion string
-
 	// Verbose, if non-nil, receives one line per rewrite for debugging.
 	Verbose io.Writer
 }
 
-// UpgradeTo31 rewrites every 3.0-form construct in doc into its 3.1 form
-// in place: bumps the version, replaces nullable: true with type arrays,
-// replaces boolean exclusiveMinimum/exclusiveMaximum with numeric form,
-// replaces example with examples. Idempotent on already-3.1 documents.
+// Upgrade canonicalizes doc into the representation of opts.Target in place.
 //
-// Returns an error only if the document is structurally invalid (e.g., nil
-// document).
-func UpgradeTo31(doc *openapi3.T) error {
-	return UpgradeTo31WithOptions(doc, UpgradeOptions{})
-}
-
-// UpgradeTo31WithOptions is the variant with explicit options.
-func UpgradeTo31WithOptions(doc *openapi3.T, opts UpgradeOptions) error {
+// The schema-level rewrites the walker applies (nullable → type array, boolean
+// exclusive bounds → numeric, example → examples) are idempotent and
+// convergent on the 3.1+ form. Calling Upgrade on an already-3.1 (or 3.2)
+// document is a no-op aside from the version bump.
+//
+// Cross-major upgrades are not supported. OpenAPI 4 (or any future major
+// version) will require a separate package mirroring the openapi2conv
+// pattern (which converts Swagger 2.0 documents to OpenAPI 3.0). Returning
+// an error here keeps that boundary explicit.
+func Upgrade(doc *openapi3.T, opts UpgradeOptions) error {
 	if doc == nil {
 		return fmt.Errorf("openapi3conv: doc is nil")
 	}
 
-	target := opts.TargetVersion
+	target := opts.Target
 	if target == "" {
 		target = DefaultTargetVersion
+	}
+
+	srcMajor, srcMinor, err := parseVersion(doc.OpenAPI)
+	if err != nil {
+		return fmt.Errorf("openapi3conv: invalid doc.OpenAPI %q: %w", doc.OpenAPI, err)
+	}
+	tgtMajor, tgtMinor, err := parseVersion(target)
+	if err != nil {
+		return fmt.Errorf("openapi3conv: invalid Target %q: %w", target, err)
+	}
+
+	if srcMajor != tgtMajor {
+		return fmt.Errorf(
+			"openapi3conv: cross-major upgrade not supported (%s -> %s); "+
+				"a separate package is the right home for cross-major conversions "+
+				"(see openapi2conv for the existing 2 -> 3 pattern)",
+			doc.OpenAPI, target,
+		)
+	}
+	if tgtMinor < srcMinor {
+		return fmt.Errorf("openapi3conv: cannot downgrade %s to %s", doc.OpenAPI, target)
 	}
 
 	w := &walker{
 		visited: map[*openapi3.Schema]struct{}{},
 		opts:    opts,
 	}
+	w.walkDoc(doc)
 
 	if !opts.SkipVersionBump && doc.OpenAPI != target {
 		w.logf("openapi: %s -> %s", doc.OpenAPI, target)
 		doc.OpenAPI = target
 	}
-
-	w.walkDoc(doc)
 	return nil
+}
+
+// UpgradeTo31 is a convenience wrapper for Upgrade with Target = "3.1.1".
+// Idempotent on already-3.1 documents.
+func UpgradeTo31(doc *openapi3.T) error {
+	return Upgrade(doc, UpgradeOptions{})
 }
 
 // UpgradeSchema canonicalizes a single schema (and its descendants) in place.
@@ -72,6 +101,24 @@ func UpgradeSchema(s *openapi3.Schema) {
 	}
 	w := &walker{visited: map[*openapi3.Schema]struct{}{}}
 	w.walkSchema(s)
+}
+
+// parseVersion splits an OpenAPI version string ("3.0.3", "3.1.1", "3.2.0")
+// into major and minor integers. Patch and pre-release suffixes are ignored.
+func parseVersion(v string) (major, minor int, err error) {
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("expected MAJOR.MINOR[.PATCH], got %q", v)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid major %q: %w", parts[0], err)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minor %q: %w", parts[1], err)
+	}
+	return major, minor, nil
 }
 
 // walker carries cycle-tracking state and verbose output across the schema

--- a/openapi3conv/openapi3_conv.go
+++ b/openapi3conv/openapi3_conv.go
@@ -3,6 +3,7 @@ package openapi3conv
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -15,17 +16,13 @@ const DefaultTargetVersion = "3.1.1"
 
 // UpgradeOptions controls per-pass behaviour.
 type UpgradeOptions struct {
-	// Target is the version string written when SkipVersionBump is false.
-	// Defaults to DefaultTargetVersion. Currently any 3.x version is accepted;
-	// representational rewrites only exist for 3.0 → 3.1, since 3.1 → 3.2 is
-	// purely additive (no breaking changes). Future minor versions that
-	// introduce representational changes can extend the dispatch in Upgrade.
+	// Target is the version string written into doc.OpenAPI after the
+	// canonicalization pass. Defaults to DefaultTargetVersion. Currently any
+	// 3.x version is accepted; representational rewrites only exist for
+	// 3.0 → 3.1, since 3.1 → 3.2 is purely additive (no breaking changes).
+	// Future minor versions that introduce representational changes can
+	// extend the dispatch in Upgrade.
 	Target string
-
-	// SkipVersionBump leaves doc.OpenAPI unchanged. Useful for consumers
-	// that want representations canonicalized while preserving the stated
-	// version (e.g., a pre-diff normalization step).
-	SkipVersionBump bool
 
 	// Verbose, if non-nil, receives one line per rewrite for debugging.
 	Verbose io.Writer
@@ -79,7 +76,7 @@ func Upgrade(doc *openapi3.T, opts UpgradeOptions) error {
 	}
 	w.walkDoc(doc)
 
-	if !opts.SkipVersionBump && doc.OpenAPI != target {
+	if doc.OpenAPI != target {
 		w.logf("openapi: %s -> %s", doc.OpenAPI, target)
 		doc.OpenAPI = target
 	}
@@ -132,7 +129,8 @@ func (w *walker) logf(format string, args ...any) {
 	if w.opts.Verbose == nil {
 		return
 	}
-	fmt.Fprintf(w.opts.Verbose, format+"\n", args...)
+	fmt.Fprintf(w.opts.Verbose, format, args...)
+	fmt.Fprintln(w.opts.Verbose)
 }
 
 // walkDoc visits every Schema reachable from the document root.
@@ -178,10 +176,8 @@ func (w *walker) walkDoc(doc *openapi3.T) {
 		}
 	}
 
-	if doc.Paths != nil {
-		for _, pathItem := range doc.Paths.Map() {
-			w.walkPathItem(pathItem)
-		}
+	for _, pathItem := range doc.Paths.Map() {
+		w.walkPathItem(pathItem)
 	}
 
 	for _, pathItem := range doc.Webhooks {
@@ -308,16 +304,8 @@ func (w *walker) rewriteNullable(s *openapi3.Schema) {
 		return
 	}
 	if s.Type != nil && len(*s.Type) > 0 {
-		alreadyHasNull := false
-		for _, t := range *s.Type {
-			if t == openapi3.TypeNull {
-				alreadyHasNull = true
-				break
-			}
-		}
-		if !alreadyHasNull {
-			newTypes := append(openapi3.Types(nil), *s.Type...)
-			newTypes = append(newTypes, openapi3.TypeNull)
+		if !slices.Contains(*s.Type, openapi3.TypeNull) {
+			newTypes := append(*s.Type, openapi3.TypeNull)
 			s.Type = &newTypes
 		}
 	}

--- a/openapi3conv/openapi3_conv.go
+++ b/openapi3conv/openapi3_conv.go
@@ -1,0 +1,334 @@
+package openapi3conv
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// DefaultTargetVersion is the OpenAPI version string written when bumping the
+// document version. Set to the current 3.1 patch release; the OAI upgrade
+// guide uses the same.
+const DefaultTargetVersion = "3.1.1"
+
+// UpgradeOptions controls per-pass behaviour.
+type UpgradeOptions struct {
+	// SkipVersionBump leaves doc.OpenAPI unchanged. Useful for consumers
+	// that want representations canonicalized while preserving the stated
+	// version (e.g., a pre-diff normalization step).
+	SkipVersionBump bool
+
+	// TargetVersion is the version string written when SkipVersionBump is
+	// false. Defaults to DefaultTargetVersion.
+	TargetVersion string
+
+	// Verbose, if non-nil, receives one line per rewrite for debugging.
+	Verbose io.Writer
+}
+
+// UpgradeTo31 rewrites every 3.0-form construct in doc into its 3.1 form
+// in place: bumps the version, replaces nullable: true with type arrays,
+// replaces boolean exclusiveMinimum/exclusiveMaximum with numeric form,
+// replaces example with examples. Idempotent on already-3.1 documents.
+//
+// Returns an error only if the document is structurally invalid (e.g., nil
+// document).
+func UpgradeTo31(doc *openapi3.T) error {
+	return UpgradeTo31WithOptions(doc, UpgradeOptions{})
+}
+
+// UpgradeTo31WithOptions is the variant with explicit options.
+func UpgradeTo31WithOptions(doc *openapi3.T, opts UpgradeOptions) error {
+	if doc == nil {
+		return fmt.Errorf("openapi3conv: doc is nil")
+	}
+
+	target := opts.TargetVersion
+	if target == "" {
+		target = DefaultTargetVersion
+	}
+
+	w := &walker{
+		visited: map[*openapi3.Schema]struct{}{},
+		opts:    opts,
+	}
+
+	if !opts.SkipVersionBump && doc.OpenAPI != target {
+		w.logf("openapi: %s -> %s", doc.OpenAPI, target)
+		doc.OpenAPI = target
+	}
+
+	w.walkDoc(doc)
+	return nil
+}
+
+// UpgradeSchema canonicalizes a single schema (and its descendants) in place.
+// Exposed for callers that need to upgrade a sub-tree rather than a full
+// document — e.g., a diff tool comparing isolated schemas.
+func UpgradeSchema(s *openapi3.Schema) {
+	if s == nil {
+		return
+	}
+	w := &walker{visited: map[*openapi3.Schema]struct{}{}}
+	w.walkSchema(s)
+}
+
+// walker carries cycle-tracking state and verbose output across the schema
+// graph. Each *Schema is visited at most once.
+type walker struct {
+	visited map[*openapi3.Schema]struct{}
+	opts    UpgradeOptions
+}
+
+func (w *walker) logf(format string, args ...any) {
+	if w.opts.Verbose == nil {
+		return
+	}
+	fmt.Fprintf(w.opts.Verbose, format+"\n", args...)
+}
+
+// walkDoc visits every Schema reachable from the document root.
+func (w *walker) walkDoc(doc *openapi3.T) {
+	if doc.Components != nil {
+		for _, sr := range doc.Components.Schemas {
+			w.walkSchemaRef(sr)
+		}
+		for _, pr := range doc.Components.Parameters {
+			if pr != nil && pr.Value != nil {
+				w.walkSchemaRef(pr.Value.Schema)
+				for _, mt := range pr.Value.Content {
+					w.walkMediaType(mt)
+				}
+			}
+		}
+		for _, hr := range doc.Components.Headers {
+			if hr != nil && hr.Value != nil {
+				w.walkSchemaRef(hr.Value.Schema)
+				for _, mt := range hr.Value.Content {
+					w.walkMediaType(mt)
+				}
+			}
+		}
+		for _, rb := range doc.Components.RequestBodies {
+			if rb != nil && rb.Value != nil {
+				for _, mt := range rb.Value.Content {
+					w.walkMediaType(mt)
+				}
+			}
+		}
+		for _, rr := range doc.Components.Responses {
+			if rr != nil && rr.Value != nil {
+				for _, mt := range rr.Value.Content {
+					w.walkMediaType(mt)
+				}
+				for _, hr := range rr.Value.Headers {
+					if hr != nil && hr.Value != nil {
+						w.walkSchemaRef(hr.Value.Schema)
+					}
+				}
+			}
+		}
+	}
+
+	if doc.Paths != nil {
+		for _, pathItem := range doc.Paths.Map() {
+			w.walkPathItem(pathItem)
+		}
+	}
+
+	for _, pathItem := range doc.Webhooks {
+		w.walkPathItem(pathItem)
+	}
+}
+
+func (w *walker) walkPathItem(pathItem *openapi3.PathItem) {
+	if pathItem == nil {
+		return
+	}
+	for _, pr := range pathItem.Parameters {
+		if pr != nil && pr.Value != nil {
+			w.walkSchemaRef(pr.Value.Schema)
+		}
+	}
+	for _, op := range pathItem.Operations() {
+		w.walkOperation(op)
+	}
+}
+
+func (w *walker) walkOperation(op *openapi3.Operation) {
+	if op == nil {
+		return
+	}
+	for _, pr := range op.Parameters {
+		if pr != nil && pr.Value != nil {
+			w.walkSchemaRef(pr.Value.Schema)
+			for _, mt := range pr.Value.Content {
+				w.walkMediaType(mt)
+			}
+		}
+	}
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		for _, mt := range op.RequestBody.Value.Content {
+			w.walkMediaType(mt)
+		}
+	}
+	if op.Responses != nil {
+		for _, rr := range op.Responses.Map() {
+			if rr == nil || rr.Value == nil {
+				continue
+			}
+			for _, mt := range rr.Value.Content {
+				w.walkMediaType(mt)
+			}
+			for _, hr := range rr.Value.Headers {
+				if hr != nil && hr.Value != nil {
+					w.walkSchemaRef(hr.Value.Schema)
+				}
+			}
+		}
+	}
+	for _, cb := range op.Callbacks {
+		if cb == nil || cb.Value == nil {
+			continue
+		}
+		for _, pathItem := range cb.Value.Map() {
+			w.walkPathItem(pathItem)
+		}
+	}
+}
+
+func (w *walker) walkMediaType(mt *openapi3.MediaType) {
+	if mt == nil {
+		return
+	}
+	w.walkSchemaRef(mt.Schema)
+}
+
+func (w *walker) walkSchemaRef(sr *openapi3.SchemaRef) {
+	if sr == nil || sr.Value == nil {
+		return
+	}
+	w.walkSchema(sr.Value)
+}
+
+func (w *walker) walkSchema(s *openapi3.Schema) {
+	if s == nil {
+		return
+	}
+	if _, seen := w.visited[s]; seen {
+		return
+	}
+	w.visited[s] = struct{}{}
+
+	// Apply the rewrites at this node before descending — order doesn't
+	// matter, the transformations are independent.
+	w.rewriteNullable(s)
+	w.rewriteExclusiveBounds(s)
+	w.rewriteExample(s)
+
+	// Recurse into every child schema.
+	for _, sub := range s.Properties {
+		w.walkSchemaRef(sub)
+	}
+	w.walkSchemaRef(s.Items)
+	if s.AdditionalProperties.Schema != nil {
+		w.walkSchemaRef(s.AdditionalProperties.Schema)
+	}
+	for _, sub := range s.AllOf {
+		w.walkSchemaRef(sub)
+	}
+	for _, sub := range s.OneOf {
+		w.walkSchemaRef(sub)
+	}
+	for _, sub := range s.AnyOf {
+		w.walkSchemaRef(sub)
+	}
+	w.walkSchemaRef(s.Not)
+	for _, sub := range s.PatternProperties {
+		w.walkSchemaRef(sub)
+	}
+}
+
+// rewriteNullable converts `nullable: true` into a type-array form.
+//
+//   - With a non-empty Type: append "null" (deduped).
+//   - Without a Type: drop nullable; the spec then accepts any type (no Type
+//     restriction), which subsumes null. This matches the OAI guide's silence
+//     on the "no type" edge case while keeping the rewrite lossless.
+func (w *walker) rewriteNullable(s *openapi3.Schema) {
+	if !s.Nullable {
+		return
+	}
+	if s.Type != nil && len(*s.Type) > 0 {
+		alreadyHasNull := false
+		for _, t := range *s.Type {
+			if t == openapi3.TypeNull {
+				alreadyHasNull = true
+				break
+			}
+		}
+		if !alreadyHasNull {
+			newTypes := append(openapi3.Types(nil), *s.Type...)
+			newTypes = append(newTypes, openapi3.TypeNull)
+			s.Type = &newTypes
+		}
+	}
+	w.logf("nullable: true -> dropped (Types=%v)", s.Type)
+	s.Nullable = false
+}
+
+// rewriteExclusiveBounds converts the 3.0 boolean modifier into the 3.1
+// numeric form:
+//
+//	minimum: x, exclusiveMinimum: true   ->  exclusiveMinimum: x  (Min cleared)
+//	exclusiveMinimum: false              ->  field dropped (default)
+//
+// Mirror logic for maximum.
+func (w *walker) rewriteExclusiveBounds(s *openapi3.Schema) {
+	// Lower bound.
+	if s.ExclusiveMin.Bool != nil {
+		if *s.ExclusiveMin.Bool && s.Min != nil {
+			v := *s.Min
+			s.ExclusiveMin = openapi3.ExclusiveBound{Value: &v}
+			s.Min = nil
+			w.logf("exclusiveMinimum: true + minimum: %v -> exclusiveMinimum: %v (numeric)", v, v)
+		} else {
+			// false, or true without paired minimum — either way, the
+			// boolean form has no meaning in 3.1. Drop it.
+			s.ExclusiveMin = openapi3.ExclusiveBound{}
+			w.logf("exclusiveMinimum: <bool> -> dropped")
+		}
+	}
+
+	// Upper bound.
+	if s.ExclusiveMax.Bool != nil {
+		if *s.ExclusiveMax.Bool && s.Max != nil {
+			v := *s.Max
+			s.ExclusiveMax = openapi3.ExclusiveBound{Value: &v}
+			s.Max = nil
+			w.logf("exclusiveMaximum: true + maximum: %v -> exclusiveMaximum: %v (numeric)", v, v)
+		} else {
+			s.ExclusiveMax = openapi3.ExclusiveBound{}
+			w.logf("exclusiveMaximum: <bool> -> dropped")
+		}
+	}
+}
+
+// rewriteExample converts the singular `example` field into the plural
+// `examples` array on Schema Objects. The plural form is required in 3.1.
+//
+// Note: `example`/`examples` on Parameter and MediaType objects use a
+// different shape (a map of named Example refs in 3.0+ that did not change
+// for 3.1) and are not touched here.
+func (w *walker) rewriteExample(s *openapi3.Schema) {
+	if s.Example == nil {
+		return
+	}
+	// Preserve the existing examples array; append to it. Some 3.0 specs
+	// do set both example and examples (the latter as a vendor-flavored
+	// extension); we keep both.
+	s.Examples = append(s.Examples, s.Example)
+	s.Example = nil
+	w.logf("example: <v> -> examples: [..., <v>]")
+}

--- a/openapi3conv/openapi3_conv.go
+++ b/openapi3conv/openapi3_conv.go
@@ -4,89 +4,64 @@ import (
 	"fmt"
 	"io"
 	"slices"
-	"strconv"
-	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// DefaultTargetVersion is the OpenAPI version string written when bumping the
-// document version. The OAI upgrade guide uses the current 3.1 patch release.
-const DefaultTargetVersion = "3.1.1"
+// latestTargetVersion is the OpenAPI version string written into doc.OpenAPI
+// after canonicalization. Always the latest 3.x patch release the package
+// knows about; bump when a new minor lands. The OAI guarantees strict
+// compatibility for 3.x going forward (3.2.x, 3.3.x, ...), so a tool that
+// handles 3.1 correctly handles later 3.x versions correctly too.
+const latestTargetVersion = "3.2.0"
 
-// UpgradeOptions controls per-pass behaviour.
-type UpgradeOptions struct {
-	// Target is the version string written into doc.OpenAPI after the
-	// canonicalization pass. Defaults to DefaultTargetVersion. Currently any
-	// 3.x version is accepted; representational rewrites only exist for
-	// 3.0 → 3.1, since 3.1 → 3.2 is purely additive (no breaking changes).
-	// Future minor versions that introduce representational changes can
-	// extend the dispatch in Upgrade.
-	Target string
+// Option configures an Upgrade pass. See WithWriter.
+type Option func(*upgradeOptions)
 
-	// Verbose, if non-nil, receives one line per rewrite for debugging.
-	Verbose io.Writer
+// upgradeOptions is the internal carrier for Option functions. Kept private
+// so the surface stays small and additive — new options are added by
+// introducing a new WithX function.
+type upgradeOptions struct {
+	verbose io.Writer
 }
 
-// Upgrade canonicalizes doc into the representation of opts.Target in place.
+// WithWriter routes one debug line per applied rewrite to w.
+func WithWriter(w io.Writer) Option {
+	return func(o *upgradeOptions) { o.verbose = w }
+}
+
+// Upgrade canonicalizes doc into the latest 3.x representation in place.
 //
-// The schema-level rewrites the walker applies (nullable → type array, boolean
-// exclusive bounds → numeric, example → examples) are idempotent and
-// convergent on the 3.1+ form. Calling Upgrade on an already-3.1 (or 3.2)
-// document is a no-op aside from the version bump.
+// The schema-level rewrites the walker applies (nullable → type array,
+// boolean exclusive bounds → numeric, example → examples) are idempotent
+// and convergent on the 3.1+ form. Calling Upgrade on an already-3.1 (or
+// later) document is a no-op aside from the version string bump.
 //
-// Cross-major upgrades are not supported. OpenAPI 4 (or any future major
-// version) will require a separate package mirroring the openapi2conv
-// pattern (which converts Swagger 2.0 documents to OpenAPI 3.0). Returning
-// an error here keeps that boundary explicit.
-func Upgrade(doc *openapi3.T, opts UpgradeOptions) error {
+// Cross-major upgrades (3 → 4 if/when v4 ships) are not handled here; that
+// belongs in a dedicated package mirroring the openapi2conv pattern.
+//
+// doc must be Validate()'d before calling Upgrade; passing an invalid
+// document is undefined behaviour.
+func Upgrade(doc *openapi3.T, opts ...Option) {
 	if doc == nil {
-		return fmt.Errorf("openapi3conv: doc is nil")
+		return
 	}
 
-	target := opts.Target
-	if target == "" {
-		target = DefaultTargetVersion
-	}
-
-	srcMajor, srcMinor, err := parseVersion(doc.OpenAPI)
-	if err != nil {
-		return fmt.Errorf("openapi3conv: invalid doc.OpenAPI %q: %w", doc.OpenAPI, err)
-	}
-	tgtMajor, tgtMinor, err := parseVersion(target)
-	if err != nil {
-		return fmt.Errorf("openapi3conv: invalid Target %q: %w", target, err)
-	}
-
-	if srcMajor != tgtMajor {
-		return fmt.Errorf(
-			"openapi3conv: cross-major upgrade not supported (%s -> %s); "+
-				"a separate package is the right home for cross-major conversions "+
-				"(see openapi2conv for the existing 2 -> 3 pattern)",
-			doc.OpenAPI, target,
-		)
-	}
-	if tgtMinor < srcMinor {
-		return fmt.Errorf("openapi3conv: cannot downgrade %s to %s", doc.OpenAPI, target)
+	o := upgradeOptions{}
+	for _, apply := range opts {
+		apply(&o)
 	}
 
 	w := &walker{
 		visited: map[*openapi3.Schema]struct{}{},
-		opts:    opts,
+		opts:    o,
 	}
 	w.walkDoc(doc)
 
-	if doc.OpenAPI != target {
-		w.logf("openapi: %s -> %s", doc.OpenAPI, target)
-		doc.OpenAPI = target
+	if doc.OpenAPI != latestTargetVersion {
+		w.logf("openapi: %s -> %s", doc.OpenAPI, latestTargetVersion)
+		doc.OpenAPI = latestTargetVersion
 	}
-	return nil
-}
-
-// UpgradeTo31 is a convenience wrapper for Upgrade with Target = "3.1.1".
-// Idempotent on already-3.1 documents.
-func UpgradeTo31(doc *openapi3.T) error {
-	return Upgrade(doc, UpgradeOptions{})
 }
 
 // UpgradeSchema canonicalizes a single schema (and its descendants) in place.
@@ -100,37 +75,19 @@ func UpgradeSchema(s *openapi3.Schema) {
 	w.walkSchema(s)
 }
 
-// parseVersion splits an OpenAPI version string ("3.0.3", "3.1.1", "3.2.0")
-// into major and minor integers. Patch and pre-release suffixes are ignored.
-func parseVersion(v string) (major, minor int, err error) {
-	parts := strings.SplitN(v, ".", 3)
-	if len(parts) < 2 {
-		return 0, 0, fmt.Errorf("expected MAJOR.MINOR[.PATCH], got %q", v)
-	}
-	major, err = strconv.Atoi(parts[0])
-	if err != nil {
-		return 0, 0, fmt.Errorf("invalid major %q: %w", parts[0], err)
-	}
-	minor, err = strconv.Atoi(parts[1])
-	if err != nil {
-		return 0, 0, fmt.Errorf("invalid minor %q: %w", parts[1], err)
-	}
-	return major, minor, nil
-}
-
 // walker carries cycle-tracking state and verbose output across the schema
 // graph. Each *Schema is visited at most once.
 type walker struct {
 	visited map[*openapi3.Schema]struct{}
-	opts    UpgradeOptions
+	opts    upgradeOptions
 }
 
 func (w *walker) logf(format string, args ...any) {
-	if w.opts.Verbose == nil {
+	if w.opts.verbose == nil {
 		return
 	}
-	fmt.Fprintf(w.opts.Verbose, format, args...)
-	fmt.Fprintln(w.opts.Verbose)
+	fmt.Fprintf(w.opts.verbose, format, args...)
+	fmt.Fprintln(w.opts.verbose)
 }
 
 // walkDoc visits every Schema reachable from the document root.

--- a/openapi3conv/openapi3_conv_test.go
+++ b/openapi3conv/openapi3_conv_test.go
@@ -7,10 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
-	"github.com/getkin/kin-openapi/openapi3conv"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3conv"
 )
 
 func loadV30(t *testing.T, raw string) *openapi3.T {

--- a/openapi3conv/openapi3_conv_test.go
+++ b/openapi3conv/openapi3_conv_test.go
@@ -2,10 +2,9 @@ package openapi3conv_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
-	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +23,7 @@ func loadV30(t *testing.T, raw string) *openapi3.T {
 
 // Round-trips through JSON so the result reflects what tooling consumers see
 // (omitted zero-value fields, normalized ordering). Easier to compare against
-// expected 3.1 output than walking structs.
+// expected output than walking structs.
 func marshalJSON(t *testing.T, doc *openapi3.T) map[string]any {
 	t.Helper()
 	b, err := json.Marshal(doc)
@@ -38,32 +37,20 @@ func marshalJSON(t *testing.T, doc *openapi3.T) map[string]any {
 // Version bump
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_BumpsVersion(t *testing.T) {
+func TestUpgrade_BumpsVersion(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
 paths: {}
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
-	assert.Equal(t, "3.1.1", doc.OpenAPI)
+	openapi3conv.Upgrade(doc)
+	assert.Equal(t, "3.2.0", doc.OpenAPI)
 }
 
-func TestUpgrade_CustomTarget(t *testing.T) {
-	doc := loadV30(t, `
-openapi: 3.0.3
-info: {title: t, version: '1'}
-paths: {}
-`)
-	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
-		Target: "3.1.0",
-	}))
-	assert.Equal(t, "3.1.0", doc.OpenAPI)
-}
-
-func TestUpgrade_TargetIs32(t *testing.T) {
-	// 3.2 is purely additive over 3.1 — no schema-level rewrites between
-	// them. Upgrade applies the 3.0 → 3.1 rewrites and writes the 3.2
-	// version string. The resulting doc is canonical and version-correct.
+// 3.2 is purely additive over 3.1 — no schema-level rewrites between them.
+// Upgrade applies the 3.0 → 3.1 rewrites (still required) and writes the
+// 3.2 version string. The result is canonical and version-correct.
+func TestUpgrade_RewritesAppliedAlongsideVersionBump(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -74,53 +61,16 @@ components:
       type: string
       nullable: true
 `)
-	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
-		Target: "3.2.0",
-	}))
+	openapi3conv.Upgrade(doc)
 	assert.Equal(t, "3.2.0", doc.OpenAPI)
 	assert.Equal(t, openapi3.Types{"string", "null"}, *doc.Components.Schemas["Pet"].Value.Type)
-}
-
-func TestUpgrade_RejectsCrossMajor(t *testing.T) {
-	// Cross-major upgrades belong in a dedicated package (mirror of
-	// openapi2conv). Pre-pin that boundary with an explicit error so any
-	// future 3 → 4 transition lands somewhere predictable.
-	doc := loadV30(t, `
-openapi: 3.0.3
-info: {title: t, version: '1'}
-paths: {}
-`)
-	err := openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{Target: "4.0.0"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "cross-major")
-}
-
-func TestUpgrade_RejectsDowngrade(t *testing.T) {
-	doc := loadV30(t, `
-openapi: 3.1.1
-info: {title: t, version: '1'}
-paths: {}
-`)
-	err := openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{Target: "3.0.3"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "downgrade")
-}
-
-func TestUpgrade_RejectsInvalidVersion(t *testing.T) {
-	doc := loadV30(t, `
-openapi: 3.0.3
-info: {title: t, version: '1'}
-paths: {}
-`)
-	err := openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{Target: "not-a-version"})
-	require.Error(t, err)
 }
 
 // ---------------------------------------------------------------------------
 // Nullable rewrite
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_NullableWithType(t *testing.T) {
+func TestUpgrade_NullableWithType(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -131,14 +81,14 @@ components:
       type: string
       nullable: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	require.NotNil(t, pet.Type)
 	assert.Equal(t, openapi3.Types{"string", "null"}, *pet.Type)
 	assert.False(t, pet.Nullable, "nullable should be cleared after rewrite")
 }
 
-func TestUpgradeTo31_NullableAlreadyHasNullInTypeArray(t *testing.T) {
+func TestUpgrade_NullableAlreadyHasNullInTypeArray(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -149,13 +99,13 @@ components:
       type: ['string', 'null']
       nullable: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	assert.Equal(t, openapi3.Types{"string", "null"}, *pet.Type, "no duplicate null appended")
 	assert.False(t, pet.Nullable)
 }
 
-func TestUpgradeTo31_NullableNoType(t *testing.T) {
+func TestUpgrade_NullableNoType(t *testing.T) {
 	// nullable without an accompanying type is ambiguous in 3.0 (the spec is
 	// silent on whether nullable applies). Drop nullable; the schema then
 	// accepts any type, which subsumes null.
@@ -168,13 +118,13 @@ components:
     Pet:
       nullable: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	assert.False(t, pet.Nullable)
 	assert.Nil(t, pet.Type)
 }
 
-func TestUpgradeTo31_NullableInsideProperties(t *testing.T) {
+func TestUpgrade_NullableInsideProperties(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -191,7 +141,7 @@ components:
           type: integer
           nullable: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	props := doc.Components.Schemas["Pet"].Value.Properties
 	assert.Equal(t, openapi3.Types{"string", "null"}, *props["name"].Value.Type)
 	assert.Equal(t, openapi3.Types{"integer", "null"}, *props["ageInYears"].Value.Type)
@@ -201,7 +151,7 @@ components:
 // Exclusive-bound rewrite
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_ExclusiveMinTrueWithMinimum(t *testing.T) {
+func TestUpgrade_ExclusiveMinTrueWithMinimum(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -213,7 +163,7 @@ components:
       minimum: 5
       exclusiveMinimum: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	score := doc.Components.Schemas["Score"].Value
 	assert.Nil(t, score.Min, "Min cleared")
 	require.NotNil(t, score.ExclusiveMin.Value)
@@ -221,7 +171,7 @@ components:
 	assert.Nil(t, score.ExclusiveMin.Bool)
 }
 
-func TestUpgradeTo31_ExclusiveMaxTrueWithMaximum(t *testing.T) {
+func TestUpgrade_ExclusiveMaxTrueWithMaximum(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -233,7 +183,7 @@ components:
       maximum: 100
       exclusiveMaximum: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	score := doc.Components.Schemas["Score"].Value
 	assert.Nil(t, score.Max)
 	require.NotNil(t, score.ExclusiveMax.Value)
@@ -241,7 +191,7 @@ components:
 	assert.Nil(t, score.ExclusiveMax.Bool)
 }
 
-func TestUpgradeTo31_ExclusiveMinFalseDropped(t *testing.T) {
+func TestUpgrade_ExclusiveMinFalseDropped(t *testing.T) {
 	// `exclusiveMinimum: false` is the default — it carries no information.
 	// The merged 3.1 form drops it.
 	doc := loadV30(t, `
@@ -255,15 +205,16 @@ components:
       minimum: 5
       exclusiveMinimum: false
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	score := doc.Components.Schemas["Score"].Value
 	require.NotNil(t, score.Min)
 	assert.Equal(t, 5.0, *score.Min)
 	assert.False(t, score.ExclusiveMin.IsSet(), "exclusiveMinimum: false should be dropped")
 }
 
-func TestUpgradeTo31_ExclusiveBoundsLeavesNumericIntact(t *testing.T) {
-	// A document already in 3.1 numeric form should round-trip unchanged.
+func TestUpgrade_ExclusiveBoundsLeavesNumericIntact(t *testing.T) {
+	// A document already in 3.1 numeric form should round-trip unchanged
+	// (apart from the version bump to 3.2.0).
 	loader := openapi3.NewLoader()
 	doc, err := loader.LoadFromData([]byte(`
 openapi: 3.1.1
@@ -277,7 +228,7 @@ components:
 `))
 	require.NoError(t, err)
 
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	score := doc.Components.Schemas["Score"].Value
 	require.NotNil(t, score.ExclusiveMin.Value)
 	assert.Equal(t, 5.0, *score.ExclusiveMin.Value)
@@ -288,7 +239,7 @@ components:
 // Example -> Examples rewrite
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_ExampleToExamples(t *testing.T) {
+func TestUpgrade_ExampleToExamples(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -299,14 +250,14 @@ components:
       type: string
       example: fido
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	assert.Nil(t, pet.Example)
 	require.Len(t, pet.Examples, 1)
 	assert.Equal(t, "fido", pet.Examples[0])
 }
 
-func TestUpgradeTo31_ExampleAppendsToExistingExamples(t *testing.T) {
+func TestUpgrade_ExampleAppendsToExistingExamples(t *testing.T) {
 	loader := openapi3.NewLoader()
 	doc, err := loader.LoadFromData([]byte(`
 openapi: 3.0.3
@@ -320,7 +271,7 @@ components:
       examples: [rex]
 `))
 	require.NoError(t, err)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	assert.Nil(t, pet.Example)
 	assert.Equal(t, []any{"rex", "fido"}, pet.Examples)
@@ -330,7 +281,7 @@ components:
 // Idempotence
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_Idempotent(t *testing.T) {
+func TestUpgrade_Idempotent(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -349,10 +300,10 @@ components:
           minimum: 0
           exclusiveMinimum: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	first := marshalJSON(t, doc)
 
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 	second := marshalJSON(t, doc)
 
 	assert.Equal(t, first, second, "second pass must be a no-op")
@@ -362,7 +313,7 @@ components:
 // Walks reachable from operations and request/response bodies
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_WalksOperationSchemas(t *testing.T) {
+func TestUpgrade_WalksOperationSchemas(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -388,7 +339,7 @@ paths:
                     minimum: 0
                     exclusiveMinimum: true
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	openapi3conv.Upgrade(doc)
 
 	getOp := doc.Paths.Value("/pets").Get
 	param := getOp.Parameters[0].Value.Schema.Value
@@ -405,7 +356,7 @@ paths:
 // Cycle safety
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_CycleSafe(t *testing.T) {
+func TestUpgrade_CycleSafe(t *testing.T) {
 	// Hand-build a cycle without going through YAML — the loader resolves
 	// $ref into shared *Schema pointers, so a self-referential schema
 	// becomes a true graph cycle. The walker must terminate.
@@ -426,13 +377,12 @@ func TestUpgradeTo31_CycleSafe(t *testing.T) {
 		},
 	}
 
-	done := make(chan error, 1)
-	go func() { done <- openapi3conv.UpgradeTo31(doc) }()
+	done := make(chan struct{})
+	go func() { openapi3conv.Upgrade(doc); close(done) }()
 	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-context.Background().Done():
-		t.Fatal("UpgradeTo31 hung on a cyclic schema")
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Upgrade hung on a cyclic schema")
 	}
 
 	// Sanity: the rewrite still ran on the non-cyclic property.
@@ -457,11 +407,9 @@ components:
       example: fido
 `)
 	var buf bytes.Buffer
-	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
-		Verbose: &buf,
-	}))
+	openapi3conv.Upgrade(doc, openapi3conv.WithWriter(&buf))
 	out := buf.String()
-	assert.Contains(t, out, "openapi: 3.0.3 -> 3.1.1")
+	assert.Contains(t, out, "openapi: 3.0.3 -> 3.2.0")
 	assert.Contains(t, out, "nullable")
 	assert.Contains(t, out, "example")
 }
@@ -470,10 +418,11 @@ components:
 // Nil safety
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_NilDoc(t *testing.T) {
-	err := openapi3conv.UpgradeTo31(nil)
-	require.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "nil"))
+func TestUpgrade_NilDocDoesNotPanic(t *testing.T) {
+	// Per Pierre's guidance, Upgrade no longer validates input — doc
+	// must be Validate()'d first. Nil is the one case we still defend
+	// against, returning silently rather than panicking.
+	openapi3conv.Upgrade(nil)
 }
 
 func TestUpgradeSchema_NilSchema(t *testing.T) {

--- a/openapi3conv/openapi3_conv_test.go
+++ b/openapi3conv/openapi3_conv_test.go
@@ -81,18 +81,6 @@ components:
 	assert.Equal(t, openapi3.Types{"string", "null"}, *doc.Components.Schemas["Pet"].Value.Type)
 }
 
-func TestUpgrade_SkipVersionBump(t *testing.T) {
-	doc := loadV30(t, `
-openapi: 3.0.3
-info: {title: t, version: '1'}
-paths: {}
-`)
-	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
-		SkipVersionBump: true,
-	}))
-	assert.Equal(t, "3.0.3", doc.OpenAPI)
-}
-
 func TestUpgrade_RejectsCrossMajor(t *testing.T) {
 	// Cross-major upgrades belong in a dedicated package (mirror of
 	// openapi2conv). Pre-pin that boundary with an explicit error so any

--- a/openapi3conv/openapi3_conv_test.go
+++ b/openapi3conv/openapi3_conv_test.go
@@ -48,28 +48,84 @@ paths: {}
 	assert.Equal(t, "3.1.1", doc.OpenAPI)
 }
 
-func TestUpgradeTo31_CustomTargetVersion(t *testing.T) {
+func TestUpgrade_CustomTarget(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
 paths: {}
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31WithOptions(doc, openapi3conv.UpgradeOptions{
-		TargetVersion: "3.1.0",
+	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
+		Target: "3.1.0",
 	}))
 	assert.Equal(t, "3.1.0", doc.OpenAPI)
 }
 
-func TestUpgradeTo31_SkipVersionBump(t *testing.T) {
+func TestUpgrade_TargetIs32(t *testing.T) {
+	// 3.2 is purely additive over 3.1 — no schema-level rewrites between
+	// them. Upgrade applies the 3.0 → 3.1 rewrites and writes the 3.2
+	// version string. The resulting doc is canonical and version-correct.
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      nullable: true
+`)
+	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
+		Target: "3.2.0",
+	}))
+	assert.Equal(t, "3.2.0", doc.OpenAPI)
+	assert.Equal(t, openapi3.Types{"string", "null"}, *doc.Components.Schemas["Pet"].Value.Type)
+}
+
+func TestUpgrade_SkipVersionBump(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
 paths: {}
 `)
-	require.NoError(t, openapi3conv.UpgradeTo31WithOptions(doc, openapi3conv.UpgradeOptions{
+	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
 		SkipVersionBump: true,
 	}))
 	assert.Equal(t, "3.0.3", doc.OpenAPI)
+}
+
+func TestUpgrade_RejectsCrossMajor(t *testing.T) {
+	// Cross-major upgrades belong in a dedicated package (mirror of
+	// openapi2conv). Pre-pin that boundary with an explicit error so any
+	// future 3 → 4 transition lands somewhere predictable.
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+`)
+	err := openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{Target: "4.0.0"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cross-major")
+}
+
+func TestUpgrade_RejectsDowngrade(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.1.1
+info: {title: t, version: '1'}
+paths: {}
+`)
+	err := openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{Target: "3.0.3"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "downgrade")
+}
+
+func TestUpgrade_RejectsInvalidVersion(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+`)
+	err := openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{Target: "not-a-version"})
+	require.Error(t, err)
 }
 
 // ---------------------------------------------------------------------------
@@ -400,7 +456,7 @@ func TestUpgradeTo31_CycleSafe(t *testing.T) {
 // Verbose logging
 // ---------------------------------------------------------------------------
 
-func TestUpgradeTo31_VerboseLogsRewrites(t *testing.T) {
+func TestUpgrade_VerboseLogsRewrites(t *testing.T) {
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -413,7 +469,7 @@ components:
       example: fido
 `)
 	var buf bytes.Buffer
-	require.NoError(t, openapi3conv.UpgradeTo31WithOptions(doc, openapi3conv.UpgradeOptions{
+	require.NoError(t, openapi3conv.Upgrade(doc, openapi3conv.UpgradeOptions{
 		Verbose: &buf,
 	}))
 	out := buf.String()

--- a/openapi3conv/openapi3_conv_test.go
+++ b/openapi3conv/openapi3_conv_test.go
@@ -1,0 +1,453 @@
+package openapi3conv_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3conv"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadV30(t *testing.T, raw string) *openapi3.T {
+	t.Helper()
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(raw))
+	require.NoError(t, err)
+	return doc
+}
+
+// Round-trips through JSON so the result reflects what tooling consumers see
+// (omitted zero-value fields, normalized ordering). Easier to compare against
+// expected 3.1 output than walking structs.
+func marshalJSON(t *testing.T, doc *openapi3.T) map[string]any {
+	t.Helper()
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(b, &m))
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// Version bump
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_BumpsVersion(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	assert.Equal(t, "3.1.1", doc.OpenAPI)
+}
+
+func TestUpgradeTo31_CustomTargetVersion(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31WithOptions(doc, openapi3conv.UpgradeOptions{
+		TargetVersion: "3.1.0",
+	}))
+	assert.Equal(t, "3.1.0", doc.OpenAPI)
+}
+
+func TestUpgradeTo31_SkipVersionBump(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31WithOptions(doc, openapi3conv.UpgradeOptions{
+		SkipVersionBump: true,
+	}))
+	assert.Equal(t, "3.0.3", doc.OpenAPI)
+}
+
+// ---------------------------------------------------------------------------
+// Nullable rewrite
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_NullableWithType(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      nullable: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	pet := doc.Components.Schemas["Pet"].Value
+	require.NotNil(t, pet.Type)
+	assert.Equal(t, openapi3.Types{"string", "null"}, *pet.Type)
+	assert.False(t, pet.Nullable, "nullable should be cleared after rewrite")
+}
+
+func TestUpgradeTo31_NullableAlreadyHasNullInTypeArray(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: ['string', 'null']
+      nullable: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	pet := doc.Components.Schemas["Pet"].Value
+	assert.Equal(t, openapi3.Types{"string", "null"}, *pet.Type, "no duplicate null appended")
+	assert.False(t, pet.Nullable)
+}
+
+func TestUpgradeTo31_NullableNoType(t *testing.T) {
+	// nullable without an accompanying type is ambiguous in 3.0 (the spec is
+	// silent on whether nullable applies). Drop nullable; the schema then
+	// accepts any type, which subsumes null.
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      nullable: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	pet := doc.Components.Schemas["Pet"].Value
+	assert.False(t, pet.Nullable)
+	assert.Nil(t, pet.Type)
+}
+
+func TestUpgradeTo31_NullableInsideProperties(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        ageInYears:
+          type: integer
+          nullable: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	props := doc.Components.Schemas["Pet"].Value.Properties
+	assert.Equal(t, openapi3.Types{"string", "null"}, *props["name"].Value.Type)
+	assert.Equal(t, openapi3.Types{"integer", "null"}, *props["ageInYears"].Value.Type)
+}
+
+// ---------------------------------------------------------------------------
+// Exclusive-bound rewrite
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_ExclusiveMinTrueWithMinimum(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Score:
+      type: integer
+      minimum: 5
+      exclusiveMinimum: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	score := doc.Components.Schemas["Score"].Value
+	assert.Nil(t, score.Min, "Min cleared")
+	require.NotNil(t, score.ExclusiveMin.Value)
+	assert.Equal(t, 5.0, *score.ExclusiveMin.Value)
+	assert.Nil(t, score.ExclusiveMin.Bool)
+}
+
+func TestUpgradeTo31_ExclusiveMaxTrueWithMaximum(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Score:
+      type: integer
+      maximum: 100
+      exclusiveMaximum: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	score := doc.Components.Schemas["Score"].Value
+	assert.Nil(t, score.Max)
+	require.NotNil(t, score.ExclusiveMax.Value)
+	assert.Equal(t, 100.0, *score.ExclusiveMax.Value)
+	assert.Nil(t, score.ExclusiveMax.Bool)
+}
+
+func TestUpgradeTo31_ExclusiveMinFalseDropped(t *testing.T) {
+	// `exclusiveMinimum: false` is the default — it carries no information.
+	// The merged 3.1 form drops it.
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Score:
+      type: integer
+      minimum: 5
+      exclusiveMinimum: false
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	score := doc.Components.Schemas["Score"].Value
+	require.NotNil(t, score.Min)
+	assert.Equal(t, 5.0, *score.Min)
+	assert.False(t, score.ExclusiveMin.IsSet(), "exclusiveMinimum: false should be dropped")
+}
+
+func TestUpgradeTo31_ExclusiveBoundsLeavesNumericIntact(t *testing.T) {
+	// A document already in 3.1 numeric form should round-trip unchanged.
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(`
+openapi: 3.1.1
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Score:
+      type: integer
+      exclusiveMinimum: 5
+`))
+	require.NoError(t, err)
+
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	score := doc.Components.Schemas["Score"].Value
+	require.NotNil(t, score.ExclusiveMin.Value)
+	assert.Equal(t, 5.0, *score.ExclusiveMin.Value)
+	assert.Nil(t, score.Min)
+}
+
+// ---------------------------------------------------------------------------
+// Example -> Examples rewrite
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_ExampleToExamples(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      example: fido
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	pet := doc.Components.Schemas["Pet"].Value
+	assert.Nil(t, pet.Example)
+	require.Len(t, pet.Examples, 1)
+	assert.Equal(t, "fido", pet.Examples[0])
+}
+
+func TestUpgradeTo31_ExampleAppendsToExistingExamples(t *testing.T) {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(`
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      example: fido
+      examples: [rex]
+`))
+	require.NoError(t, err)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	pet := doc.Components.Schemas["Pet"].Value
+	assert.Nil(t, pet.Example)
+	assert.Equal(t, []any{"rex", "fido"}, pet.Examples)
+}
+
+// ---------------------------------------------------------------------------
+// Idempotence
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_Idempotent(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+          example: fido
+        score:
+          type: integer
+          minimum: 0
+          exclusiveMinimum: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	first := marshalJSON(t, doc)
+
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+	second := marshalJSON(t, doc)
+
+	assert.Equal(t, first, second, "second pass must be a no-op")
+}
+
+// ---------------------------------------------------------------------------
+// Walks reachable from operations and request/response bodies
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_WalksOperationSchemas(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: id
+          in: query
+          schema:
+            type: string
+            nullable: true
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total:
+                    type: integer
+                    minimum: 0
+                    exclusiveMinimum: true
+`)
+	require.NoError(t, openapi3conv.UpgradeTo31(doc))
+
+	getOp := doc.Paths.Value("/pets").Get
+	param := getOp.Parameters[0].Value.Schema.Value
+	assert.Equal(t, openapi3.Types{"string", "null"}, *param.Type)
+
+	body := getOp.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	total := body.Properties["total"].Value
+	assert.Nil(t, total.Min)
+	require.NotNil(t, total.ExclusiveMin.Value)
+	assert.Equal(t, 0.0, *total.ExclusiveMin.Value)
+}
+
+// ---------------------------------------------------------------------------
+// Cycle safety
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_CycleSafe(t *testing.T) {
+	// Hand-build a cycle without going through YAML — the loader resolves
+	// $ref into shared *Schema pointers, so a self-referential schema
+	// becomes a true graph cycle. The walker must terminate.
+	cycle := &openapi3.Schema{Type: &openapi3.Types{"object"}}
+	cycle.Properties = openapi3.Schemas{
+		"self": &openapi3.SchemaRef{Value: cycle},
+		"name": &openapi3.SchemaRef{Value: &openapi3.Schema{
+			Type:     &openapi3.Types{"string"},
+			Nullable: true,
+		}},
+	}
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Info:    &openapi3.Info{Title: "t", Version: "1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{"Cycle": &openapi3.SchemaRef{Value: cycle}},
+		},
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- openapi3conv.UpgradeTo31(doc) }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-context.Background().Done():
+		t.Fatal("UpgradeTo31 hung on a cyclic schema")
+	}
+
+	// Sanity: the rewrite still ran on the non-cyclic property.
+	name := cycle.Properties["name"].Value
+	assert.Equal(t, openapi3.Types{"string", "null"}, *name.Type)
+}
+
+// ---------------------------------------------------------------------------
+// Verbose logging
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_VerboseLogsRewrites(t *testing.T) {
+	doc := loadV30(t, `
+openapi: 3.0.3
+info: {title: t, version: '1'}
+paths: {}
+components:
+  schemas:
+    Pet:
+      type: string
+      nullable: true
+      example: fido
+`)
+	var buf bytes.Buffer
+	require.NoError(t, openapi3conv.UpgradeTo31WithOptions(doc, openapi3conv.UpgradeOptions{
+		Verbose: &buf,
+	}))
+	out := buf.String()
+	assert.Contains(t, out, "openapi: 3.0.3 -> 3.1.1")
+	assert.Contains(t, out, "nullable")
+	assert.Contains(t, out, "example")
+}
+
+// ---------------------------------------------------------------------------
+// Nil safety
+// ---------------------------------------------------------------------------
+
+func TestUpgradeTo31_NilDoc(t *testing.T) {
+	err := openapi3conv.UpgradeTo31(nil)
+	require.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "nil"))
+}
+
+func TestUpgradeSchema_NilSchema(t *testing.T) {
+	// Should not panic.
+	openapi3conv.UpgradeSchema(nil)
+}
+
+func TestUpgradeSchema_OperatesOnSubtree(t *testing.T) {
+	s := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"x": &openapi3.SchemaRef{Value: &openapi3.Schema{
+				Type:     &openapi3.Types{"string"},
+				Nullable: true,
+			}},
+		},
+	}
+	openapi3conv.UpgradeSchema(s)
+	x := s.Properties["x"].Value
+	assert.Equal(t, openapi3.Types{"string", "null"}, *x.Type)
+	assert.False(t, x.Nullable)
+}

--- a/openapi3conv/openapi3_conv_test.go
+++ b/openapi3conv/openapi3_conv_test.go
@@ -2,6 +2,7 @@ package openapi3conv_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -19,6 +20,26 @@ func loadV30(t *testing.T, raw string) *openapi3.T {
 	doc, err := loader.LoadFromData([]byte(raw))
 	require.NoError(t, err)
 	return doc
+}
+
+// requireValidate asserts doc passes openapi3 validation. Used as the
+// before-and-after invariant around Upgrade calls: a document valid as
+// 3.0 must remain valid after canonicalization to the latest 3.x.
+func requireValidate(t *testing.T, doc *openapi3.T, when string) {
+	t.Helper()
+	require.NoError(t, doc.Validate(context.Background()),
+		"document must validate %s Upgrade", when)
+}
+
+// upgradeAndAssertValid runs Upgrade with a Validate invariant on both
+// sides — input must validate, output must validate. Tests that exercise
+// representational rewrites use this helper so a regression that
+// produces an invalid output document fails the test.
+func upgradeAndAssertValid(t *testing.T, doc *openapi3.T, opts ...openapi3conv.Option) {
+	t.Helper()
+	requireValidate(t, doc, "before")
+	openapi3conv.Upgrade(doc, opts...)
+	requireValidate(t, doc, "after")
 }
 
 // Round-trips through JSON so the result reflects what tooling consumers see
@@ -43,7 +64,7 @@ openapi: 3.0.3
 info: {title: t, version: '1'}
 paths: {}
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	assert.Equal(t, "3.2.0", doc.OpenAPI)
 }
 
@@ -61,7 +82,7 @@ components:
       type: string
       nullable: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	assert.Equal(t, "3.2.0", doc.OpenAPI)
 	assert.Equal(t, openapi3.Types{"string", "null"}, *doc.Components.Schemas["Pet"].Value.Type)
 }
@@ -81,7 +102,7 @@ components:
       type: string
       nullable: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	require.NotNil(t, pet.Type)
 	assert.Equal(t, openapi3.Types{"string", "null"}, *pet.Type)
@@ -89,6 +110,9 @@ components:
 }
 
 func TestUpgrade_NullableAlreadyHasNullInTypeArray(t *testing.T) {
+	// Input intentionally mixes a 3.0 version stamp with a 3.1-only
+	// type array containing "null" — it doesn't validate as 3.0, so
+	// skip the before-Upgrade validate invariant here.
 	doc := loadV30(t, `
 openapi: 3.0.3
 info: {title: t, version: '1'}
@@ -118,7 +142,7 @@ components:
     Pet:
       nullable: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	assert.False(t, pet.Nullable)
 	assert.Nil(t, pet.Type)
@@ -141,7 +165,7 @@ components:
           type: integer
           nullable: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	props := doc.Components.Schemas["Pet"].Value.Properties
 	assert.Equal(t, openapi3.Types{"string", "null"}, *props["name"].Value.Type)
 	assert.Equal(t, openapi3.Types{"integer", "null"}, *props["ageInYears"].Value.Type)
@@ -163,7 +187,7 @@ components:
       minimum: 5
       exclusiveMinimum: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	score := doc.Components.Schemas["Score"].Value
 	assert.Nil(t, score.Min, "Min cleared")
 	require.NotNil(t, score.ExclusiveMin.Value)
@@ -183,7 +207,7 @@ components:
       maximum: 100
       exclusiveMaximum: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	score := doc.Components.Schemas["Score"].Value
 	assert.Nil(t, score.Max)
 	require.NotNil(t, score.ExclusiveMax.Value)
@@ -205,7 +229,7 @@ components:
       minimum: 5
       exclusiveMinimum: false
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	score := doc.Components.Schemas["Score"].Value
 	require.NotNil(t, score.Min)
 	assert.Equal(t, 5.0, *score.Min)
@@ -228,7 +252,7 @@ components:
 `))
 	require.NoError(t, err)
 
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	score := doc.Components.Schemas["Score"].Value
 	require.NotNil(t, score.ExclusiveMin.Value)
 	assert.Equal(t, 5.0, *score.ExclusiveMin.Value)
@@ -250,7 +274,7 @@ components:
       type: string
       example: fido
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	pet := doc.Components.Schemas["Pet"].Value
 	assert.Nil(t, pet.Example)
 	require.Len(t, pet.Examples, 1)
@@ -258,6 +282,9 @@ components:
 }
 
 func TestUpgrade_ExampleAppendsToExistingExamples(t *testing.T) {
+	// Input intentionally mixes a 3.0 version stamp with the 3.1-only
+	// schema-level examples array — it doesn't validate as 3.0, so
+	// skip the before-Upgrade validate invariant here.
 	loader := openapi3.NewLoader()
 	doc, err := loader.LoadFromData([]byte(`
 openapi: 3.0.3
@@ -300,10 +327,10 @@ components:
           minimum: 0
           exclusiveMinimum: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	first := marshalJSON(t, doc)
 
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 	second := marshalJSON(t, doc)
 
 	assert.Equal(t, first, second, "second pass must be a no-op")
@@ -339,7 +366,7 @@ paths:
                     minimum: 0
                     exclusiveMinimum: true
 `)
-	openapi3conv.Upgrade(doc)
+	upgradeAndAssertValid(t, doc)
 
 	getOp := doc.Paths.Value("/pets").Get
 	param := getOp.Parameters[0].Value.Schema.Value
@@ -407,7 +434,7 @@ components:
       example: fido
 `)
 	var buf bytes.Buffer
-	openapi3conv.Upgrade(doc, openapi3conv.WithWriter(&buf))
+	upgradeAndAssertValid(t, doc, openapi3conv.WithWriter(&buf))
 	out := buf.String()
 	assert.Contains(t, out, "openapi: 3.0.3 -> 3.2.0")
 	assert.Contains(t, out, "nullable")


### PR DESCRIPTION
> **Status: draft.** Opening early to gauge whether this fits in kin-openapi proper, and to settle a couple of small open questions before marking ready for review.

## Motivation

kin-openapi parses both OpenAPI 3.0 and 3.1, sharing one `openapi3.T` type. Schema-level constructs serialize differently between the two versions but represent the same semantics:

- `nullable: true` (3.0) ↔ `type: ["string", "null"]` (3.1)
- `minimum: 5, exclusiveMinimum: true` (3.0) ↔ `exclusiveMinimum: 5` (3.1)
- `example: v` (3.0) ↔ `examples: [v]` (3.1)

Downstream consumers that need a *single canonical form* (diff tools, code generators, validators) currently have to special-case both representations or accept inconsistent output. In the JS/Python ecosystems this is a solved problem with multiple tools — [apiture/openapi-down-convert](https://github.com/apiture/openapi-down-convert) (3.1 → 3.0), [openapi-format](https://www.npmjs.com/package/openapi-format) (Node, upgrades 3.0 → 3.2), [Scalar's openapi-upgrader](https://github.com/scalar/scalar), [openapi-downgrade](https://pypi.org/project/openapi-downgrade/) (Python), [openapi-spec-converter](https://denseanalysis.org/blog/post/2025-03-27-openapi-spec-converter/). In Go (kin-openapi), the equivalent slot — paralleling the existing `openapi2conv` — is empty.

This PR fills that slot.

## Scope

- **In scope**: 3.0 ↔ 3.1 ↔ 3.2 ↔ any future 3.x where representational differences can be rewritten in place. OpenAPI 3.2 is purely additive over 3.1 (structured tags, streaming, `additionalOperations`, OAuth device flow, `defaultMapping`), so 3.1 → 3.2 is a version-string change with no further rewrites.
- **Out of scope**: 3.x → 3.0 (lossy by nature).
- **Out of scope**: cross-major upgrades (3 → 4 if/when v4 ships). Those belong in a dedicated package mirroring `openapi2conv`. The package errors out explicitly with a message pointing at that pattern.

## What it does

The 3.0 → 3.1 direction is **mechanical and lossless**: every 3.0 construct has a direct 3.1 form per the [OAI upgrade guide](https://learn.openapis.org/upgrading/v3.0-to-v3.1.html). The package walks the schema graph and rewrites in place.

| 3.0 | 3.1 |
|---|---|
| `openapi: 3.0.x` | `openapi: 3.1.1` (or any 3.x via `Target`) |
| `nullable: true` + `type: T` | `type: [T, "null"]` |
| `nullable: true` + `type: [T, U]` | `type: [T, U, "null"]` (deduped) |
| `nullable: true` (no `type`) | drop `nullable` |
| `minimum: x` + `exclusiveMinimum: true` | `exclusiveMinimum: x`; `minimum` cleared |
| `maximum: x` + `exclusiveMaximum: true` | `exclusiveMaximum: x`; `maximum` cleared |
| `exclusiveMinimum: false` / `exclusiveMaximum: false` | dropped (default) |
| Schema `example: v` | `examples: [..., v]` |

## API

```go
package openapi3conv

// Upgrade canonicalizes doc into the representation of opts.Target.
// Cross-major and downgrade attempts return an error.
func Upgrade(doc *openapi3.T, opts UpgradeOptions) error

// UpgradeTo31 is a convenience wrapper for Upgrade with Target = "3.1.1".
func UpgradeTo31(doc *openapi3.T) error

// UpgradeSchema canonicalizes a single schema (and its descendants) in place.
func UpgradeSchema(s *openapi3.Schema)

type UpgradeOptions struct {
    Target          string    // e.g. "3.1.1", "3.2.0"; defaults to "3.1.1"
    SkipVersionBump bool      // leave doc.OpenAPI alone
    Verbose         io.Writer // log each rewrite
}
```

In-place mutation (vs returning a new doc à la `openapi2conv.ToV3`) is intentional: kin-openapi already shares one `openapi3.T` type between 3.0, 3.1, and 3.2, so no type conversion is happening — only field rewrites. Deep-copying the entire tree just to leave the input untouched would be wasteful and error-prone for refs and components.

The walk is cycle-safe via a `map[*openapi3.Schema]struct{}` visited set.

## Tests

24 tests covering all transformations, idempotence, custom targets including 3.2, the cross-major / downgrade / bad-version error paths, operation-tree walking (parameters, request bodies, responses, callbacks), cycle safety, verbose logging, and nil safety.

```
$ go test ./openapi3conv/
ok  github.com/getkin/kin-openapi/openapi3conv  0.562s
```

Full `go test ./...` is green; no changes outside the new package.

## Open questions

1. **Default `Target`** — currently `3.1.1` (the OAI guide uses this). Open to `3.1.0` if you prefer the floor.
2. **Naming** — `openapi3conv` parallels `openapi2conv`. The package's purpose is upgrading *within* 3.x rather than between major versions, so the name is slightly off-key. Open to alternatives.

## Out of scope

Lower-priority items I deliberately did not include:

- **File-upload normalization** (`format: byte` → `contentEncoding: base64`, multipart `format: binary` → `contentMediaType`). Context-dependent on media type and rarely the bottleneck.
- **`$schema` dialect declaration** on Schema Objects. Opt-in enhancement, not a representational difference.
- **Direct 2.0 → 3.1**. Composes cleanly: `openapi2conv.ToV3` then `openapi3conv.Upgrade`.

Happy to address any of these in follow-ups if there's interest.
