### PR TITLE
feat(openapi3): more RequiredFieldError leaves (parameter.name, responses, apiKey name)

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -252,6 +252,10 @@ func WithValidationOptions(ctx context.Context, opts ...ValidationOption) contex
 
 TYPES
 
+type APIKeySecuritySchemeNameRequired struct{ ValidationError }
+
+func (e *APIKeySecuritySchemeNameRequired) As(target any) bool
+
 type AdditionalProperties = BoolSchema
     AdditionalProperties is a type alias for BoolSchema, kept for backward
     compatibility.
@@ -1326,6 +1330,10 @@ func (parameter *Parameter) WithRequired(value bool) *Parameter
 
 func (parameter *Parameter) WithSchema(value *Schema) *Parameter
 
+type ParameterNameRequired struct{ ValidationError }
+
+func (e *ParameterNameRequired) As(target any) bool
+
 type ParameterRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
 	// are allowed by the openapi spec.
@@ -1853,6 +1861,10 @@ func (responses *Responses) Validate(ctx context.Context, opts ...ValidationOpti
 
 func (responses *Responses) Value(key string) *ResponseRef
     Value returns the responses for key or nil
+
+type ResponsesNonEmptyRequired struct{ ValidationError }
+
+func (e *ResponsesNonEmptyRequired) As(target any) bool
 
 type Schema struct {
 	Extensions map[string]any `json:"-" yaml:"-"`

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -311,7 +311,7 @@ func (parameter *Parameter) Validate(ctx context.Context, opts ...ValidationOpti
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if parameter.Name == "" {
-		return errors.New("parameter name can't be blank")
+		return newParameterNameRequired(parameter.Origin)
 	}
 	in := parameter.In
 	switch in {

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -78,7 +78,7 @@ func (responses *Responses) Validate(ctx context.Context, opts ...ValidationOpti
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if responses.Len() == 0 {
-		return errors.New("the responses object MUST contain at least one response code")
+		return newResponsesNonEmptyRequired(responses.Origin)
 	}
 
 	for _, key := range responses.Keys() {

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -188,7 +188,7 @@ func (ss *SecurityScheme) Validate(ctx context.Context, opts ...ValidationOption
 			return fmt.Errorf("security scheme of type 'apiKey' should have 'in'. It can be 'query', 'header' or 'cookie', not %q", ss.In)
 		}
 		if ss.Name == "" {
-			return errors.New("security scheme of type 'apiKey' should have 'name'")
+			return newAPIKeySecuritySchemeNameRequired(ss.Origin)
 		}
 	} else if len(ss.In) > 0 {
 		return fmt.Errorf("security scheme of type %q can't have 'in'", ss.Type)

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -198,6 +198,24 @@ func (e *ServerURLRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type ParameterNameRequired struct{ ValidationError }
+
+func (e *ParameterNameRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type ResponsesNonEmptyRequired struct{ ValidationError }
+
+func (e *ResponsesNonEmptyRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type APIKeySecuritySchemeNameRequired struct{ ValidationError }
+
+func (e *APIKeySecuritySchemeNameRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // FieldVersionMismatchError leaves — non-schema fields.
 
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
@@ -412,6 +430,23 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+func newParameterNameRequired(origin *Origin) error {
+	return newRequiredField("parameter.name",
+		&ParameterNameRequired{ValidationError{Message: "parameter name can't be blank"}}, origin)
+}
+
+func newResponsesNonEmptyRequired(origin *Origin) error {
+	const msg = "the responses object MUST contain at least one response code"
+	return newRequiredField("responses",
+		&ResponsesNonEmptyRequired{ValidationError{Message: msg}}, origin)
+}
+
+func newAPIKeySecuritySchemeNameRequired(origin *Origin) error {
+	const msg = "security scheme of type 'apiKey' should have 'name'"
+	return newRequiredField("securityScheme.name",
+		&APIKeySecuritySchemeNameRequired{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -176,6 +176,22 @@ func TestValidationError_AllRequiredFieldLeaves(t *testing.T) {
 			field:   "server.url",
 			message: "value of url must be a non-empty string",
 		},
+		{
+			name: "responses non-empty required",
+			doc: &openapi3.T{
+				OpenAPI: "3.0.3",
+				Info:    &openapi3.Info{Title: "x", Version: "1.0.0"},
+				Paths: openapi3.NewPaths(openapi3.WithPath("/p", &openapi3.PathItem{
+					Get: &openapi3.Operation{Responses: openapi3.NewResponses()},
+				})),
+			},
+			leafCheck: func(t *testing.T, err error) {
+				var l *openapi3.ResponsesNonEmptyRequired
+				require.True(t, errors.As(err, &l))
+			},
+			field:   "responses",
+			message: "the responses object MUST contain at least one response code",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -428,4 +444,34 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
+}
+
+// Pin parameter.name and apiKey securityScheme.name leaves directly:
+// these check Validate on a single component (without wiring a full
+// document around it).
+func TestValidationError_ParameterAndAPIKeyNameLeaves(t *testing.T) {
+	t.Run("parameter name required", func(t *testing.T) {
+		err := (&openapi3.Parameter{}).Validate(context.Background())
+		require.EqualError(t, err, "parameter name can't be blank")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "parameter.name", rfe.Field)
+
+		var leaf *openapi3.ParameterNameRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("apiKey securityScheme name required", func(t *testing.T) {
+		ss := &openapi3.SecurityScheme{Type: "apiKey", In: "header"}
+		err := ss.Validate(context.Background())
+		require.EqualError(t, err, "security scheme of type 'apiKey' should have 'name'")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "securityScheme.name", rfe.Field)
+
+		var leaf *openapi3.APIKeySecuritySchemeNameRequired
+		require.True(t, errors.As(err, &leaf))
+	})
 }


### PR DESCRIPTION
Three new `RequiredFieldError` leaves covering "this field/object must not be empty" sites that don't share the existing helper.

| Site | Leaf | Field |
|---|---|---|
| `parameter.go:314` | `*ParameterNameRequired` | `parameter.name` |
| `response.go:81` | `*ResponsesNonEmptyRequired` | `responses` |
| `security_scheme.go:191` | `*APIKeySecuritySchemeNameRequired` | `securityScheme.name` |

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte.

## Tests

- `parameter.name` and `responses non-empty` exercised through the existing `TestValidationError_AllRequiredFieldLeaves` table.
- `apiKey securityScheme.name` covered by a focused subtest because the failure is gated on `Type=apiKey` + valid `In`, not document-shape.
