### PR TITLE
feat(openapi3): batch-convert long-tail RequiredFieldError sites

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -704,6 +704,10 @@ func (e *ExternalDocs) Validate(ctx context.Context, opts ...ValidationOption) e
     Validate returns an error if ExternalDocs does not comply with the OpenAPI
     spec.
 
+type ExternalDocsURLRequired struct{ ValidationError }
+
+func (e *ExternalDocsURLRequired) As(target any) bool
+
 type FieldVersionMismatchError struct {
 	// Field is the field name flagged (e.g. "summary", "identifier",
 	// "$defs", "prefixItems", "contains", ...).
@@ -1165,6 +1169,18 @@ func (flow *OAuthFlow) Validate(ctx context.Context, opts ...ValidationOption) e
     Validate returns an error if OAuthFlows does not comply with the OpenAPI
     spec.
 
+type OAuthFlowAuthorizationURLRequired struct{ ValidationError }
+
+func (e *OAuthFlowAuthorizationURLRequired) As(target any) bool
+
+type OAuthFlowScopesRequired struct{ ValidationError }
+
+func (e *OAuthFlowScopesRequired) As(target any) bool
+
+type OAuthFlowTokenURLRequired struct{ ValidationError }
+
+func (e *OAuthFlowTokenURLRequired) As(target any) bool
+
 type OAuthFlows struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -1258,6 +1274,10 @@ func (operation *Operation) UnmarshalJSON(data []byte) error
 func (operation *Operation) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Operation does not comply with the OpenAPI
     spec.
+
+type OperationResponsesRequired struct{ ValidationError }
+
+func (e *OperationResponsesRequired) As(target any) bool
 
 type Origin struct {
 	Key       *Location             `json:"key,omitempty" yaml:"key,omitempty"`
@@ -1641,6 +1661,10 @@ func (requestBody *RequestBody) WithSchema(value *Schema, consumes []string) *Re
 
 func (requestBody *RequestBody) WithSchemaRef(value *SchemaRef, consumes []string) *RequestBody
 
+type RequestBodyContentRequired struct{ ValidationError }
+
+func (e *RequestBodyContentRequired) As(target any) bool
+
 type RequestBodyRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
 	// are allowed by the openapi spec.
@@ -1751,6 +1775,10 @@ func (m ResponseBodies) JSONLookup(token string) (any, error)
 
 func (responseBodies *ResponseBodies) UnmarshalJSON(data []byte) (err error)
     UnmarshalJSON sets ResponseBodies to a copy of data.
+
+type ResponseDescriptionRequired struct{ ValidationError }
+
+func (e *ResponseDescriptionRequired) As(target any) bool
 
 type ResponseRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields

--- a/openapi3/external_docs.go
+++ b/openapi3/external_docs.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/url"
@@ -63,7 +62,7 @@ func (e *ExternalDocs) Validate(ctx context.Context, opts ...ValidationOption) e
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if e.URL == "" {
-		return errors.New("url is required")
+		return newExternalDocsURLRequired(e.Origin)
 	}
 	if _, err := url.Parse(e.URL); err != nil {
 		return fmt.Errorf("url is incorrect: %w", err)

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"strconv"
@@ -209,7 +208,7 @@ func (operation *Operation) Validate(ctx context.Context, opts ...ValidationOpti
 			return err
 		}
 	} else {
-		return errors.New("value of responses must be an object")
+		return newOperationResponsesRequired(operation.Origin)
 	}
 
 	if v := operation.ExternalDocs; v != nil {

--- a/openapi3/operation_test.go
+++ b/openapi3/operation_test.go
@@ -1,7 +1,6 @@
 package openapi3_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,19 +45,19 @@ func operationWithResponses() *openapi3.Operation {
 
 func TestOperationValidation(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         *openapi3.Operation
-		expectedError error
+		name             string
+		input            *openapi3.Operation
+		expectedErrorMsg string // empty = expect no error
 	}{
 		{
 			"when no Responses object is provided",
 			operationWithoutResponses(),
-			errors.New("value of responses must be an object"),
+			"value of responses must be an object",
 		},
 		{
 			"when a Responses object is provided",
 			operationWithResponses(),
-			nil,
+			"",
 		},
 	}
 
@@ -67,7 +66,11 @@ func TestOperationValidation(t *testing.T) {
 			c := t.Context()
 			validationErr := test.input.Validate(c)
 
-			require.Equal(t, test.expectedError, validationErr, "expected errors (or lack of) to match")
+			if test.expectedErrorMsg == "" {
+				require.NoError(t, validationErr)
+			} else {
+				require.EqualError(t, validationErr, test.expectedErrorMsg)
+			}
 		})
 	}
 }

--- a/openapi3/request_body.go
+++ b/openapi3/request_body.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"maps"
 )
 
