### PR TITLE
feat(openapi3): ForbiddenFieldError cluster for set-but-not-allowed fields

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -727,6 +727,24 @@ func (e *FieldVersionMismatchError) Error() string
 
 func (e *FieldVersionMismatchError) Unwrap() error
 
+type ForbiddenFieldError struct {
+	// Field is the name of the forbidden field (e.g. "name", "in",
+	// "authorizationUrl", "tokenUrl").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    ForbiddenFieldError clusters "field X must not be set in this context"
+    failures (header.name and header.in inside a Headers map, OAuth flow URLs
+    that don't apply to the chosen flow type).
+
+func (e *ForbiddenFieldError) Error() string
+
+func (e *ForbiddenFieldError) Unwrap() error
+
 type FormatValidator[T any] interface {
 	Validate(value T) error
 }
@@ -768,6 +786,14 @@ func (header *Header) UnmarshalJSON(data []byte) error
 
 func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Header does not comply with the OpenAPI spec.
+
+type HeaderInForbidden struct{ ValidationError }
+
+func (e *HeaderInForbidden) As(target any) bool
+
+type HeaderNameForbidden struct{ ValidationError }
+
+func (e *HeaderNameForbidden) As(target any) bool
 
 type HeaderRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1164,6 +1190,14 @@ func (flow *OAuthFlow) UnmarshalJSON(data []byte) error
 func (flow *OAuthFlow) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if OAuthFlows does not comply with the OpenAPI
     spec.
+
+type OAuthFlowAuthorizationURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowAuthorizationURLForbidden) As(target any) bool
+
+type OAuthFlowTokenURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowTokenURLForbidden) As(target any) bool
 
 type OAuthFlows struct {
 	Extensions map[string]any `json:"-" yaml:"-"`

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -54,10 +54,10 @@ func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) er
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if header.Name != "" {
-		return errors.New("header 'name' MUST NOT be specified, it is given in the corresponding headers map")
+		return newHeaderNameForbidden(header.Origin)
 	}
 	if header.In != "" {
-		return errors.New("header 'in' MUST NOT be specified, it is implicitly in header")
+		return newHeaderInForbidden(header.Origin)
 	}
 
 	// Validate a parameter's serialization method.

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -404,7 +404,7 @@ func (flow *OAuthFlow) validate(ctx context.Context, typ oAuthFlowType, opts ...
 		case flow.AuthorizationURL == "" && in:
 			return errors.New("field 'authorizationUrl' is empty or missing")
 		case flow.AuthorizationURL != "" && !in:
-			return errors.New("field 'authorizationUrl' should not be set")
+			return newOAuthFlowAuthorizationURLForbidden(flow.Origin)
 		case flow.AuthorizationURL != "":
 			if _, err := url.Parse(flow.AuthorizationURL); err != nil {
 				return fmt.Errorf("field 'authorizationUrl' is invalid: %w", err)
@@ -417,7 +417,7 @@ func (flow *OAuthFlow) validate(ctx context.Context, typ oAuthFlowType, opts ...
 		case flow.TokenURL == "" && in:
 			return errors.New("field 'tokenUrl' is empty or missing")
 		case flow.TokenURL != "" && !in:
-			return errors.New("field 'tokenUrl' should not be set")
+			return newOAuthFlowTokenURLForbidden(flow.Origin)
 		case flow.TokenURL != "":
 			if _, err := url.Parse(flow.TokenURL); err != nil {
 				return fmt.Errorf("field 'tokenUrl' is invalid: %w", err)

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,23 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// ForbiddenFieldError clusters "field X must not be set in this
+// context" failures (header.name and header.in inside a Headers map,
+// OAuth flow URLs that don't apply to the chosen flow type).
+type ForbiddenFieldError struct {
+	// Field is the name of the forbidden field (e.g. "name", "in",
+	// "authorizationUrl", "tokenUrl").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *ForbiddenFieldError) Error() string { return e.Cause.Error() }
+func (e *ForbiddenFieldError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +212,32 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// ForbiddenFieldError leaves.
+
+type HeaderNameForbidden struct{ ValidationError }
+
+func (e *HeaderNameForbidden) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type HeaderInForbidden struct{ ValidationError }
+
+func (e *HeaderInForbidden) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowAuthorizationURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowAuthorizationURLForbidden) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowTokenURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowTokenURLForbidden) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +455,36 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newForbiddenField wraps leaf in a *ForbiddenFieldError carrying the
+// name of the field that the spec forbids in the current context.
+func newForbiddenField(field string, leaf error, origin *Origin) error {
+	return &ForbiddenFieldError{Field: field, Cause: leaf, Origin: origin}
+}
+
+func newHeaderNameForbidden(origin *Origin) error {
+	const msg = "header 'name' MUST NOT be specified, it is given in the corresponding headers map"
+	return newForbiddenField("name",
+		&HeaderNameForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newHeaderInForbidden(origin *Origin) error {
+	const msg = "header 'in' MUST NOT be specified, it is implicitly in header"
+	return newForbiddenField("in",
+		&HeaderInForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newOAuthFlowAuthorizationURLForbidden(origin *Origin) error {
+	const msg = "field 'authorizationUrl' should not be set"
+	return newForbiddenField("authorizationUrl",
+		&OAuthFlowAuthorizationURLForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newOAuthFlowTokenURLForbidden(origin *Origin) error {
+	const msg = "field 'tokenUrl' should not be set"
+	return newForbiddenField("tokenUrl",
+		&OAuthFlowTokenURLForbidden{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,38 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin ForbiddenFieldError cluster + leaf reachability for the four
+// sites where a field is set but the spec forbids it in that context.
+func TestValidationError_ForbiddenFieldLeaves(t *testing.T) {
+	t.Run("header.name forbidden", func(t *testing.T) {
+		h := &openapi3.Header{Parameter: openapi3.Parameter{Name: "X-Trace"}}
+		err := h.Validate(context.Background())
+		require.EqualError(t, err,
+			"header 'name' MUST NOT be specified, it is given in the corresponding headers map")
+
+		var ffe *openapi3.ForbiddenFieldError
+		require.True(t, errors.As(err, &ffe))
+		require.Equal(t, "name", ffe.Field)
+
+		var leaf *openapi3.HeaderNameForbidden
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("header.in forbidden", func(t *testing.T) {
+		h := &openapi3.Header{Parameter: openapi3.Parameter{In: "header"}}
+		err := h.Validate(context.Background())
+		require.EqualError(t, err,
+			"header 'in' MUST NOT be specified, it is implicitly in header")
+
+		var ffe *openapi3.ForbiddenFieldError
+		require.True(t, errors.As(err, &ffe))
+		require.Equal(t, "in", ffe.Field)
+
+		var leaf *openapi3.HeaderInForbidden
+		require.True(t, errors.As(err, &leaf))
+	})
+}


### PR DESCRIPTION
Adds a `ForbiddenFieldError` cluster covering four sites where the spec forbids a field in a specific context.

| Site | Leaf | Field |
|---|---|---|
| `header.go:57` | `*HeaderNameForbidden` | `name` |
| `header.go:60` | `*HeaderInForbidden` | `in` |
| `security_scheme.go:407` | `*OAuthFlowAuthorizationURLForbidden` | `authorizationUrl` |
| `security_scheme.go:420` | `*OAuthFlowTokenURLForbidden` | `tokenUrl` |

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte.

## Tests

`TestValidationError_ForbiddenFieldLeaves` covers the two header sites end-to-end. The two OAuth flow sites fire through the same constructor pattern and are exercised indirectly through document round-trip validation.
