### PR TITLE
openapi3gen: skip component export for anonymous types

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -435,6 +435,15 @@ func (g *Generator) generateWithoutSaving(parents []*theTypeInfo, t reflect.Type
 
 		typeName := g.generateTypeName(t)
 
+		// Anonymous types (e.g. `struct{...}` literals) have an empty name.
+		// Registering them as a component would produce
+		// "#/components/schemas/" which violates the OpenAPI spec
+		// (component keys must match ^[a-zA-Z0-9._-]+$). Inline the
+		// schema instead so downstream codegen tools don't choke.
+		if typeName == "" {
+			return openapi3.NewSchemaRef("", schema), nil
+		}
+
 		// The body becomes the canonical component definition shared by every
 		// $ref site. The Nullable flag, set above when the type was reached
 		// via *T, applies to one specific field, not to the type itself --

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -698,3 +698,36 @@ func TestExportComponentSchemasNoNullableOnBody(t *testing.T) {
 	require.NotNil(t, channel.Value)
 	assert.False(t, channel.Value.Nullable, "exported component body must not carry the nullable flag from a *T reference site")
 }
+
+// TestExportComponentSchemasSkipsAnonymousType verifies that anonymous struct
+// types (whose reflect.Type.Name() is "") are inlined rather than registered
+// as components, so the resulting spec has no "#/components/schemas/" entry
+// or ref (which would violate the OpenAPI component-key pattern).
+func TestExportComponentSchemasSkipsAnonymousType(t *testing.T) {
+	type Outer struct {
+		Inline struct {
+			X int
+		}
+	}
+
+	schemas := make(openapi3.Schemas)
+	g := openapi3gen.NewGenerator(
+		openapi3gen.UseAllExportedFields(),
+		openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
+			ExportComponentSchemas: true,
+			ExportTopLevelSchema:   true,
+		}),
+	)
+
+	_, err := g.NewSchemaRefForValue(&Outer{}, schemas)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, schemas, "outer named struct should still be registered as a component")
+
+	_, hasEmptyKey := schemas[""]
+	assert.False(t, hasEmptyKey, "anonymous nested struct should not be registered as a component")
+
+	for key := range schemas {
+		assert.NotEmpty(t, key, "every component schema must have a non-empty key")
+	}
+}


### PR DESCRIPTION
## Problem

When `ExportComponentSchemas: true` is set and the generator walks into a struct field whose type is anonymous (e.g. an inline `struct{...}` literal), `reflect.Type.Name()` returns `""`. The component-export branch in `generateSchemaRefFor` happily registers it:

```go
typeName := g.generateTypeName(t)
g.componentSchemaRefs[typeName] = struct{}{}
return openapi3.NewSchemaRef(fmt.Sprintf("#/components/schemas/%s", typeName), schema), nil
```

The result is a component keyed by `""` and a `\$ref` of `#/components/schemas/`. Both violate the [OpenAPI 3 component-key pattern](https://spec.openapis.org/oas/v3.0.3.html#components-object) (`^[a-zA-Z0-9._-]+\$`) and downstream codegen tools reject the spec:

```
🛑 Invalid component key found. OpenAPI component keys must match the pattern /^[a-zA-Z0-9.\-_]+/
  Invalid keys:
    - components.schemas.
```

## Fix

When `generateTypeName` returns `""`, inline the schema instead of registering it as a component. This matches the behavior already used for generics and `time.Time` in the same function.

## Test

`TestExportComponentSchemasSkipsAnonymousType` registers a struct with an inline anonymous field and asserts no component schema is created with an empty key.