### PR TITLE
feat(openapi3): ExactlyOneFieldError + SingleEntryContentError clusters

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -576,6 +576,24 @@ type Encodings map[string]*Encoding
 func (encodings *Encodings) UnmarshalJSON(data []byte) (err error)
     UnmarshalJSON sets Encodings to a copy of data.
 
+type ExactlyOneFieldError struct {
+	// Fields is the set of fields, exactly one of which must be set
+	// (e.g. ["content", "schema"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    ExactlyOneFieldError clusters "exactly one of these fields must be set"
+    failures — e.g. a parameter or header where neither content nor schema is
+    set, or both are.
+
+func (e *ExactlyOneFieldError) Error() string
+
+func (e *ExactlyOneFieldError) Unwrap() error
+
 type Example struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -768,6 +786,14 @@ func (header *Header) UnmarshalJSON(data []byte) error
 
 func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Header does not comply with the OpenAPI spec.
+
+type HeaderContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *HeaderContentSchemaExactlyOne) As(target any) bool
+
+type HeaderContentSingleEntry struct{ ValidationError }
+
+func (e *HeaderContentSingleEntry) As(target any) bool
 
 type HeaderRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1325,6 +1351,14 @@ func (parameter *Parameter) WithDescription(value string) *Parameter
 func (parameter *Parameter) WithRequired(value bool) *Parameter
 
 func (parameter *Parameter) WithSchema(value *Schema) *Parameter
+
+type ParameterContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *ParameterContentSchemaExactlyOne) As(target any) bool
+
+type ParameterContentSingleEntry struct{ ValidationError }
+
+func (e *ParameterContentSingleEntry) As(target any) bool
 
 type ParameterRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -2497,6 +2531,23 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string)
 
 func (servers Servers) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Servers does not comply with the OpenAPI spec.
