### PR TITLE
feat(openapi3): ServerURLTemplateError cluster for server URL template failures

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2453,9 +2453,34 @@ func (server *Server) UnmarshalJSON(data []byte) error
 func (server *Server) Validate(ctx context.Context, opts ...ValidationOption) (err error)
     Validate returns an error if Server does not comply with the OpenAPI spec.
 
+type ServerURLMismatchedBraces struct{ ValidationError }
+
+func (e *ServerURLMismatchedBraces) As(target any) bool
+
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool
+
+type ServerURLTemplateError struct {
+	// URL is the server URL whose template failed validation.
+	URL string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    ServerURLTemplateError clusters server URL template failures — mismatched
+    braces and undeclared variables (template variables not matched by
+    Server.Variables, or vice versa).
+
+func (e *ServerURLTemplateError) Error() string
+
+func (e *ServerURLTemplateError) Unwrap() error
+
+type ServerURLUndeclaredVariables struct{ ValidationError }
+
+func (e *ServerURLUndeclaredVariables) As(target any) bool
 
 type ServerVariable struct {
 	Extensions map[string]any `json:"-" yaml:"-"`

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -205,17 +205,17 @@ func (server *Server) Validate(ctx context.Context, opts ...ValidationOption) (e
 
 	opening, closing := strings.Count(server.URL, "{"), strings.Count(server.URL, "}")
 	if opening != closing {
-		return errors.New("server URL has mismatched { and }")
+		return newServerURLMismatchedBraces(server.URL, server.Origin)
 	}
 
 	if opening != len(server.Variables) {
-		return errors.New("server has undeclared variables")
+		return newServerURLUndeclaredVariables(server.URL, server.Origin)
 	}
 
 	for _, name := range componentNames(server.Variables) {
 		v := server.Variables[name]
 		if !strings.Contains(server.URL, "{"+name+"}") {
-			return errors.New("server has undeclared variables")
+			return newServerURLUndeclaredVariables(server.URL, server.Origin)
 		}
 		if err = v.Validate(ctx); err != nil {
 			return

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,22 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// ServerURLTemplateError clusters server URL template failures —
+// mismatched braces and undeclared variables (template variables not
+// matched by Server.Variables, or vice versa).
+type ServerURLTemplateError struct {
+	// URL is the server URL whose template failed validation.
+	URL string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *ServerURLTemplateError) Error() string { return e.Cause.Error() }
+func (e *ServerURLTemplateError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +211,20 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// ServerURLTemplateError leaves.
+
+type ServerURLMismatchedBraces struct{ ValidationError }
+
+func (e *ServerURLMismatchedBraces) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type ServerURLUndeclaredVariables struct{ ValidationError }
+
+func (e *ServerURLUndeclaredVariables) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +442,24 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newServerURLTemplateError wraps leaf in a *ServerURLTemplateError
+// carrying the offending Server.URL.
+func newServerURLTemplateError(serverURL string, leaf error, origin *Origin) error {
+	return &ServerURLTemplateError{URL: serverURL, Cause: leaf, Origin: origin}
+}
+
+func newServerURLMismatchedBraces(serverURL string, origin *Origin) error {
+	const msg = "server URL has mismatched { and }"
+	return newServerURLTemplateError(serverURL,
+		&ServerURLMismatchedBraces{ValidationError{Message: msg}}, origin)
+}
+
+func newServerURLUndeclaredVariables(serverURL string, origin *Origin) error {
+	const msg = "server has undeclared variables"
+	return newServerURLTemplateError(serverURL,
+		&ServerURLUndeclaredVariables{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,48 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin ServerURLTemplateError cluster + leaf reachability for the three
+// server URL template sites (mismatched braces, undeclared variables
+// in two flavours).
+func TestValidationError_ServerURLTemplateLeaves(t *testing.T) {
+	t.Run("mismatched braces", func(t *testing.T) {
+		s := &openapi3.Server{URL: "https://example.com/{x"}
+		err := s.Validate(context.Background())
+		require.EqualError(t, err, "server URL has mismatched { and }")
+
+		var sue *openapi3.ServerURLTemplateError
+		require.True(t, errors.As(err, &sue))
+		require.Equal(t, "https://example.com/{x", sue.URL)
+
+		var leaf *openapi3.ServerURLMismatchedBraces
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("undeclared variables (count mismatch)", func(t *testing.T) {
+		s := &openapi3.Server{URL: "https://example.com/{x}"} // no Variables declared
+		err := s.Validate(context.Background())
+		require.EqualError(t, err, "server has undeclared variables")
+
+		var sue *openapi3.ServerURLTemplateError
+		require.True(t, errors.As(err, &sue))
+
+		var leaf *openapi3.ServerURLUndeclaredVariables
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("undeclared variables (name mismatch)", func(t *testing.T) {
+		s := &openapi3.Server{
+			URL:       "https://example.com/{x}",
+			Variables: map[string]*openapi3.ServerVariable{"y": {Default: "z"}},
+		}
+		err := s.Validate(context.Background())
+		require.EqualError(t, err, "server has undeclared variables")
+
+		var leaf *openapi3.ServerURLUndeclaredVariables
+		require.True(t, errors.As(err, &leaf))
+	})
+}


### PR DESCRIPTION
Adds a `ServerURLTemplateError` cluster covering the three server URL template failure sites in `Server.Validate`.

| Site | Leaf | Trigger |
|---|---|---|
| `server.go:208` | `*ServerURLMismatchedBraces` | `{` and `}` count differ |
| `server.go:212` | `*ServerURLUndeclaredVariables` | template-variable count ≠ `Server.Variables` count |
| `server.go:218` | `*ServerURLUndeclaredVariables` | declared variable name not in URL template |

The two undeclared-variables sites share a leaf because they share their `Error()` string and represent the same defect from a consumer's perspective.

The cluster carries `URL string` so callers don't have to parse the message to recover the offending template.

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte.

## Tests

`TestValidationError_ServerURLTemplateLeaves` covers all three sites end-to-end.