@@ -123,7 +122,7 @@ func (requestBody *RequestBody) Validate(ctx context.Context, opts ...Validation
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if requestBody.Content == nil {
-		return errors.New("content of the request body is required")
+		return newRequestBodyContentRequired(requestBody.Origin)
 	}
 
 	if vo := getValidationOptions(ctx); !vo.examplesValidationDisabled {

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -179,7 +179,7 @@ func (response *Response) Validate(ctx context.Context, opts ...ValidationOption
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if response.Description == nil {
-		return errors.New("a short description of the response is required")
+		return newResponseDescriptionRequired(response.Origin)
 	}
 	if vo := getValidationOptions(ctx); !vo.examplesValidationDisabled {
 		vo.examplesValidationAsReq, vo.examplesValidationAsRes = false, true

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -386,7 +386,7 @@ func (flow *OAuthFlow) Validate(ctx context.Context, opts ...ValidationOption) e
 	}
 
 	if flow.Scopes == nil {
-		return errors.New("field 'scopes' is missing")
+		return newOAuthFlowScopesRequired(flow.Origin)
 	}
 
 	return validateExtensions(ctx, flow.Extensions)
@@ -402,7 +402,7 @@ func (flow *OAuthFlow) validate(ctx context.Context, typ oAuthFlowType, opts ...
 	if in := typeIn(oAuthFlowTypeImplicit, oAuthFlowAuthorizationCode); true {
 		switch {
 		case flow.AuthorizationURL == "" && in:
-			return errors.New("field 'authorizationUrl' is empty or missing")
+			return newOAuthFlowAuthorizationURLRequired(flow.Origin)
 		case flow.AuthorizationURL != "" && !in:
 			return errors.New("field 'authorizationUrl' should not be set")
 		case flow.AuthorizationURL != "":
@@ -415,7 +415,7 @@ func (flow *OAuthFlow) validate(ctx context.Context, typ oAuthFlowType, opts ...
 	if in := typeIn(oAuthFlowTypePassword, oAuthFlowTypeClientCredentials, oAuthFlowAuthorizationCode); true {
 		switch {
 		case flow.TokenURL == "" && in:
-			return errors.New("field 'tokenUrl' is empty or missing")
+			return newOAuthFlowTokenURLRequired(flow.Origin)
 		case flow.TokenURL != "" && !in:
 			return errors.New("field 'tokenUrl' should not be set")
 		case flow.TokenURL != "":

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -198,6 +198,48 @@ func (e *ServerURLRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type ExternalDocsURLRequired struct{ ValidationError }
+
+func (e *ExternalDocsURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OperationResponsesRequired struct{ ValidationError }
+
+func (e *OperationResponsesRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type RequestBodyContentRequired struct{ ValidationError }
+
+func (e *RequestBodyContentRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type ResponseDescriptionRequired struct{ ValidationError }
+
+func (e *ResponseDescriptionRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowScopesRequired struct{ ValidationError }
+
+func (e *OAuthFlowScopesRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowAuthorizationURLRequired struct{ ValidationError }
+
+func (e *OAuthFlowAuthorizationURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowTokenURLRequired struct{ ValidationError }
+
+func (e *OAuthFlowTokenURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // FieldVersionMismatchError leaves — non-schema fields.
 
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
@@ -412,6 +454,41 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+func newExternalDocsURLRequired(origin *Origin) error {
+	return newRequiredField("externalDocs.url",
+		&ExternalDocsURLRequired{ValidationError{Message: "url is required"}}, origin)
+}
+
+func newOperationResponsesRequired(origin *Origin) error {
+	return newRequiredField("operation.responses",
+		&OperationResponsesRequired{ValidationError{Message: "value of responses must be an object"}}, origin)
+}
+
+func newRequestBodyContentRequired(origin *Origin) error {
+	return newRequiredField("requestBody.content",
+		&RequestBodyContentRequired{ValidationError{Message: "content of the request body is required"}}, origin)
+}
+
+func newResponseDescriptionRequired(origin *Origin) error {
+	return newRequiredField("response.description",
+		&ResponseDescriptionRequired{ValidationError{Message: "a short description of the response is required"}}, origin)
+}
+
+func newOAuthFlowScopesRequired(origin *Origin) error {
+	return newRequiredField("oAuthFlow.scopes",
+		&OAuthFlowScopesRequired{ValidationError{Message: "field 'scopes' is missing"}}, origin)
+}
+
+func newOAuthFlowAuthorizationURLRequired(origin *Origin) error {
+	return newRequiredField("oAuthFlow.authorizationUrl",
+		&OAuthFlowAuthorizationURLRequired{ValidationError{Message: "field 'authorizationUrl' is empty or missing"}}, origin)
+}
+
+func newOAuthFlowTokenURLRequired(origin *Origin) error {
+	return newRequiredField("oAuthFlow.tokenUrl",
+		&OAuthFlowTokenURLRequired{ValidationError{Message: "field 'tokenUrl' is empty or missing"}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -409,11 +409,8 @@ paths:
 	require.Contains(t, sve.Error(), "invalid example: ")
 }
 
-// Spot-check the seven follow-up RequiredFieldError leaves added in
-// the long-tail conversion: external docs, operation responses,
-// request body content, response description, three OAuth flow fields.
-// Two representative cases here; the remaining five follow the same
-// shape and are exercised indirectly through round-trip Validate calls.
+// Pin RequiredFieldError cluster + leaf reachability for required-field
+// validation on operations and external docs.
 func TestValidationError_FollowupRequiredFieldLeaves(t *testing.T) {
 	type tc struct {
 		name      string

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -409,6 +409,70 @@ paths:
 	require.Contains(t, sve.Error(), "invalid example: ")
 }
 
+// Spot-check the seven follow-up RequiredFieldError leaves added in
+// the long-tail conversion: external docs, operation responses,
+// request body content, response description, three OAuth flow fields.
+// Two representative cases here; the remaining five follow the same
+// shape and are exercised indirectly through round-trip Validate calls.
+func TestValidationError_FollowupRequiredFieldLeaves(t *testing.T) {
+	type tc struct {
+		name      string
+		doc       *openapi3.T
+		field     string
+		message   string
+		leafCheck func(t *testing.T, err error)
+	}
+	cases := []tc{
+		{
+			name: "operation responses required",
+			doc: &openapi3.T{
+				OpenAPI: "3.0.3",
+				Info:    &openapi3.Info{Title: "x", Version: "1.0.0"},
+				Paths: openapi3.NewPaths(openapi3.WithPath("/p", &openapi3.PathItem{
+					Get: &openapi3.Operation{}, // no Responses
+				})),
+			},
+			field:   "operation.responses",
+			message: "value of responses must be an object",
+			leafCheck: func(t *testing.T, err error) {
+				var l *openapi3.OperationResponsesRequired
+				require.True(t, errors.As(err, &l))
+			},
+		},
+		{
+			name: "external docs url required",
+			doc: &openapi3.T{
+				OpenAPI:      "3.0.3",
+				Info:         &openapi3.Info{Title: "x", Version: "1.0.0"},
+				Paths:        openapi3.NewPaths(),
+				ExternalDocs: &openapi3.ExternalDocs{}, // empty URL
+			},
+			field:   "externalDocs.url",
+			message: "url is required",
+			leafCheck: func(t *testing.T, err error) {
+				var l *openapi3.ExternalDocsURLRequired
+				require.True(t, errors.As(err, &l))
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.doc.Validate(context.Background())
+			require.Error(t, err)
+
+			var rfe *openapi3.RequiredFieldError
+			require.True(t, errors.As(err, &rfe))
+			require.Equal(t, c.field, rfe.Field)
+
+			c.leafCheck(t, err)
+
+			var ve *openapi3.ValidationError
+			require.True(t, errors.As(err, &ve))
+			require.Equal(t, c.message, ve.Message)
+		})
+	}
+}
+
 // MultiError already implements As() that recurses into elements, so a
 // typed validation error wrapped inside a MultiError must remain
 // reachable. This pins that no special wiring is needed for the typed


### PR DESCRIPTION
Seven long-tail untyped errors converted to the `*RequiredFieldError` cluster pattern.

| Site | Leaf | Field |
|---|---|---|
| `external_docs.go:66` | `*ExternalDocsURLRequired` | `externalDocs.url` |
| `operation.go:212` | `*OperationResponsesRequired` | `operation.responses` |
| `request_body.go:126` | `*RequestBodyContentRequired` | `requestBody.content` |
| `response.go:182` | `*ResponseDescriptionRequired` | `response.description` |
| `security_scheme.go:389` | `*OAuthFlowScopesRequired` | `oAuthFlow.scopes` |
| `security_scheme.go:405` | `*OAuthFlowAuthorizationURLRequired` | `oAuthFlow.authorizationUrl` |
| `security_scheme.go:418` | `*OAuthFlowTokenURLRequired` | `oAuthFlow.tokenUrl` |

Existing tests with `require.Equal(t, errors.New("..."))` against the converted sites switched to `require.EqualError` on the message string (one site: `operation_test.go`'s `TestOperationValidation`).

Two new tests in `validation_error_test.go` pin the cluster + leaf + base reachability for representative cases (`operation.responses`, `externalDocs.url`); the other five follow the same mechanical shape.

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte.

## Scope

Only sites that fit the existing `RequiredFieldError` cluster — no new cluster types. Other long-tail flavors (mutually-exclusive fields, "should not be set", link XOR-required, etc.) need new clusters and would land in separate follow-ups.
