### PR TITLE
feat(openapi3): SchemaBothFormsExclusive cluster for union-typed schema fields

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2087,6 +2087,28 @@ func (schema *Schema) WithUniqueItems(unique bool) *Schema
 
 func (schema *Schema) WithoutAdditionalProperties() *Schema
 
+type SchemaAdditionalPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaAdditionalPropertiesBothForms) As(target any) bool
+
+type SchemaBothFormsExclusive struct {
+	// Field is the name of the union-typed schema property
+	// (e.g. "additionalProperties", "unevaluatedItems").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    SchemaBothFormsExclusive clusters "this union-typed schema field is
+    set to both its boolean and schema forms simultaneously" failures —
+    additionalProperties, unevaluatedItems, unevaluatedProperties.
+
+func (e *SchemaBothFormsExclusive) Error() string
+
+func (e *SchemaBothFormsExclusive) Unwrap() error
+
 type SchemaError struct {
 	// Value is the value that failed validation.
 	Value any
@@ -2164,6 +2186,14 @@ type SchemaRefs []*SchemaRef
 func (s SchemaRefs) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
+
+type SchemaUnevaluatedItemsBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedItemsBothForms) As(target any) bool
+
+type SchemaUnevaluatedPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedPropertiesBothForms) As(target any) bool
 
 type SchemaValidationOption func(*schemaValidationSettings)
     SchemaValidationOption describes options a user has when validating request

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1729,7 +1729,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	}
 
 	if schema.AdditionalProperties.Has != nil && schema.AdditionalProperties.Schema != nil {
-		return stack, errors.New("additionalProperties are set to both boolean and schema")
+		return stack, newSchemaAdditionalPropertiesBothForms(schema.Origin)
 	}
 	if ref := schema.AdditionalProperties.Schema; ref != nil {
 		if err := ref.validateExtras(ctx); err != nil {
@@ -1835,7 +1835,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if schema.UnevaluatedItems.Has != nil && schema.UnevaluatedItems.Schema != nil {
-		return stack, errors.New("unevaluatedItems is set to both boolean and schema")
+		return stack, newSchemaUnevaluatedItemsBothForms(schema.Origin)
 	}
 	if ref := schema.UnevaluatedItems.Schema; ref != nil {
 		if err := ref.validateExtras(ctx); err != nil {
@@ -1852,7 +1852,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if schema.UnevaluatedProperties.Has != nil && schema.UnevaluatedProperties.Schema != nil {
-		return stack, errors.New("unevaluatedProperties is set to both boolean and schema")
+		return stack, newSchemaUnevaluatedPropertiesBothForms(schema.Origin)
 	}
 	if ref := schema.UnevaluatedProperties.Schema; ref != nil {
 		if err := ref.validateExtras(ctx); err != nil {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,23 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// SchemaBothFormsExclusive clusters "this union-typed schema field is
+// set to both its boolean and schema forms simultaneously" failures —
+// additionalProperties, unevaluatedItems, unevaluatedProperties.
+type SchemaBothFormsExclusive struct {
+	// Field is the name of the union-typed schema property
+	// (e.g. "additionalProperties", "unevaluatedItems").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *SchemaBothFormsExclusive) Error() string { return e.Cause.Error() }
+func (e *SchemaBothFormsExclusive) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +212,26 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// SchemaBothFormsExclusive leaves.
+
+type SchemaAdditionalPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaAdditionalPropertiesBothForms) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type SchemaUnevaluatedItemsBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedItemsBothForms) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type SchemaUnevaluatedPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedPropertiesBothForms) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +449,30 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newSchemaBothForms wraps leaf in a *SchemaBothFormsExclusive carrying
+// the name of the union-typed schema property.
+func newSchemaBothForms(field string, leaf error, origin *Origin) error {
+	return &SchemaBothFormsExclusive{Field: field, Cause: leaf, Origin: origin}
+}
+
+func newSchemaAdditionalPropertiesBothForms(origin *Origin) error {
+	const msg = "additionalProperties are set to both boolean and schema"
+	return newSchemaBothForms("additionalProperties",
+		&SchemaAdditionalPropertiesBothForms{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaUnevaluatedItemsBothForms(origin *Origin) error {
+	const msg = "unevaluatedItems is set to both boolean and schema"
+	return newSchemaBothForms("unevaluatedItems",
+		&SchemaUnevaluatedItemsBothForms{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaUnevaluatedPropertiesBothForms(origin *Origin) error {
+	const msg = "unevaluatedProperties is set to both boolean and schema"
+	return newSchemaBothForms("unevaluatedProperties",
+		&SchemaUnevaluatedPropertiesBothForms{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,70 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin SchemaBothFormsExclusive cluster + leaf reachability for the
+// three union-typed schema fields set to both boolean and schema forms.
+func TestValidationError_SchemaBothFormsLeaves(t *testing.T) {
+	t.Run("additionalProperties both forms", func(t *testing.T) {
+		yes := true
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			AdditionalProperties: openapi3.AdditionalProperties{
+				Has:    &yes,
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		err := schema.Validate(context.Background())
+		require.EqualError(t, err, "additionalProperties are set to both boolean and schema")
+
+		var sbf *openapi3.SchemaBothFormsExclusive
+		require.True(t, errors.As(err, &sbf))
+		require.Equal(t, "additionalProperties", sbf.Field)
+
+		var leaf *openapi3.SchemaAdditionalPropertiesBothForms
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("unevaluatedItems both forms", func(t *testing.T) {
+		yes := true
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			UnevaluatedItems: openapi3.BoolSchema{
+				Has:    &yes,
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "unevaluatedItems is set to both boolean and schema")
+
+		var sbf *openapi3.SchemaBothFormsExclusive
+		require.True(t, errors.As(err, &sbf))
+		require.Equal(t, "unevaluatedItems", sbf.Field)
+
+		var leaf *openapi3.SchemaUnevaluatedItemsBothForms
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("unevaluatedProperties both forms", func(t *testing.T) {
+		yes := true
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			UnevaluatedProperties: openapi3.BoolSchema{
+				Has:    &yes,
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "unevaluatedProperties is set to both boolean and schema")
+
+		var sbf *openapi3.SchemaBothFormsExclusive
+		require.True(t, errors.As(err, &sbf))
+		require.Equal(t, "unevaluatedProperties", sbf.Field)
+
+		var leaf *openapi3.SchemaUnevaluatedPropertiesBothForms
+		require.True(t, errors.As(err, &leaf))
+	})
+}


### PR DESCRIPTION
Adds a `SchemaBothFormsExclusive` cluster covering the three schema fields stored as `BoolSchema` (a union of `Has *bool` and `Schema *SchemaRef`) where both forms are set simultaneously.

| Site | Leaf | Field |
|---|---|---|
| `schema.go:1732` | `*SchemaAdditionalPropertiesBothForms` | `additionalProperties` |
| `schema.go:1838` | `*SchemaUnevaluatedItemsBothForms` | `unevaluatedItems` |
| `schema.go:1855` | `*SchemaUnevaluatedPropertiesBothForms` | `unevaluatedProperties` |

This is a different shape from `MutuallyExclusiveFieldsError` (which is for two separate fields): here a single union-typed field has both forms populated. The cluster carries `Field string` so callers know which property fired without parsing the message.

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte.

## Tests

`TestValidationError_SchemaBothFormsLeaves` covers all three sites end-to-end.
