### PR TITLE
feat(openapi3): WebhookNilError for nil-pathitem webhook

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2889,6 +2889,23 @@ type ValidationOptions struct {
 }
     ValidationOptions provides configuration for validating OpenAPI documents.
 
+type WebhookNil struct{ ValidationError }
+
+func (e *WebhookNil) As(target any) bool
+
+type WebhookNilError struct {
+	// Name is the webhook key whose value was nil.
+	Name string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+}
+    WebhookNilError clusters "the value at webhook key X is nil" failures from
+    T.Validate's webhook walk. Carries the offending key name.
+
+func (e *WebhookNilError) Error() string
+
+func (e *WebhookNilError) Unwrap() error
+
 type WebhooksFieldFor31Plus struct{ ValidationError }
 
 func (e *WebhooksFieldFor31Plus) As(target any) bool

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -338,7 +338,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 	for _, name := range componentNames(doc.Webhooks) {
 		pathItem := doc.Webhooks[name]
 		if pathItem == nil {
-			return wrap(fmt.Errorf("webhook %q is nil", name))
+			return wrap(newWebhookNil(name))
 		}
 		if err := pathItem.Validate(ctx); err != nil {
 			return wrap(fmt.Errorf("webhook %q: %w", name, err))

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,19 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// WebhookNilError clusters "the value at webhook key X is nil"
+// failures from T.Validate's webhook walk. Carries the offending
+// key name.
+type WebhookNilError struct {
+	// Name is the webhook key whose value was nil.
+	Name string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+}
+
+func (e *WebhookNilError) Error() string { return e.Cause.Error() }
+func (e *WebhookNilError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -195,6 +208,14 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// WebhookNilError leaf.
+
+type WebhookNil struct{ ValidationError }
+
+func (e *WebhookNil) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -412,6 +433,14 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+func newWebhookNil(name string) error {
+	msg := fmt.Sprintf("webhook %q is nil", name)
+	return &WebhookNilError{
+		Name:  name,
+		Cause: &WebhookNil{ValidationError{Message: msg}},
+	}
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -429,3 +429,26 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin WebhookNilError cluster + leaf reachability for the
+// nil-pathitem webhook check in T.Validate.
+func TestValidationError_WebhookNilLeaf(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI:  "3.1.0",
+		Info:     &openapi3.Info{Title: "x", Version: "1.0.0"},
+		Paths:    openapi3.NewPaths(),
+		Webhooks: map[string]*openapi3.PathItem{"onEvent": nil},
+	}
+	err := doc.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+	require.EqualError(t, err, `invalid webhooks: webhook "onEvent" is nil`)
+
+	var wne *openapi3.WebhookNilError
+	require.True(t, errors.As(err, &wne))
+	require.Equal(t, "onEvent", wne.Name)
+
+	var leaf *openapi3.WebhookNil
+	require.True(t, errors.As(err, &leaf))
+
+	var ve *openapi3.ValidationError
+	require.True(t, errors.As(err, &ve))
+}


### PR DESCRIPTION
Single-site cluster `WebhookNilError` for the nil-pathitem check in `T.Validate`'s webhook walk.

| Site | Leaf | Field |
|---|---|---|
| `openapi3.go:341` | `*WebhookNil` | webhook key (carried as `Name string` on the cluster) |

The cluster carries the offending key so callers don't have to parse `webhook %q is nil` to recover it.

## Backward compat

Error string preserved byte-for-byte (including the surrounding `invalid webhooks: ...` wrap).

## Tests

`TestValidationError_WebhookNilLeaf` covers the site end-to-end.
