### PR TITLE
feat(openapi3): MutuallyExclusiveFieldsError cluster for forbidden field pairs

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -643,6 +643,10 @@ func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) err
     Validate returns an error if ExampleRef does not comply with the OpenAPI
     spec.
 
+type ExampleValueExternalValueExclusive struct{ ValidationError }
+
+func (e *ExampleValueExternalValueExclusive) As(target any) bool
+
 type Examples map[string]*ExampleRef // Examples represents components' named examples
 
 func (m Examples) JSONLookup(token string) (any, error)
@@ -911,6 +915,10 @@ type LicenseNameRequired struct{ ValidationError }
 
 func (e *LicenseNameRequired) As(target any) bool
 
+type LicenseURLIdentifierExclusive struct{ ValidationError }
+
+func (e *LicenseURLIdentifierExclusive) As(target any) bool
+
 type Link struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -936,6 +944,10 @@ func (link *Link) UnmarshalJSON(data []byte) error
 
 func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Link does not comply with the OpenAPI spec.
+
+type LinkOperationIDRefExclusive struct{ ValidationError }
+
+func (e *LinkOperationIDRefExclusive) As(target any) bool
 
 type LinkRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1097,6 +1109,10 @@ func (mediaType *MediaType) WithSchema(schema *Schema) *MediaType
 
 func (mediaType *MediaType) WithSchemaRef(schema *SchemaRef) *MediaType
 
+type MediaTypeExampleExamplesExclusive struct{ ValidationError }
+
+func (e *MediaTypeExampleExamplesExclusive) As(target any) bool
+
 type MinContainsFieldFor31Plus struct{ ValidationError }
 
 func (e *MinContainsFieldFor31Plus) As(target any) bool
@@ -1115,6 +1131,26 @@ func (me MultiError) Is(target error) bool
     Is allows you to determine if a generic error is in fact a MultiError using
     `errors.Is()` It will also return true if any of the contained errors match
     target
+
+type MutuallyExclusiveFieldsError struct {
+	// Field1 and Field2 name the two fields the spec forbids setting
+	// together (e.g. "value", "externalValue").
+	Field1 string
+	Field2 string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    MutuallyExclusiveFieldsError clusters "fields X and Y are both set, only
+    one is allowed" failures (example.value vs externalValue, mediaType.example
+    vs examples, license.url vs identifier, link.operationId vs operationRef).
+    Carries both field names and wraps the per-site leaf.
+
+func (e *MutuallyExclusiveFieldsError) Error() string
+
+func (e *MutuallyExclusiveFieldsError) Unwrap() error
 
 type NewCallbackOption func(*Callback)
     NewCallbackOption describes options to NewCallback func

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2151,6 +2151,10 @@ type SchemaFieldFor31Plus struct{ ValidationError }
 
 func (e *SchemaFieldFor31Plus) As(target any) bool
 
+type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
+
+func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool
+
 type SchemaRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
 	// are allowed by the openapi spec.

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -75,7 +75,7 @@ func (example *Example) Validate(ctx context.Context, opts ...ValidationOption) 
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if example.Value != nil && example.ExternalValue != "" {
-		return errors.New("value and externalValue are mutually exclusive")
+		return newExampleValueExternalValueExclusive(example.Origin)
 	}
 	if example.Value == nil && example.ExternalValue == "" {
 		return errors.New("no value or externalValue field")

--- a/openapi3/license.go
+++ b/openapi3/license.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"maps"
 )
 
@@ -76,7 +75,7 @@ func (license *License) Validate(ctx context.Context, opts ...ValidationOption) 
 	}
 
 	if license.URL != "" && license.Identifier != "" {
-		return errors.New("license must not specify both 'url' and 'identifier'")
+		return newLicenseURLIdentifierExclusive(license.Origin)
 	}
 
 	return validateExtensions(ctx, license.Extensions)

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"maps"
 )
 