+
+type SingleEntryContentError struct {
+	// Subject is the kind of object whose Content map is too large
+	// ("parameter", "header").
+	Subject string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    SingleEntryContentError clusters "the content map must contain at most one
+    entry" failures (parameter.content, header.content).
+
+func (e *SingleEntryContentError) Error() string
+
+func (e *SingleEntryContentError) Unwrap() error
 
 type SliceUniqueItemsChecker func(items []any) bool
     SliceUniqueItemsChecker is an function used to check if an given slice have

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -73,8 +73,8 @@ func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) er
 	}
 
 	if (header.Schema == nil) == (len(header.Content) == 0) {
-		e := fmt.Errorf("parameter must contain exactly one of content and schema: %v", header)
-		return fmt.Errorf("header schema is invalid: %w", e)
+		return fmt.Errorf("header schema is invalid: %w",
+			newHeaderContentSchemaExactlyOne(header, header.Origin))
 	}
 	if schema := header.Schema; schema != nil {
 		if err := schema.Validate(ctx); err != nil {
@@ -83,9 +83,9 @@ func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) er
 	}
 
 	if content := header.Content; content != nil {
-		e := errors.New("parameter content must only contain one entry")
 		if len(content) > 1 {
-			return fmt.Errorf("header content is invalid: %w", e)
+			return fmt.Errorf("header content is invalid: %w",
+				newHeaderContentSingleEntry(header.Origin))
 		}
 
 		if err := content.Validate(ctx); err != nil {

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -363,14 +363,14 @@ func (parameter *Parameter) Validate(ctx context.Context, opts ...ValidationOpti
 	}
 
 	if (parameter.Schema == nil) == (len(parameter.Content) == 0) {
-		e := errors.New("parameter must contain exactly one of content and schema")
-		return fmt.Errorf("parameter %q schema is invalid: %w", parameter.Name, e)
+		return fmt.Errorf("parameter %q schema is invalid: %w", parameter.Name,
+			newParameterContentSchemaExactlyOne(parameter.Origin))
 	}
 
 	if content := parameter.Content; content != nil {
-		e := errors.New("parameter content must only contain one entry")
 		if len(content) > 1 {
-			return fmt.Errorf("parameter %q content is invalid: %w", parameter.Name, e)
+			return fmt.Errorf("parameter %q content is invalid: %w", parameter.Name,
+				newParameterContentSingleEntry(parameter.Origin))
 		}
 
 		if err := content.Validate(ctx); err != nil {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,39 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// ExactlyOneFieldError clusters "exactly one of these fields must be
+// set" failures — e.g. a parameter or header where neither content
+// nor schema is set, or both are.
+type ExactlyOneFieldError struct {
+	// Fields is the set of fields, exactly one of which must be set
+	// (e.g. ["content", "schema"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *ExactlyOneFieldError) Error() string { return e.Cause.Error() }
+func (e *ExactlyOneFieldError) Unwrap() error { return e.Cause }
+
+// SingleEntryContentError clusters "the content map must contain at
+// most one entry" failures (parameter.content, header.content).
+type SingleEntryContentError struct {
+	// Subject is the kind of object whose Content map is too large
+	// ("parameter", "header").
+	Subject string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *SingleEntryContentError) Error() string { return e.Cause.Error() }
+func (e *SingleEntryContentError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +228,34 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// ExactlyOneFieldError leaves.
+
+type ParameterContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *ParameterContentSchemaExactlyOne) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type HeaderContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *HeaderContentSchemaExactlyOne) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// SingleEntryContentError leaves.
+
+type ParameterContentSingleEntry struct{ ValidationError }
+
+func (e *ParameterContentSingleEntry) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type HeaderContentSingleEntry struct{ ValidationError }
+
+func (e *HeaderContentSingleEntry) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +473,46 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newExactlyOneField wraps leaf in an *ExactlyOneFieldError carrying
+// the set of fields, exactly one of which must be set.
+func newExactlyOneField(fields []string, leaf error, origin *Origin) error {
+	return &ExactlyOneFieldError{Fields: fields, Cause: leaf, Origin: origin}
+}
+
+func newParameterContentSchemaExactlyOne(origin *Origin) error {
+	const msg = "parameter must contain exactly one of content and schema"
+	return newExactlyOneField([]string{"content", "schema"},
+		&ParameterContentSchemaExactlyOne{ValidationError{Message: msg}}, origin)
+}
+
+// newHeaderContentSchemaExactlyOne formats the same way the existing
+// header.go site does, including the historical "%v" dump of the
+// Header struct, so the Error() string remains byte-identical.
+func newHeaderContentSchemaExactlyOne(header any, origin *Origin) error {
+	msg := fmt.Sprintf("parameter must contain exactly one of content and schema: %v", header)
+	return newExactlyOneField([]string{"content", "schema"},
+		&HeaderContentSchemaExactlyOne{ValidationError{Message: msg}}, origin)
+}
+
+// newSingleEntryContent wraps leaf in a *SingleEntryContentError
+// carrying the Subject ("parameter" or "header") whose Content map
+// has more than one entry.
+func newSingleEntryContent(subject string, leaf error, origin *Origin) error {
+	return &SingleEntryContentError{Subject: subject, Cause: leaf, Origin: origin}
+}
+
+func newParameterContentSingleEntry(origin *Origin) error {
+	const msg = "parameter content must only contain one entry"
+	return newSingleEntryContent("parameter",
+		&ParameterContentSingleEntry{ValidationError{Message: msg}}, origin)
+}
+
+func newHeaderContentSingleEntry(origin *Origin) error {
+	const msg = "parameter content must only contain one entry"
+	return newSingleEntryContent("header",
+		&HeaderContentSingleEntry{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -436,7 +436,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 	t.Run("parameter content/schema exactly one (neither set)", func(t *testing.T) {
 		p := &openapi3.Parameter{Name: "p", In: "query"}
 		err := p.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+		require.ErrorContains(t, err, "parameter must contain exactly one of content and schema")
 
 		var efe *openapi3.ExactlyOneFieldError
 		require.True(t, errors.As(err, &efe))
@@ -455,7 +455,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 			},
 		}
 		err := p.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+		require.ErrorContains(t, err, "parameter content must only contain one entry")
 
 		var sec *openapi3.SingleEntryContentError
 		require.True(t, errors.As(err, &sec))
@@ -468,7 +468,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 	t.Run("header content/schema exactly one (neither set)", func(t *testing.T) {
 		h := &openapi3.Header{}
 		err := h.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+		require.ErrorContains(t, err, "parameter must contain exactly one of content and schema")
 
 		var efe *openapi3.ExactlyOneFieldError
 		require.True(t, errors.As(err, &efe))
@@ -488,7 +488,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 			},
 		}
 		err := h.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+		require.ErrorContains(t, err, "parameter content must only contain one entry")
 
 		var sec *openapi3.SingleEntryContentError
 		require.True(t, errors.As(err, &sec))

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,72 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin ExactlyOneFieldError and SingleEntryContentError clusters for
+// the four parameter/header content+schema sites.
+func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
+	t.Run("parameter content/schema exactly one (neither set)", func(t *testing.T) {
+		p := &openapi3.Parameter{Name: "p", In: "query"}
+		err := p.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+
+		var efe *openapi3.ExactlyOneFieldError
+		require.True(t, errors.As(err, &efe))
+		require.Equal(t, []string{"content", "schema"}, efe.Fields)
+
+		var leaf *openapi3.ParameterContentSchemaExactlyOne
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("parameter content single entry", func(t *testing.T) {
+		p := &openapi3.Parameter{
+			Name: "p", In: "query",
+			Content: openapi3.Content{
+				"application/json": &openapi3.MediaType{},
+				"application/xml":  &openapi3.MediaType{},
+			},
+		}
+		err := p.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+
+		var sec *openapi3.SingleEntryContentError
+		require.True(t, errors.As(err, &sec))
+		require.Equal(t, "parameter", sec.Subject)
+
+		var leaf *openapi3.ParameterContentSingleEntry
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("header content/schema exactly one (neither set)", func(t *testing.T) {
+		h := &openapi3.Header{}
+		err := h.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+
+		var efe *openapi3.ExactlyOneFieldError
+		require.True(t, errors.As(err, &efe))
+		require.Equal(t, []string{"content", "schema"}, efe.Fields)
+
+		var leaf *openapi3.HeaderContentSchemaExactlyOne
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("header content single entry", func(t *testing.T) {
+		h := &openapi3.Header{
+			Parameter: openapi3.Parameter{
+				Content: openapi3.Content{
+					"application/json": &openapi3.MediaType{},
+					"application/xml":  &openapi3.MediaType{},
+				},
+			},
+		}
+		err := h.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+
+		var sec *openapi3.SingleEntryContentError
+		require.True(t, errors.As(err, &sec))
+		require.Equal(t, "header", sec.Subject)
+
+		var leaf *openapi3.HeaderContentSingleEntry
+		require.True(t, errors.As(err, &leaf))
+	})
+}


### PR DESCRIPTION
Two new clusters cover the four parameter/header content+schema sites.

## ExactlyOneFieldError

| Site | Leaf | Fields |
|---|---|---|
| `parameter.go:366` | `*ParameterContentSchemaExactlyOne` | `content`, `schema` |
| `header.go:75` | `*HeaderContentSchemaExactlyOne` | `content`, `schema` |

Cluster carries `Fields []string` so callers know which fields the constraint applies to.

## SingleEntryContentError

| Site | Leaf | Subject |
|---|---|---|
| `parameter.go:371` | `*ParameterContentSingleEntry` | `parameter` |
| `header.go:86` | `*HeaderContentSingleEntry` | `header` |

Cluster carries `Subject string` (`parameter` or `header`) so callers know whose Content map fired.

## Backward compat

Every converted site preserves its original `Error()` string byte-for-byte, including the historical `%v` dump of the Header struct in the header content/schema site (preserved verbatim by passing the Header to `newHeaderContentSchemaExactlyOne`).

## Tests

`TestValidationError_ParameterHeaderContentSchemaLeaves` covers all four sites end-to-end.
