### PR TITLE
feat(openapi3): EitherFieldRequiredError cluster + SchemaItemsRequired leaf

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -530,6 +530,23 @@ type DynamicRefFieldFor31Plus struct{ ValidationError }
 
 func (e *DynamicRefFieldFor31Plus) As(target any) bool
 
+type EitherFieldRequiredError struct {
+	// Fields is the set of field names, at least one of which must be
+	// set (e.g. ["value", "externalValue"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    EitherFieldRequiredError clusters "at least one of these fields must be set"
+    failures (example.value vs externalValue, link.operationId vs operationRef).
+
+func (e *EitherFieldRequiredError) Error() string
+
+func (e *EitherFieldRequiredError) Unwrap() error
+
 type ElseFieldFor31Plus struct{ ValidationError }
 
 func (e *ElseFieldFor31Plus) As(target any) bool
@@ -642,6 +659,10 @@ func (x *ExampleRef) UnmarshalJSON(data []byte) error
 func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if ExampleRef does not comply with the OpenAPI
     spec.
+
+type ExampleValueOrExternalValueRequired struct{ ValidationError }
+
+func (e *ExampleValueOrExternalValueRequired) As(target any) bool
 
 type Examples map[string]*ExampleRef // Examples represents components' named examples
 
@@ -936,6 +957,10 @@ func (link *Link) UnmarshalJSON(data []byte) error
 
 func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Link does not comply with the OpenAPI spec.
+
+type LinkOperationIDOrRefRequired struct{ ValidationError }
+
+func (e *LinkOperationIDOrRefRequired) As(target any) bool
 
 type LinkRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -2114,6 +2139,10 @@ func (err SchemaError) Unwrap() error
 type SchemaFieldFor31Plus struct{ ValidationError }
 
 func (e *SchemaFieldFor31Plus) As(target any) bool
+
+type SchemaItemsRequired struct{ ValidationError }
+
+func (e *SchemaItemsRequired) As(target any) bool
 
 type SchemaRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -78,7 +78,7 @@ func (example *Example) Validate(ctx context.Context, opts ...ValidationOption) 
 		return errors.New("value and externalValue are mutually exclusive")
 	}
 	if example.Value == nil && example.ExternalValue == "" {
-		return errors.New("no value or externalValue field")
+		return newExampleValueOrExternalValueRequired(example.Origin)
 	}
 
 	return validateExtensions(ctx, example.Extensions)

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 )
@@ -85,7 +84,7 @@ func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error 
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if link.OperationID == "" && link.OperationRef == "" {
-		return errors.New("missing operationId or operationRef on link")
+		return newLinkOperationIDOrRefRequired(link.Origin)
 	}
 	if link.OperationID != "" && link.OperationRef != "" {
 		return fmt.Errorf("operationId %q and operationRef %q are mutually exclusive", link.OperationID, link.OperationRef)

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1685,7 +1685,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 			}
 		case TypeArray:
 			if schema.Items == nil && !validationOpts.jsonSchema2020ValidationEnabled && len(schema.PrefixItems) == 0 {
-				return stack, errors.New("when schema type is 'array', schema 'items' must be non-null")
+				return stack, newSchemaItemsRequired(schema.Origin)
 			}
 		case TypeObject:
 		case TypeNull:

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,23 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// EitherFieldRequiredError clusters "at least one of these fields must
+// be set" failures (example.value vs externalValue, link.operationId
+// vs operationRef).
+type EitherFieldRequiredError struct {
+	// Fields is the set of field names, at least one of which must be
+	// set (e.g. ["value", "externalValue"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *EitherFieldRequiredError) Error() string { return e.Cause.Error() }
+func (e *EitherFieldRequiredError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +212,26 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type SchemaItemsRequired struct{ ValidationError }
+
+func (e *SchemaItemsRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// EitherFieldRequiredError leaves.
+
+type ExampleValueOrExternalValueRequired struct{ ValidationError }
+
+func (e *ExampleValueOrExternalValueRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type LinkOperationIDOrRefRequired struct{ ValidationError }
+
+func (e *LinkOperationIDOrRefRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +449,30 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+func newSchemaItemsRequired(origin *Origin) error {
+	const msg = "when schema type is 'array', schema 'items' must be non-null"
+	return newRequiredField("schema.items",
+		&SchemaItemsRequired{ValidationError{Message: msg}}, origin)
+}
+
+// newEitherFieldRequired wraps leaf in an *EitherFieldRequiredError
+// carrying the set of field names, at least one of which must be set.
+func newEitherFieldRequired(fields []string, leaf error, origin *Origin) error {
+	return &EitherFieldRequiredError{Fields: fields, Cause: leaf, Origin: origin}
+}
+
+func newExampleValueOrExternalValueRequired(origin *Origin) error {
+	const msg = "no value or externalValue field"
+	return newEitherFieldRequired([]string{"value", "externalValue"},
+		&ExampleValueOrExternalValueRequired{ValidationError{Message: msg}}, origin)
+}
+
+func newLinkOperationIDOrRefRequired(origin *Origin) error {
+	const msg = "missing operationId or operationRef on link"
+	return newEitherFieldRequired([]string{"operationId", "operationRef"},
+		&LinkOperationIDOrRefRequired{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,51 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin EitherFieldRequiredError cluster + leaf reachability for the
+// two "at least one of these fields must be set" sites.
+func TestValidationError_EitherFieldRequiredLeaves(t *testing.T) {
+	t.Run("example value or externalValue", func(t *testing.T) {
+		ex := &openapi3.Example{}
+		err := ex.Validate(context.Background())
+		require.EqualError(t, err, "no value or externalValue field")
+
+		var efr *openapi3.EitherFieldRequiredError
+		require.True(t, errors.As(err, &efr))
+		require.Equal(t, []string{"value", "externalValue"}, efr.Fields)
+
+		var leaf *openapi3.ExampleValueOrExternalValueRequired
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("link operationId or operationRef", func(t *testing.T) {
+		link := &openapi3.Link{}
+		err := link.Validate(context.Background())
+		require.EqualError(t, err, "missing operationId or operationRef on link")
+
+		var efr *openapi3.EitherFieldRequiredError
+		require.True(t, errors.As(err, &efr))
+		require.Equal(t, []string{"operationId", "operationRef"}, efr.Fields)
+
+		var leaf *openapi3.LinkOperationIDOrRefRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+}
+
+// Pin SchemaItemsRequired leaf reachability via the existing
+// RequiredFieldError cluster.
+func TestValidationError_SchemaItemsRequiredLeaf(t *testing.T) {
+	schema := &openapi3.Schema{Type: &openapi3.Types{"array"}}
+	err := schema.Validate(context.Background())
+	require.EqualError(t, err, "when schema type is 'array', schema 'items' must be non-null")
+
+	var rfe *openapi3.RequiredFieldError
+	require.True(t, errors.As(err, &rfe))
+	require.Equal(t, "schema.items", rfe.Field)
+
+	var leaf *openapi3.SchemaItemsRequired
+	require.True(t, errors.As(err, &leaf))
+}


### PR DESCRIPTION
Adds an `EitherFieldRequiredError` cluster for "at least one of these fields must be set" failures, plus one new `RequiredFieldError` leaf for `schema.items` (required when `type=array`).

## EitherFieldRequiredError (new cluster)

| Site | Leaf | Required fields |
|---|---|---|
| `example.go:81` | `*ExampleValueOrExternalValueRequired` | `value`, `externalValue` |
| `link.go:88` | `*LinkOperationIDOrRefRequired` | `operationId`, `operationRef` |

Cluster carries `Fields []string` so callers don't have to parse the message to learn which fields were eligible.

## RequiredFieldError leaf (existing cluster)

| Site | Leaf | Field |
|---|---|---|
| `schema.go:1688` | `*SchemaItemsRequired` | `schema.items` |

Fires only when `type=array`, no `prefixItems`, and Draft 2020-12 keywords disabled — i.e. plain OpenAPI 3.0 array schemas missing `items`.

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte.

## Tests

`TestValidationError_EitherFieldRequiredLeaves` covers both new-cluster sites; `TestValidationError_SchemaItemsRequiredLeaf` covers the array-items site.