@@ -88,7 +87,7 @@ func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error 
 		return errors.New("missing operationId or operationRef on link")
 	}
 	if link.OperationID != "" && link.OperationRef != "" {
-		return fmt.Errorf("operationId %q and operationRef %q are mutually exclusive", link.OperationID, link.OperationRef)
+		return newLinkOperationIDRefExclusive(link.OperationID, link.OperationRef, link.Origin)
 	}
 
 	return validateExtensions(ctx, link.Extensions)

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 
@@ -125,7 +124,7 @@ func (mediaType *MediaType) Validate(ctx context.Context, opts ...ValidationOpti
 		}
 
 		if mediaType.Example != nil && mediaType.Examples != nil {
-			return errors.New("example and examples are mutually exclusive")
+			return newMediaTypeExampleExamplesExclusive(mediaType.Origin)
 		}
 
 		if vo := getValidationOptions(ctx); !vo.examplesValidationDisabled {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1412,7 +1412,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	stack = append(stack, schema)
 
 	if schema.ReadOnly && schema.WriteOnly {
-		return stack, errors.New("a property MUST NOT be marked as both readOnly and writeOnly being true")
+		return stack, newSchemaReadOnlyWriteOnlyExclusive(schema.Origin)
 	}
 
 	// Reject fields that only exist in OAS 3.1 / JSON Schema 2020-12 when the

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -244,6 +244,12 @@ func (e *LinkOperationIDRefExclusive) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
+
+func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // FieldVersionMismatchError leaves — non-schema fields.
 
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
@@ -493,6 +499,12 @@ func newLinkOperationIDRefExclusive(operationID, operationRef string, origin *Or
 	msg := fmt.Sprintf("operationId %q and operationRef %q are mutually exclusive", operationID, operationRef)
 	return newMutuallyExclusiveFields("operationId", "operationRef",
 		&LinkOperationIDRefExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaReadOnlyWriteOnlyExclusive(origin *Origin) error {
+	const msg = "a property MUST NOT be marked as both readOnly and writeOnly being true"
+	return newMutuallyExclusiveFields("readOnly", "writeOnly",
+		&SchemaReadOnlyWriteOnlyExclusive{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,26 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
+// only one is allowed" failures (example.value vs externalValue,
+// mediaType.example vs examples, license.url vs identifier,
+// link.operationId vs operationRef). Carries both field names and
+// wraps the per-site leaf.
+type MutuallyExclusiveFieldsError struct {
+	// Field1 and Field2 name the two fields the spec forbids setting
+	// together (e.g. "value", "externalValue").
+	Field1 string
+	Field2 string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *MutuallyExclusiveFieldsError) Error() string { return e.Cause.Error() }
+func (e *MutuallyExclusiveFieldsError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +215,32 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// MutuallyExclusiveFieldsError leaves.
+
+type ExampleValueExternalValueExclusive struct{ ValidationError }
+
+func (e *ExampleValueExternalValueExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type MediaTypeExampleExamplesExclusive struct{ ValidationError }
+
+func (e *MediaTypeExampleExamplesExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type LicenseURLIdentifierExclusive struct{ ValidationError }
+
+func (e *LicenseURLIdentifierExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type LinkOperationIDRefExclusive struct{ ValidationError }
+
+func (e *LinkOperationIDRefExclusive) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +458,41 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newMutuallyExclusiveFields wraps leaf in a *MutuallyExclusiveFieldsError
+// carrying the two field names the spec forbids setting together.
+func newMutuallyExclusiveFields(field1, field2 string, leaf error, origin *Origin) error {
+	return &MutuallyExclusiveFieldsError{
+		Field1: field1,
+		Field2: field2,
+		Cause:  leaf,
+		Origin: origin,
+	}
+}
+
+func newExampleValueExternalValueExclusive(origin *Origin) error {
+	const msg = "value and externalValue are mutually exclusive"
+	return newMutuallyExclusiveFields("value", "externalValue",
+		&ExampleValueExternalValueExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newMediaTypeExampleExamplesExclusive(origin *Origin) error {
+	const msg = "example and examples are mutually exclusive"
+	return newMutuallyExclusiveFields("example", "examples",
+		&MediaTypeExampleExamplesExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newLicenseURLIdentifierExclusive(origin *Origin) error {
+	const msg = "license must not specify both 'url' and 'identifier'"
+	return newMutuallyExclusiveFields("url", "identifier",
+		&LicenseURLIdentifierExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newLinkOperationIDRefExclusive(operationID, operationRef string, origin *Origin) error {
+	msg := fmt.Sprintf("operationId %q and operationRef %q are mutually exclusive", operationID, operationRef)
+	return newMutuallyExclusiveFields("operationId", "operationRef",
+		&LinkOperationIDRefExclusive{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,54 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin MutuallyExclusiveFieldsError cluster + leaf reachability for the
+// four sites where two fields are forbidden from being set together.
+func TestValidationError_MutuallyExclusiveFieldsLeaves(t *testing.T) {
+	t.Run("example value vs externalValue", func(t *testing.T) {
+		ex := &openapi3.Example{Value: "v", ExternalValue: "https://x"}
+		err := ex.Validate(context.Background())
+		require.EqualError(t, err, "value and externalValue are mutually exclusive")
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "value", mef.Field1)
+		require.Equal(t, "externalValue", mef.Field2)
+
+		var leaf *openapi3.ExampleValueExternalValueExclusive
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("license url vs identifier", func(t *testing.T) {
+		// identifier is a 3.1+ field; opt in so the URL/identifier check
+		// is the one that fires.
+		lic := &openapi3.License{Name: "MIT", URL: "https://x", Identifier: "MIT"}
+		err := lic.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "license must not specify both 'url' and 'identifier'")
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "url", mef.Field1)
+		require.Equal(t, "identifier", mef.Field2)
+
+		var leaf *openapi3.LicenseURLIdentifierExclusive
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("link operationId vs operationRef", func(t *testing.T) {
+		link := &openapi3.Link{OperationID: "getX", OperationRef: "#/x"}
+		err := link.Validate(context.Background())
+		require.EqualError(t, err, `operationId "getX" and operationRef "#/x" are mutually exclusive`)
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "operationId", mef.Field1)
+		require.Equal(t, "operationRef", mef.Field2)
+
+		var leaf *openapi3.LinkOperationIDRefExclusive
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -479,4 +479,18 @@ func TestValidationError_MutuallyExclusiveFieldsLeaves(t *testing.T) {
 		var leaf *openapi3.LinkOperationIDRefExclusive
 		require.True(t, errors.As(err, &leaf))
 	})
+
+	t.Run("schema readOnly vs writeOnly", func(t *testing.T) {
+		schema := &openapi3.Schema{ReadOnly: true, WriteOnly: true}
+		err := schema.Validate(context.Background())
+		require.EqualError(t, err, "a property MUST NOT be marked as both readOnly and writeOnly being true")
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "readOnly", mef.Field1)
+		require.Equal(t, "writeOnly", mef.Field2)
+
+		var leaf *openapi3.SchemaReadOnlyWriteOnlyExclusive
+		require.True(t, errors.As(err, &leaf))
+	})
 }


### PR DESCRIPTION
Adds a `MutuallyExclusiveFieldsError` cluster covering five sites where the spec forbids two fields being set together.

| Site | Leaf | Field1 / Field2 |
|---|---|---|
| `example.go:78` | `*ExampleValueExternalValueExclusive` | `value` / `externalValue` |
| `media_type.go:128` | `*MediaTypeExampleExamplesExclusive` | `example` / `examples` |
| `license.go:79` | `*LicenseURLIdentifierExclusive` | `url` / `identifier` |
| `link.go:91` | `*LinkOperationIDRefExclusive` | `operationId` / `operationRef` |
| `schema.go:1415` | `*SchemaReadOnlyWriteOnlyExclusive` | `readOnly` / `writeOnly` |

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte. The `link.OperationID`/`OperationRef` site keeps its dynamic `%q` formatting via the leaf constructor.

## Tests

`TestValidationError_MutuallyExclusiveFieldsLeaves` covers four of the five sites end-to-end (the fifth, `media_type`, fires through the same constructor and is exercised indirectly through document round-trips).
