### PR TITLE
feat(openapi3): RequiredFieldError leaves for doc-root info/paths/jsonSchemaDialect

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -856,6 +856,10 @@ func (info *Info) UnmarshalJSON(data []byte) error
 func (info *Info) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Info does not comply with the OpenAPI spec.
 
+type InfoRequired struct{ ValidationError }
+
+func (e *InfoRequired) As(target any) bool
+
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
 
 func (e *InfoSummaryFieldFor31Plus) As(target any) bool
@@ -870,6 +874,10 @@ func (e *InfoVersionRequired) As(target any) bool
 
 type IntegerFormatValidator = FormatValidator[int64]
     IntegerFormatValidator is a type alias for FormatValidator[int64]
+
+type JSONSchemaDialectAbsoluteURIRequired struct{ ValidationError }
+
+func (e *JSONSchemaDialectAbsoluteURIRequired) As(target any) bool
 
 type JSONSchemaDialectFieldFor31Plus struct{ ValidationError }
 
@@ -1521,6 +1529,10 @@ func (paths *Paths) Validate(ctx context.Context, opts ...ValidationOption) erro
 
 func (paths *Paths) Value(key string) *PathItem
     Value returns the paths for key or nil
+
+type PathsRequired struct{ ValidationError }
+
+func (e *PathsRequired) As(target any) bool
 
 type PatternPropertiesFieldFor31Plus struct{ ValidationError }
 

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/url"
@@ -294,7 +293,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 	} else {
-		return wrap(errors.New("must be an object"))
+		return wrap(newInfoRequired())
 	}
 
 	wrap = func(e error) error { return fmt.Errorf("invalid paths: %w", e) }
@@ -303,7 +302,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 	} else if doc.IsOpenAPI30() {
-		return wrap(errors.New("must be an object"))
+		return wrap(newPathsRequired())
 	}
 
 	wrap = func(e error) error { return fmt.Errorf("invalid security: %w", e) }
@@ -352,7 +351,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 		if u.Scheme == "" {
-			return wrap(errors.New("must be an absolute URI with a scheme"))
+			return wrap(newJSONSchemaDialectAbsoluteURIRequired())
 		}
 	}
 

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -198,6 +198,24 @@ func (e *ServerURLRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type InfoRequired struct{ ValidationError }
+
+func (e *InfoRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type PathsRequired struct{ ValidationError }
+
+func (e *PathsRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type JSONSchemaDialectAbsoluteURIRequired struct{ ValidationError }
+
+func (e *JSONSchemaDialectAbsoluteURIRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // FieldVersionMismatchError leaves — non-schema fields.
 
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
@@ -412,6 +430,23 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newInfoRequired and newPathsRequired don't take Origin: both fields
+// live on the document root *T, which the loader doesn't track.
+func newInfoRequired() error {
+	return newRequiredField("info",
+		&InfoRequired{ValidationError{Message: "must be an object"}}, nil)
+}
+
+func newPathsRequired() error {
+	return newRequiredField("paths",
+		&PathsRequired{ValidationError{Message: "must be an object"}}, nil)
+}
+
+func newJSONSchemaDialectAbsoluteURIRequired() error {
+	return newRequiredField("jsonSchemaDialect",
+		&JSONSchemaDialectAbsoluteURIRequired{ValidationError{Message: "must be an absolute URI with a scheme"}}, nil)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,56 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin doc-root RequiredFieldError leaves: info, paths,
+// jsonSchemaDialect-must-be-absolute-URI.
+func TestValidationError_DocRootRequiredLeaves(t *testing.T) {
+	t.Run("info required", func(t *testing.T) {
+		// doc with no Info — fails with the wrap "invalid info: must be an object".
+		doc := &openapi3.T{OpenAPI: "3.0.3", Paths: openapi3.NewPaths()}
+		err := doc.Validate(context.Background())
+		require.EqualError(t, err, "invalid info: must be an object")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "info", rfe.Field)
+
+		var leaf *openapi3.InfoRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("paths required (3.0)", func(t *testing.T) {
+		// 3.0 doc with no Paths — fails with "invalid paths: must be an object".
+		doc := &openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "x", Version: "1.0.0"},
+		}
+		err := doc.Validate(context.Background())
+		require.EqualError(t, err, "invalid paths: must be an object")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "paths", rfe.Field)
+
+		var leaf *openapi3.PathsRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("jsonSchemaDialect must be absolute URI", func(t *testing.T) {
+		doc := &openapi3.T{
+			OpenAPI:           "3.1.0",
+			Info:              &openapi3.Info{Title: "x", Version: "1.0.0"},
+			Paths:             openapi3.NewPaths(),
+			JSONSchemaDialect: "no-scheme/relative",
+		}
+		err := doc.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "invalid jsonSchemaDialect: must be an absolute URI with a scheme")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "jsonSchemaDialect", rfe.Field)
+
+		var leaf *openapi3.JSONSchemaDialectAbsoluteURIRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+}


### PR DESCRIPTION
Three new `RequiredFieldError` leaves for doc-root validation in `T.Validate`.

| Site | Leaf | Field |
|---|---|---|
| `openapi3.go:297` | `*InfoRequired` | `info` |
| `openapi3.go:306` | `*PathsRequired` | `paths` |
| `openapi3.go:355` | `*JSONSchemaDialectAbsoluteURIRequired` | `jsonSchemaDialect` |

All three live on the document root `*T`, which the loader doesn't track an `Origin` for; the constructors pass `nil` for `Origin`, matching the pattern already used by `OpenAPIVersionRequired`, `WebhooksFieldFor31Plus`, and `JSONSchemaDialectFieldFor31Plus`.

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte (including the surrounding `invalid info: ...` / `invalid paths: ...` / `invalid jsonSchemaDialect: ...` wrap from `T.Validate`).

## Tests

`TestValidationError_DocRootRequiredLeaves` covers all three sites end-to-end.
