### PR TITLE
openapi3gen: clear nullable on exported component bodies

### DIFF
--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -435,6 +435,14 @@ func (g *Generator) generateWithoutSaving(parents []*theTypeInfo, t reflect.Type
 
 		typeName := g.generateTypeName(t)
 
+		// The body becomes the canonical component definition shared by every
+		// $ref site. The Nullable flag, set above when the type was reached
+		// via *T, applies to one specific field, not to the type itself --
+		// keeping it here would emit a polluted component like
+		// `"Foo": {"nullable": true, "type": "object", ...}` and break codegen
+		// tools (e.g. Orval generates `interface Foo {...} | null`).
+		schema.Nullable = false
+
 		g.componentSchemaRefs[typeName] = struct{}{}
 		return openapi3.NewSchemaRef(fmt.Sprintf("#/components/schemas/%s", typeName), schema), nil
 	}

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -667,3 +667,34 @@ func TestExportComponentSchemasForTimeProp(t *testing.T) {
 		return !strings.Contains(string(schema), "#/components/schemas/Time")
 	}, "Expected no schema for time.Time property but got one: %s", schema)
 }
+
+// TestExportComponentSchemasNoNullableOnBody verifies that a struct reached
+// via *T (e.g. as the Data field of `Response[*Channel]`) does not pollute
+// its exported component definition with `nullable: true`. The component
+// body is shared by every reference site, so a nullable component breaks
+// codegen tools (e.g. Orval emits `interface Channel {...} | null`).
+func TestExportComponentSchemasNoNullableOnBody(t *testing.T) {
+	type Channel struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	type Wrapper struct {
+		Data *Channel `json:"data"`
+	}
+
+	schemas := make(openapi3.Schemas)
+	g := openapi3gen.NewGenerator(
+		openapi3gen.UseAllExportedFields(),
+		openapi3gen.CreateComponentSchemas(openapi3gen.ExportComponentSchemasOptions{
+			ExportComponentSchemas: true,
+		}),
+	)
+
+	_, err := g.NewSchemaRefForValue(&Wrapper{}, schemas)
+	require.NoError(t, err)
+
+	channel, ok := schemas["Channel"]
+	require.True(t, ok, "Channel must be registered as a component")
+	require.NotNil(t, channel.Value)
+	assert.False(t, channel.Value.Nullable, "exported component body must not carry the nullable flag from a *T reference site")
+}


### PR DESCRIPTION
## Problem

When a struct is reached via `*T`, `generateSchemaRefFor` sets `schema.Nullable = true` to encode nullability of that one reference site:

```go
isNullable := false
for t.Kind() == reflect.Ptr {
    t = t.Elem()
    isNullable = !isRoot
}
// ...
schema.Nullable = isNullable
```

With `ExportComponentSchemas: true`, that same `*openapi3.Schema` body later becomes the canonical component definition shared by every `\$ref` site:

```go
g.componentSchemaRefs[typeName] = struct{}{}
return openapi3.NewSchemaRef(fmt.Sprintf("#/components/schemas/%s", typeName), schema), nil
```

So the nullable flag leaks into the component itself. Real-world example from a Fuego-based API:

```yaml
components:
  schemas:
    Channel:
      type: object
      nullable: true   # <-- wrong, the component is always defined
      properties: { ... }
    AddChannelRequest:
      properties:
        channel:
          \$ref: '#/components/schemas/Channel'  # this single use was *Channel
```

Codegen tools (Orval, openapi-typescript) interpret `nullable` on a component body as "the type itself can be null" and emit broken TypeScript:

```ts
export interface Channel {
  // ...
} | null   // <-- syntax error
```

## Fix

Clear `schema.Nullable` right before registering the schema as a component. Nullability of the body is meaningless once the body is shared by every reference site; the field-level decision belongs at the `\$ref` site (and OpenAPI 3.0 has no clean way to mark a `\$ref` as nullable, but that's a separate concern). Inline schemas (the fallback at the bottom of the function) keep the existing nullable behavior.

## Test

`TestExportComponentSchemasNoNullableOnBody` registers `Wrapper{ Data *Channel }`, exports components, and asserts `schemas["Channel"].Value.Nullable == false`.

The existing `ExampleThrowErrorOnCycle` snapshot is unaffected (it doesn't enable `ExportComponentSchemas`).