### PR TITLE
feat(openapi3): typed validation error clusters (combined: #1171-#1179)

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -534,6 +534,23 @@ type DynamicRefFieldFor31Plus struct{ ValidationError }
 
 func (e *DynamicRefFieldFor31Plus) As(target any) bool
 
+type EitherFieldRequiredError struct {
+	// Fields is the set of field names, at least one of which must be
+	// set (e.g. ["value", "externalValue"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    EitherFieldRequiredError clusters "at least one of these fields must be set"
+    failures (example.value vs externalValue, link.operationId vs operationRef).
+
+func (e *EitherFieldRequiredError) Error() string
+
+func (e *EitherFieldRequiredError) Unwrap() error
+
 type ElseFieldFor31Plus struct{ ValidationError }
 
 func (e *ElseFieldFor31Plus) As(target any) bool
@@ -579,6 +596,24 @@ type Encodings map[string]*Encoding
 
 func (encodings *Encodings) UnmarshalJSON(data []byte) (err error)
     UnmarshalJSON sets Encodings to a copy of data.
+
+type ExactlyOneFieldError struct {
+	// Fields is the set of fields, exactly one of which must be set
+	// (e.g. ["content", "schema"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    ExactlyOneFieldError clusters "exactly one of these fields must be set"
+    failures — e.g. a parameter or header where neither content nor schema is
+    set, or both are.
+
+func (e *ExactlyOneFieldError) Error() string
+
+func (e *ExactlyOneFieldError) Unwrap() error
 
 type Example struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -650,6 +685,10 @@ func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) err
 type ExampleValueExternalValueExclusive struct{ ValidationError }
 
 func (e *ExampleValueExternalValueExclusive) As(target any) bool
+
+type ExampleValueOrExternalValueRequired struct{ ValidationError }
+
+func (e *ExampleValueOrExternalValueRequired) As(target any) bool
 
 type Examples map[string]*ExampleRef // Examples represents components' named examples
 
@@ -799,6 +838,14 @@ func (header *Header) UnmarshalJSON(data []byte) error
 func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Header does not comply with the OpenAPI spec.
 
+type HeaderContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *HeaderContentSchemaExactlyOne) As(target any) bool
+
+type HeaderContentSingleEntry struct{ ValidationError }
+
+func (e *HeaderContentSingleEntry) As(target any) bool
+
 type HeaderInForbidden struct{ ValidationError }
 
 func (e *HeaderInForbidden) As(target any) bool
@@ -894,6 +941,10 @@ func (info *Info) UnmarshalJSON(data []byte) error
 func (info *Info) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Info does not comply with the OpenAPI spec.
 
+type InfoRequired struct{ ValidationError }
+
+func (e *InfoRequired) As(target any) bool
+
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
 
 func (e *InfoSummaryFieldFor31Plus) As(target any) bool
@@ -908,6 +959,10 @@ func (e *InfoVersionRequired) As(target any) bool
 
 type IntegerFormatValidator = FormatValidator[int64]
     IntegerFormatValidator is a type alias for FormatValidator[int64]
+
+type JSONSchemaDialectAbsoluteURIRequired struct{ ValidationError }
+
+func (e *JSONSchemaDialectAbsoluteURIRequired) As(target any) bool
 
 type JSONSchemaDialectFieldFor31Plus struct{ ValidationError }
 
@@ -978,6 +1033,10 @@ func (link *Link) UnmarshalJSON(data []byte) error
 
 func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Link does not comply with the OpenAPI spec.
+
+type LinkOperationIDOrRefRequired struct{ ValidationError }
+
+func (e *LinkOperationIDOrRefRequired) As(target any) bool
 
 type LinkOperationIDRefExclusive struct{ ValidationError }
 
@@ -1420,6 +1479,14 @@ func (parameter *Parameter) WithRequired(value bool) *Parameter
 
 func (parameter *Parameter) WithSchema(value *Schema) *Parameter
 
+type ParameterContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *ParameterContentSchemaExactlyOne) As(target any) bool
+
+type ParameterContentSingleEntry struct{ ValidationError }
+
+func (e *ParameterContentSingleEntry) As(target any) bool
+
 type ParameterNameRequired struct{ ValidationError }
 
 func (e *ParameterNameRequired) As(target any) bool
@@ -1619,6 +1686,10 @@ func (paths *Paths) Validate(ctx context.Context, opts ...ValidationOption) erro
 
 func (paths *Paths) Value(key string) *PathItem
     Value returns the paths for key or nil
+
+type PathsRequired struct{ ValidationError }
+
+func (e *PathsRequired) As(target any) bool
 
 type PatternPropertiesFieldFor31Plus struct{ ValidationError }
 
@@ -2197,6 +2268,28 @@ func (schema *Schema) WithUniqueItems(unique bool) *Schema
 
 func (schema *Schema) WithoutAdditionalProperties() *Schema
 
+type SchemaAdditionalPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaAdditionalPropertiesBothForms) As(target any) bool
+
+type SchemaBothFormsExclusive struct {
+	// Field is the name of the union-typed schema property
+	// (e.g. "additionalProperties", "unevaluatedItems").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    SchemaBothFormsExclusive clusters "this union-typed schema field is
+    set to both its boolean and schema forms simultaneously" failures —
+    additionalProperties, unevaluatedItems, unevaluatedProperties.
+
+func (e *SchemaBothFormsExclusive) Error() string
+
+func (e *SchemaBothFormsExclusive) Unwrap() error
+
 type SchemaError struct {
 	// Value is the value that failed validation.
 	Value any
@@ -2224,6 +2317,10 @@ func (err SchemaError) Unwrap() error
 type SchemaFieldFor31Plus struct{ ValidationError }
 
 func (e *SchemaFieldFor31Plus) As(target any) bool
+
+type SchemaItemsRequired struct{ ValidationError }
+
+func (e *SchemaItemsRequired) As(target any) bool
 
 type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
 
@@ -2278,6 +2375,14 @@ type SchemaRefs []*SchemaRef
 func (s SchemaRefs) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
+
+type SchemaUnevaluatedItemsBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedItemsBothForms) As(target any) bool
+
+type SchemaUnevaluatedPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedPropertiesBothForms) As(target any) bool
 
 type SchemaValidationOption func(*schemaValidationSettings)
     SchemaValidationOption describes options a user has when validating request
@@ -2636,6 +2741,23 @@ func (servers Servers) MatchURL(parsedURL *url.URL) (*Server, []string, string)
 
 func (servers Servers) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Servers does not comply with the OpenAPI spec.
+
+type SingleEntryContentError struct {
+	// Subject is the kind of object whose Content map is too large
+	// ("parameter", "header").
+	Subject string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    SingleEntryContentError clusters "the content map must contain at most one
+    entry" failures (parameter.content, header.content).
+
+func (e *SingleEntryContentError) Error() string
+
+func (e *SingleEntryContentError) Unwrap() error
 
 type SliceUniqueItemsChecker func(items []any) bool
     SliceUniqueItemsChecker is an function used to check if an given slice have
@@ -3027,6 +3149,23 @@ type ValidationOptions struct {
 	// Has unexported fields.
 }
     ValidationOptions provides configuration for validating OpenAPI documents.
+
+type WebhookNil struct{ ValidationError }
+
+func (e *WebhookNil) As(target any) bool
+
+type WebhookNilError struct {
+	// Name is the webhook key whose value was nil.
+	Name string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+}
+    WebhookNilError clusters "the value at webhook key X is nil" failures from
+    T.Validate's webhook walk. Carries the offending key name.
+
+func (e *WebhookNilError) Error() string
+
+func (e *WebhookNilError) Unwrap() error
 
 type WebhooksFieldFor31Plus struct{ ValidationError }
 

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -735,6 +735,24 @@ func (e *FieldVersionMismatchError) Error() string
 
 func (e *FieldVersionMismatchError) Unwrap() error
 
+type ForbiddenFieldError struct {
+	// Field is the name of the forbidden field (e.g. "name", "in",
+	// "authorizationUrl", "tokenUrl").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    ForbiddenFieldError clusters "field X must not be set in this context"
+    failures (header.name and header.in inside a Headers map, OAuth flow URLs
+    that don't apply to the chosen flow type).
+
+func (e *ForbiddenFieldError) Error() string
+
+func (e *ForbiddenFieldError) Unwrap() error
+
 type FormatValidator[T any] interface {
 	Validate(value T) error
 }
@@ -776,6 +794,14 @@ func (header *Header) UnmarshalJSON(data []byte) error
 
 func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Header does not comply with the OpenAPI spec.
+
+type HeaderInForbidden struct{ ValidationError }
+
+func (e *HeaderInForbidden) As(target any) bool
+
+type HeaderNameForbidden struct{ ValidationError }
+
+func (e *HeaderNameForbidden) As(target any) bool
 
 type HeaderRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1205,6 +1231,10 @@ func (flow *OAuthFlow) Validate(ctx context.Context, opts ...ValidationOption) e
     Validate returns an error if OAuthFlows does not comply with the OpenAPI
     spec.
 
+type OAuthFlowAuthorizationURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowAuthorizationURLForbidden) As(target any) bool
+
 type OAuthFlowAuthorizationURLRequired struct{ ValidationError }
 
 func (e *OAuthFlowAuthorizationURLRequired) As(target any) bool
@@ -1212,6 +1242,10 @@ func (e *OAuthFlowAuthorizationURLRequired) As(target any) bool
 type OAuthFlowScopesRequired struct{ ValidationError }
 
 func (e *OAuthFlowScopesRequired) As(target any) bool
+
+type OAuthFlowTokenURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowTokenURLForbidden) As(target any) bool
 
 type OAuthFlowTokenURLRequired struct{ ValidationError }
 

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2179,6 +2179,10 @@ type SchemaFieldFor31Plus struct{ ValidationError }
 
 func (e *SchemaFieldFor31Plus) As(target any) bool
 
+type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
+
+func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool
+
 type SchemaRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
 	// are allowed by the openapi spec.

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -643,6 +643,10 @@ func (x *ExampleRef) Validate(ctx context.Context, opts ...ValidationOption) err
     Validate returns an error if ExampleRef does not comply with the OpenAPI
     spec.
 
+type ExampleValueExternalValueExclusive struct{ ValidationError }
+
+func (e *ExampleValueExternalValueExclusive) As(target any) bool
+
 type Examples map[string]*ExampleRef // Examples represents components' named examples
 
 func (m Examples) JSONLookup(token string) (any, error)
@@ -915,6 +919,10 @@ type LicenseNameRequired struct{ ValidationError }
 
 func (e *LicenseNameRequired) As(target any) bool
 
+type LicenseURLIdentifierExclusive struct{ ValidationError }
+
+func (e *LicenseURLIdentifierExclusive) As(target any) bool
+
 type Link struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -940,6 +948,10 @@ func (link *Link) UnmarshalJSON(data []byte) error
 
 func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error
     Validate returns an error if Link does not comply with the OpenAPI spec.
+
+type LinkOperationIDRefExclusive struct{ ValidationError }
+
+func (e *LinkOperationIDRefExclusive) As(target any) bool
 
 type LinkRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1101,6 +1113,10 @@ func (mediaType *MediaType) WithSchema(schema *Schema) *MediaType
 
 func (mediaType *MediaType) WithSchemaRef(schema *SchemaRef) *MediaType
 
+type MediaTypeExampleExamplesExclusive struct{ ValidationError }
+
+func (e *MediaTypeExampleExamplesExclusive) As(target any) bool
+
 type MinContainsFieldFor31Plus struct{ ValidationError }
 
 func (e *MinContainsFieldFor31Plus) As(target any) bool
@@ -1119,6 +1135,26 @@ func (me MultiError) Is(target error) bool
     Is allows you to determine if a generic error is in fact a MultiError using
     `errors.Is()` It will also return true if any of the contained errors match
     target
+
+type MutuallyExclusiveFieldsError struct {
+	// Field1 and Field2 name the two fields the spec forbids setting
+	// together (e.g. "value", "externalValue").
+	Field1 string
+	Field2 string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    MutuallyExclusiveFieldsError clusters "fields X and Y are both set, only
+    one is allowed" failures (example.value vs externalValue, mediaType.example
+    vs examples, license.url vs identifier, link.operationId vs operationRef).
+    Carries both field names and wraps the per-site leaf.
+
+func (e *MutuallyExclusiveFieldsError) Error() string
+
+func (e *MutuallyExclusiveFieldsError) Unwrap() error
 
 type NewCallbackOption func(*Callback)
     NewCallbackOption describes options to NewCallback func

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2567,9 +2567,34 @@ func (server *Server) UnmarshalJSON(data []byte) error
 func (server *Server) Validate(ctx context.Context, opts ...ValidationOption) (err error)
     Validate returns an error if Server does not comply with the OpenAPI spec.
 
+type ServerURLMismatchedBraces struct{ ValidationError }
+
+func (e *ServerURLMismatchedBraces) As(target any) bool
+
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool
+
+type ServerURLTemplateError struct {
+	// URL is the server URL whose template failed validation.
+	URL string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    ServerURLTemplateError clusters server URL template failures — mismatched
+    braces and undeclared variables (template variables not matched by
+    Server.Variables, or vice versa).
+
+func (e *ServerURLTemplateError) Error() string
+
+func (e *ServerURLTemplateError) Unwrap() error
+
+type ServerURLUndeclaredVariables struct{ ValidationError }
+
+func (e *ServerURLUndeclaredVariables) As(target any) bool
 
 type ServerVariable struct {
 	Extensions map[string]any `json:"-" yaml:"-"`

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -252,6 +252,10 @@ func WithValidationOptions(ctx context.Context, opts ...ValidationOption) contex
 
 TYPES
 
+type APIKeySecuritySchemeNameRequired struct{ ValidationError }
+
+func (e *APIKeySecuritySchemeNameRequired) As(target any) bool
+
 type AdditionalProperties = BoolSchema
     AdditionalProperties is a type alias for BoolSchema, kept for backward
     compatibility.
@@ -1416,6 +1420,10 @@ func (parameter *Parameter) WithRequired(value bool) *Parameter
 
 func (parameter *Parameter) WithSchema(value *Schema) *Parameter
 
+type ParameterNameRequired struct{ ValidationError }
+
+func (e *ParameterNameRequired) As(target any) bool
+
 type ParameterRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
 	// are allowed by the openapi spec.
@@ -1951,6 +1959,10 @@ func (responses *Responses) Validate(ctx context.Context, opts ...ValidationOpti
 
 func (responses *Responses) Value(key string) *ResponseRef
     Value returns the responses for key or nil
+
+type ResponsesNonEmptyRequired struct{ ValidationError }
+
+func (e *ResponsesNonEmptyRequired) As(target any) bool
 
 type Schema struct {
 	Extensions map[string]any `json:"-" yaml:"-"`

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"maps"
 )
 
@@ -78,7 +77,7 @@ func (example *Example) Validate(ctx context.Context, opts ...ValidationOption) 
 		return newExampleValueExternalValueExclusive(example.Origin)
 	}
 	if example.Value == nil && example.ExternalValue == "" {
-		return errors.New("no value or externalValue field")
+		return newExampleValueOrExternalValueRequired(example.Origin)
 	}
 
 	return validateExtensions(ctx, example.Extensions)

--- a/openapi3/example.go
+++ b/openapi3/example.go
@@ -75,7 +75,7 @@ func (example *Example) Validate(ctx context.Context, opts ...ValidationOption) 
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if example.Value != nil && example.ExternalValue != "" {
-		return errors.New("value and externalValue are mutually exclusive")
+		return newExampleValueExternalValueExclusive(example.Origin)
 	}
 	if example.Value == nil && example.ExternalValue == "" {
 		return errors.New("no value or externalValue field")

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -2,7 +2,6 @@ package openapi3
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/go-openapi/jsonpointer"
@@ -73,8 +72,8 @@ func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) er
 	}
 
 	if (header.Schema == nil) == (len(header.Content) == 0) {
-		e := fmt.Errorf("parameter must contain exactly one of content and schema: %v", header)
-		return fmt.Errorf("header schema is invalid: %w", e)
+		return fmt.Errorf("header schema is invalid: %w",
+			newHeaderContentSchemaExactlyOne(header, header.Origin))
 	}
 	if schema := header.Schema; schema != nil {
 		if err := schema.Validate(ctx); err != nil {
@@ -83,9 +82,9 @@ func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) er
 	}
 
 	if content := header.Content; content != nil {
-		e := errors.New("parameter content must only contain one entry")
 		if len(content) > 1 {
-			return fmt.Errorf("header content is invalid: %w", e)
+			return fmt.Errorf("header content is invalid: %w",
+				newHeaderContentSingleEntry(header.Origin))
 		}
 
 		if err := content.Validate(ctx); err != nil {

--- a/openapi3/header.go
+++ b/openapi3/header.go
@@ -54,10 +54,10 @@ func (header *Header) Validate(ctx context.Context, opts ...ValidationOption) er
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if header.Name != "" {
-		return errors.New("header 'name' MUST NOT be specified, it is given in the corresponding headers map")
+		return newHeaderNameForbidden(header.Origin)
 	}
 	if header.In != "" {
-		return errors.New("header 'in' MUST NOT be specified, it is implicitly in header")
+		return newHeaderInForbidden(header.Origin)
 	}
 
 	// Validate a parameter's serialization method.

--- a/openapi3/license.go
+++ b/openapi3/license.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"maps"
 )
 
@@ -76,7 +75,7 @@ func (license *License) Validate(ctx context.Context, opts ...ValidationOption) 
 	}
 
 	if license.URL != "" && license.Identifier != "" {
-		return errors.New("license must not specify both 'url' and 'identifier'")
+		return newLicenseURLIdentifierExclusive(license.Origin)
 	}
 
 	return validateExtensions(ctx, license.Extensions)

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"maps"
 )
 
@@ -84,7 +83,7 @@ func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error 
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if link.OperationID == "" && link.OperationRef == "" {
-		return errors.New("missing operationId or operationRef on link")
+		return newLinkOperationIDOrRefRequired(link.Origin)
 	}
 	if link.OperationID != "" && link.OperationRef != "" {
 		return newLinkOperationIDRefExclusive(link.OperationID, link.OperationRef, link.Origin)

--- a/openapi3/link.go
+++ b/openapi3/link.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"maps"
 )
 
@@ -88,7 +87,7 @@ func (link *Link) Validate(ctx context.Context, opts ...ValidationOption) error 
 		return errors.New("missing operationId or operationRef on link")
 	}
 	if link.OperationID != "" && link.OperationRef != "" {
-		return fmt.Errorf("operationId %q and operationRef %q are mutually exclusive", link.OperationID, link.OperationRef)
+		return newLinkOperationIDRefExclusive(link.OperationID, link.OperationRef, link.Origin)
 	}
 
 	return validateExtensions(ctx, link.Extensions)

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 
@@ -125,7 +124,7 @@ func (mediaType *MediaType) Validate(ctx context.Context, opts ...ValidationOpti
 		}
 
 		if mediaType.Example != nil && mediaType.Examples != nil {
-			return errors.New("example and examples are mutually exclusive")
+			return newMediaTypeExampleExamplesExclusive(mediaType.Origin)
 		}
 
 		if vo := getValidationOptions(ctx); !vo.examplesValidationDisabled {

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/url"
@@ -294,7 +293,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 	} else {
-		return wrap(errors.New("must be an object"))
+		return wrap(newInfoRequired())
 	}
 
 	wrap = func(e error) error { return fmt.Errorf("invalid paths: %w", e) }
@@ -303,7 +302,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 	} else if doc.IsOpenAPI30() {
-		return wrap(errors.New("must be an object"))
+		return wrap(newPathsRequired())
 	}
 
 	wrap = func(e error) error { return fmt.Errorf("invalid security: %w", e) }
@@ -352,7 +351,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 		if u.Scheme == "" {
-			return wrap(errors.New("must be an absolute URI with a scheme"))
+			return wrap(newJSONSchemaDialectAbsoluteURIRequired())
 		}
 	}
 

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -337,7 +337,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 	for _, name := range componentNames(doc.Webhooks) {
 		pathItem := doc.Webhooks[name]
 		if pathItem == nil {
-			return wrap(fmt.Errorf("webhook %q is nil", name))
+			return wrap(newWebhookNil(name))
 		}
 		if err := pathItem.Validate(ctx); err != nil {
 			return wrap(fmt.Errorf("webhook %q: %w", name, err))

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"strconv"
@@ -363,14 +362,14 @@ func (parameter *Parameter) Validate(ctx context.Context, opts ...ValidationOpti
 	}
 
 	if (parameter.Schema == nil) == (len(parameter.Content) == 0) {
-		e := errors.New("parameter must contain exactly one of content and schema")
-		return fmt.Errorf("parameter %q schema is invalid: %w", parameter.Name, e)
+		return fmt.Errorf("parameter %q schema is invalid: %w", parameter.Name,
+			newParameterContentSchemaExactlyOne(parameter.Origin))
 	}
 
 	if content := parameter.Content; content != nil {
-		e := errors.New("parameter content must only contain one entry")
 		if len(content) > 1 {
-			return fmt.Errorf("parameter %q content is invalid: %w", parameter.Name, e)
+			return fmt.Errorf("parameter %q content is invalid: %w", parameter.Name,
+				newParameterContentSingleEntry(parameter.Origin))
 		}
 
 		if err := content.Validate(ctx); err != nil {

--- a/openapi3/parameter.go
+++ b/openapi3/parameter.go
@@ -311,7 +311,7 @@ func (parameter *Parameter) Validate(ctx context.Context, opts ...ValidationOpti
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if parameter.Name == "" {
-		return errors.New("parameter name can't be blank")
+		return newParameterNameRequired(parameter.Origin)
 	}
 	in := parameter.In
 	switch in {

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"maps"
 	"strconv"
 )
@@ -78,7 +77,7 @@ func (responses *Responses) Validate(ctx context.Context, opts ...ValidationOpti
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if responses.Len() == 0 {
-		return errors.New("the responses object MUST contain at least one response code")
+		return newResponsesNonEmptyRequired(responses.Origin)
 	}
 
 	for _, key := range responses.Keys() {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1685,7 +1685,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 			}
 		case TypeArray:
 			if schema.Items == nil && !validationOpts.jsonSchema2020ValidationEnabled && len(schema.PrefixItems) == 0 {
-				return stack, errors.New("when schema type is 'array', schema 'items' must be non-null")
+				return stack, newSchemaItemsRequired(schema.Origin)
 			}
 		case TypeObject:
 		case TypeNull:

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1412,7 +1412,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	stack = append(stack, schema)
 
 	if schema.ReadOnly && schema.WriteOnly {
-		return stack, errors.New("a property MUST NOT be marked as both readOnly and writeOnly being true")
+		return stack, newSchemaReadOnlyWriteOnlyExclusive(schema.Origin)
 	}
 
 	// Reject fields that only exist in OAS 3.1 / JSON Schema 2020-12 when the

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1729,7 +1729,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	}
 
 	if schema.AdditionalProperties.Has != nil && schema.AdditionalProperties.Schema != nil {
-		return stack, errors.New("additionalProperties are set to both boolean and schema")
+		return stack, newSchemaAdditionalPropertiesBothForms(schema.Origin)
 	}
 	if ref := schema.AdditionalProperties.Schema; ref != nil {
 		if err := ref.validateExtras(ctx); err != nil {
@@ -1835,7 +1835,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if schema.UnevaluatedItems.Has != nil && schema.UnevaluatedItems.Schema != nil {
-		return stack, errors.New("unevaluatedItems is set to both boolean and schema")
+		return stack, newSchemaUnevaluatedItemsBothForms(schema.Origin)
 	}
 	if ref := schema.UnevaluatedItems.Schema; ref != nil {
 		if err := ref.validateExtras(ctx); err != nil {
@@ -1852,7 +1852,7 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		}
 	}
 	if schema.UnevaluatedProperties.Has != nil && schema.UnevaluatedProperties.Schema != nil {
-		return stack, errors.New("unevaluatedProperties is set to both boolean and schema")
+		return stack, newSchemaUnevaluatedPropertiesBothForms(schema.Origin)
 	}
 	if ref := schema.UnevaluatedProperties.Schema; ref != nil {
 		if err := ref.validateExtras(ctx); err != nil {

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -3,7 +3,6 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"maps"
 	"net/url"
@@ -188,7 +187,7 @@ func (ss *SecurityScheme) Validate(ctx context.Context, opts ...ValidationOption
 			return fmt.Errorf("security scheme of type 'apiKey' should have 'in'. It can be 'query', 'header' or 'cookie', not %q", ss.In)
 		}
 		if ss.Name == "" {
-			return errors.New("security scheme of type 'apiKey' should have 'name'")
+			return newAPIKeySecuritySchemeNameRequired(ss.Origin)
 		}
 	} else if len(ss.In) > 0 {
 		return fmt.Errorf("security scheme of type %q can't have 'in'", ss.Type)

--- a/openapi3/security_scheme.go
+++ b/openapi3/security_scheme.go
@@ -404,7 +404,7 @@ func (flow *OAuthFlow) validate(ctx context.Context, typ oAuthFlowType, opts ...
 		case flow.AuthorizationURL == "" && in:
 			return newOAuthFlowAuthorizationURLRequired(flow.Origin)
 		case flow.AuthorizationURL != "" && !in:
-			return errors.New("field 'authorizationUrl' should not be set")
+			return newOAuthFlowAuthorizationURLForbidden(flow.Origin)
 		case flow.AuthorizationURL != "":
 			if _, err := url.Parse(flow.AuthorizationURL); err != nil {
 				return fmt.Errorf("field 'authorizationUrl' is invalid: %w", err)
@@ -417,7 +417,7 @@ func (flow *OAuthFlow) validate(ctx context.Context, typ oAuthFlowType, opts ...
 		case flow.TokenURL == "" && in:
 			return newOAuthFlowTokenURLRequired(flow.Origin)
 		case flow.TokenURL != "" && !in:
-			return errors.New("field 'tokenUrl' should not be set")
+			return newOAuthFlowTokenURLForbidden(flow.Origin)
 		case flow.TokenURL != "":
 			if _, err := url.Parse(flow.TokenURL); err != nil {
 				return fmt.Errorf("field 'tokenUrl' is invalid: %w", err)

--- a/openapi3/server.go
+++ b/openapi3/server.go
@@ -205,17 +205,17 @@ func (server *Server) Validate(ctx context.Context, opts ...ValidationOption) (e
 
 	opening, closing := strings.Count(server.URL, "{"), strings.Count(server.URL, "}")
 	if opening != closing {
-		return errors.New("server URL has mismatched { and }")
+		return newServerURLMismatchedBraces(server.URL, server.Origin)
 	}
 
 	if opening != len(server.Variables) {
-		return errors.New("server has undeclared variables")
+		return newServerURLUndeclaredVariables(server.URL, server.Origin)
 	}
 
 	for _, name := range componentNames(server.Variables) {
 		v := server.Variables[name]
 		if !strings.Contains(server.URL, "{"+name+"}") {
-			return errors.New("server has undeclared variables")
+			return newServerURLUndeclaredVariables(server.URL, server.Origin)
 		}
 		if err = v.Validate(ctx); err != nil {
 			return

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -238,6 +238,19 @@ type SingleEntryContentError struct {
 func (e *SingleEntryContentError) Error() string { return e.Cause.Error() }
 func (e *SingleEntryContentError) Unwrap() error { return e.Cause }
 
+// WebhookNilError clusters "the value at webhook key X is nil"
+// failures from T.Validate's webhook walk. Carries the offending
+// key name.
+type WebhookNilError struct {
+	// Name is the webhook key whose value was nil.
+	Name string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+}
+
+func (e *WebhookNilError) Error() string { return e.Cause.Error() }
+func (e *WebhookNilError) Unwrap() error { return e.Cause }
+
 // MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
 // only one is allowed" failures (example.value vs externalValue,
 // mediaType.example vs examples, license.url vs identifier,
@@ -415,6 +428,14 @@ func (e *ParameterContentSingleEntry) As(target any) bool {
 type HeaderContentSingleEntry struct{ ValidationError }
 
 func (e *HeaderContentSingleEntry) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// WebhookNilError leaf.
+
+type WebhookNil struct{ ValidationError }
+
+func (e *WebhookNil) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -873,6 +894,14 @@ func newHeaderContentSingleEntry(origin *Origin) error {
 	const msg = "parameter content must only contain one entry"
 	return newSingleEntryContent("header",
 		&HeaderContentSingleEntry{ValidationError{Message: msg}}, origin)
+}
+
+func newWebhookNil(name string) error {
+	msg := fmt.Sprintf("webhook %q is nil", name)
+	return &WebhookNilError{
+		Name:  name,
+		Cause: &WebhookNil{ValidationError{Message: msg}},
+	}
 }
 
 func newExternalDocsURLRequired(origin *Origin) error {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -188,6 +188,23 @@ type EitherFieldRequiredError struct {
 func (e *EitherFieldRequiredError) Error() string { return e.Cause.Error() }
 func (e *EitherFieldRequiredError) Unwrap() error { return e.Cause }
 
+// SchemaBothFormsExclusive clusters "this union-typed schema field is
+// set to both its boolean and schema forms simultaneously" failures —
+// additionalProperties, unevaluatedItems, unevaluatedProperties.
+type SchemaBothFormsExclusive struct {
+	// Field is the name of the union-typed schema property
+	// (e.g. "additionalProperties", "unevaluatedItems").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *SchemaBothFormsExclusive) Error() string { return e.Cause.Error() }
+func (e *SchemaBothFormsExclusive) Unwrap() error { return e.Cause }
+
 // MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
 // only one is allowed" failures (example.value vs externalValue,
 // mediaType.example vs examples, license.url vs identifier,
@@ -317,6 +334,26 @@ func (e *PathsRequired) As(target any) bool {
 type JSONSchemaDialectAbsoluteURIRequired struct{ ValidationError }
 
 func (e *JSONSchemaDialectAbsoluteURIRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// SchemaBothFormsExclusive leaves.
+
+type SchemaAdditionalPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaAdditionalPropertiesBothForms) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type SchemaUnevaluatedItemsBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedItemsBothForms) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type SchemaUnevaluatedPropertiesBothForms struct{ ValidationError }
+
+func (e *SchemaUnevaluatedPropertiesBothForms) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -711,6 +748,30 @@ func newPathsRequired() error {
 func newJSONSchemaDialectAbsoluteURIRequired() error {
 	return newRequiredField("jsonSchemaDialect",
 		&JSONSchemaDialectAbsoluteURIRequired{ValidationError{Message: "must be an absolute URI with a scheme"}}, nil)
+}
+
+// newSchemaBothForms wraps leaf in a *SchemaBothFormsExclusive carrying
+// the name of the union-typed schema property.
+func newSchemaBothForms(field string, leaf error, origin *Origin) error {
+	return &SchemaBothFormsExclusive{Field: field, Cause: leaf, Origin: origin}
+}
+
+func newSchemaAdditionalPropertiesBothForms(origin *Origin) error {
+	const msg = "additionalProperties are set to both boolean and schema"
+	return newSchemaBothForms("additionalProperties",
+		&SchemaAdditionalPropertiesBothForms{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaUnevaluatedItemsBothForms(origin *Origin) error {
+	const msg = "unevaluatedItems is set to both boolean and schema"
+	return newSchemaBothForms("unevaluatedItems",
+		&SchemaUnevaluatedItemsBothForms{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaUnevaluatedPropertiesBothForms(origin *Origin) error {
+	const msg = "unevaluatedProperties is set to both boolean and schema"
+	return newSchemaBothForms("unevaluatedProperties",
+		&SchemaUnevaluatedPropertiesBothForms{ValidationError{Message: msg}}, origin)
 }
 
 func newExternalDocsURLRequired(origin *Origin) error {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -302,6 +302,24 @@ func (e *LinkOperationIDOrRefRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type InfoRequired struct{ ValidationError }
+
+func (e *InfoRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type PathsRequired struct{ ValidationError }
+
+func (e *PathsRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type JSONSchemaDialectAbsoluteURIRequired struct{ ValidationError }
+
+func (e *JSONSchemaDialectAbsoluteURIRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 type ExternalDocsURLRequired struct{ ValidationError }
 
 func (e *ExternalDocsURLRequired) As(target any) bool {
@@ -676,6 +694,23 @@ func newLinkOperationIDOrRefRequired(origin *Origin) error {
 	const msg = "missing operationId or operationRef on link"
 	return newEitherFieldRequired([]string{"operationId", "operationRef"},
 		&LinkOperationIDOrRefRequired{ValidationError{Message: msg}}, origin)
+}
+
+// newInfoRequired and newPathsRequired don't take Origin: both fields
+// live on the document root *T, which the loader doesn't track.
+func newInfoRequired() error {
+	return newRequiredField("info",
+		&InfoRequired{ValidationError{Message: "must be an object"}}, nil)
+}
+
+func newPathsRequired() error {
+	return newRequiredField("paths",
+		&PathsRequired{ValidationError{Message: "must be an object"}}, nil)
+}
+
+func newJSONSchemaDialectAbsoluteURIRequired() error {
+	return newRequiredField("jsonSchemaDialect",
+		&JSONSchemaDialectAbsoluteURIRequired{ValidationError{Message: "must be an absolute URI with a scheme"}}, nil)
 }
 
 func newExternalDocsURLRequired(origin *Origin) error {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,22 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// ServerURLTemplateError clusters server URL template failures —
+// mismatched braces and undeclared variables (template variables not
+// matched by Server.Variables, or vice versa).
+type ServerURLTemplateError struct {
+	// URL is the server URL whose template failed validation.
+	URL string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *ServerURLTemplateError) Error() string { return e.Cause.Error() }
+func (e *ServerURLTemplateError) Unwrap() error { return e.Cause }
+
 // MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
 // only one is allowed" failures (example.value vs externalValue,
 // mediaType.example vs examples, license.url vs identifier,
@@ -232,6 +248,20 @@ func (e *OpenAPIVersionRequired) As(target any) bool {
 type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// ServerURLTemplateError leaves.
+
+type ServerURLMismatchedBraces struct{ ValidationError }
+
+func (e *ServerURLMismatchedBraces) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type ServerURLUndeclaredVariables struct{ ValidationError }
+
+func (e *ServerURLUndeclaredVariables) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -567,6 +597,24 @@ func newOpenAPIVersionRequired() error {
 func newServerURLRequired(origin *Origin) error {
 	return newRequiredField("server.url",
 		&ServerURLRequired{ValidationError{Message: "value of url must be a non-empty string"}}, origin)
+}
+
+// newServerURLTemplateError wraps leaf in a *ServerURLTemplateError
+// carrying the offending Server.URL.
+func newServerURLTemplateError(serverURL string, leaf error, origin *Origin) error {
+	return &ServerURLTemplateError{URL: serverURL, Cause: leaf, Origin: origin}
+}
+
+func newServerURLMismatchedBraces(serverURL string, origin *Origin) error {
+	const msg = "server URL has mismatched { and }"
+	return newServerURLTemplateError(serverURL,
+		&ServerURLMismatchedBraces{ValidationError{Message: msg}}, origin)
+}
+
+func newServerURLUndeclaredVariables(serverURL string, origin *Origin) error {
+	const msg = "server has undeclared variables"
+	return newServerURLTemplateError(serverURL,
+		&ServerURLUndeclaredVariables{ValidationError{Message: msg}}, origin)
 }
 
 func newExternalDocsURLRequired(origin *Origin) error {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -277,6 +277,24 @@ func (e *OAuthFlowTokenURLRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type ParameterNameRequired struct{ ValidationError }
+
+func (e *ParameterNameRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type ResponsesNonEmptyRequired struct{ ValidationError }
+
+func (e *ResponsesNonEmptyRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type APIKeySecuritySchemeNameRequired struct{ ValidationError }
+
+func (e *APIKeySecuritySchemeNameRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // MutuallyExclusiveFieldsError leaves.
 
 type ExampleValueExternalValueExclusive struct{ ValidationError }
@@ -655,6 +673,23 @@ func newOAuthFlowTokenURLForbidden(origin *Origin) error {
 	const msg = "field 'tokenUrl' should not be set"
 	return newForbiddenField("tokenUrl",
 		&OAuthFlowTokenURLForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newParameterNameRequired(origin *Origin) error {
+	return newRequiredField("parameter.name",
+		&ParameterNameRequired{ValidationError{Message: "parameter name can't be blank"}}, origin)
+}
+
+func newResponsesNonEmptyRequired(origin *Origin) error {
+	const msg = "the responses object MUST contain at least one response code"
+	return newRequiredField("responses",
+		&ResponsesNonEmptyRequired{ValidationError{Message: msg}}, origin)
+}
+
+func newAPIKeySecuritySchemeNameRequired(origin *Origin) error {
+	const msg = "security scheme of type 'apiKey' should have 'name'"
+	return newRequiredField("securityScheme.name",
+		&APIKeySecuritySchemeNameRequired{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -205,6 +205,39 @@ type SchemaBothFormsExclusive struct {
 func (e *SchemaBothFormsExclusive) Error() string { return e.Cause.Error() }
 func (e *SchemaBothFormsExclusive) Unwrap() error { return e.Cause }
 
+// ExactlyOneFieldError clusters "exactly one of these fields must be
+// set" failures — e.g. a parameter or header where neither content
+// nor schema is set, or both are.
+type ExactlyOneFieldError struct {
+	// Fields is the set of fields, exactly one of which must be set
+	// (e.g. ["content", "schema"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *ExactlyOneFieldError) Error() string { return e.Cause.Error() }
+func (e *ExactlyOneFieldError) Unwrap() error { return e.Cause }
+
+// SingleEntryContentError clusters "the content map must contain at
+// most one entry" failures (parameter.content, header.content).
+type SingleEntryContentError struct {
+	// Subject is the kind of object whose Content map is too large
+	// ("parameter", "header").
+	Subject string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *SingleEntryContentError) Error() string { return e.Cause.Error() }
+func (e *SingleEntryContentError) Unwrap() error { return e.Cause }
+
 // MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
 // only one is allowed" failures (example.value vs externalValue,
 // mediaType.example vs examples, license.url vs identifier,
@@ -354,6 +387,34 @@ func (e *SchemaUnevaluatedItemsBothForms) As(target any) bool {
 type SchemaUnevaluatedPropertiesBothForms struct{ ValidationError }
 
 func (e *SchemaUnevaluatedPropertiesBothForms) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// ExactlyOneFieldError leaves.
+
+type ParameterContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *ParameterContentSchemaExactlyOne) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type HeaderContentSchemaExactlyOne struct{ ValidationError }
+
+func (e *HeaderContentSchemaExactlyOne) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// SingleEntryContentError leaves.
+
+type ParameterContentSingleEntry struct{ ValidationError }
+
+func (e *ParameterContentSingleEntry) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type HeaderContentSingleEntry struct{ ValidationError }
+
+func (e *HeaderContentSingleEntry) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -772,6 +833,46 @@ func newSchemaUnevaluatedPropertiesBothForms(origin *Origin) error {
 	const msg = "unevaluatedProperties is set to both boolean and schema"
 	return newSchemaBothForms("unevaluatedProperties",
 		&SchemaUnevaluatedPropertiesBothForms{ValidationError{Message: msg}}, origin)
+}
+
+// newExactlyOneField wraps leaf in an *ExactlyOneFieldError carrying
+// the set of fields, exactly one of which must be set.
+func newExactlyOneField(fields []string, leaf error, origin *Origin) error {
+	return &ExactlyOneFieldError{Fields: fields, Cause: leaf, Origin: origin}
+}
+
+func newParameterContentSchemaExactlyOne(origin *Origin) error {
+	const msg = "parameter must contain exactly one of content and schema"
+	return newExactlyOneField([]string{"content", "schema"},
+		&ParameterContentSchemaExactlyOne{ValidationError{Message: msg}}, origin)
+}
+
+// newHeaderContentSchemaExactlyOne formats the same way the existing
+// header.go site does, including the historical "%v" dump of the
+// Header struct, so the Error() string remains byte-identical.
+func newHeaderContentSchemaExactlyOne(header any, origin *Origin) error {
+	msg := fmt.Sprintf("parameter must contain exactly one of content and schema: %v", header)
+	return newExactlyOneField([]string{"content", "schema"},
+		&HeaderContentSchemaExactlyOne{ValidationError{Message: msg}}, origin)
+}
+
+// newSingleEntryContent wraps leaf in a *SingleEntryContentError
+// carrying the Subject ("parameter" or "header") whose Content map
+// has more than one entry.
+func newSingleEntryContent(subject string, leaf error, origin *Origin) error {
+	return &SingleEntryContentError{Subject: subject, Cause: leaf, Origin: origin}
+}
+
+func newParameterContentSingleEntry(origin *Origin) error {
+	const msg = "parameter content must only contain one entry"
+	return newSingleEntryContent("parameter",
+		&ParameterContentSingleEntry{ValidationError{Message: msg}}, origin)
+}
+
+func newHeaderContentSingleEntry(origin *Origin) error {
+	const msg = "parameter content must only contain one entry"
+	return newSingleEntryContent("header",
+		&HeaderContentSingleEntry{ValidationError{Message: msg}}, origin)
 }
 
 func newExternalDocsURLRequired(origin *Origin) error {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -155,6 +155,26 @@ type FieldVersionMismatchError struct {
 func (e *FieldVersionMismatchError) Error() string { return e.Cause.Error() }
 func (e *FieldVersionMismatchError) Unwrap() error { return e.Cause }
 
+// MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
+// only one is allowed" failures (example.value vs externalValue,
+// mediaType.example vs examples, license.url vs identifier,
+// link.operationId vs operationRef). Carries both field names and
+// wraps the per-site leaf.
+type MutuallyExclusiveFieldsError struct {
+	// Field1 and Field2 name the two fields the spec forbids setting
+	// together (e.g. "value", "externalValue").
+	Field1 string
+	Field2 string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *MutuallyExclusiveFieldsError) Error() string { return e.Cause.Error() }
+func (e *MutuallyExclusiveFieldsError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -237,6 +257,32 @@ func (e *OAuthFlowAuthorizationURLRequired) As(target any) bool {
 type OAuthFlowTokenURLRequired struct{ ValidationError }
 
 func (e *OAuthFlowTokenURLRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// MutuallyExclusiveFieldsError leaves.
+
+type ExampleValueExternalValueExclusive struct{ ValidationError }
+
+func (e *ExampleValueExternalValueExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type MediaTypeExampleExamplesExclusive struct{ ValidationError }
+
+func (e *MediaTypeExampleExamplesExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type LicenseURLIdentifierExclusive struct{ ValidationError }
+
+func (e *LicenseURLIdentifierExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type LinkOperationIDRefExclusive struct{ ValidationError }
+
+func (e *LinkOperationIDRefExclusive) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -489,6 +535,41 @@ func newOAuthFlowAuthorizationURLRequired(origin *Origin) error {
 func newOAuthFlowTokenURLRequired(origin *Origin) error {
 	return newRequiredField("oAuthFlow.tokenUrl",
 		&OAuthFlowTokenURLRequired{ValidationError{Message: "field 'tokenUrl' is empty or missing"}}, origin)
+}
+
+// newMutuallyExclusiveFields wraps leaf in a *MutuallyExclusiveFieldsError
+// carrying the two field names the spec forbids setting together.
+func newMutuallyExclusiveFields(field1, field2 string, leaf error, origin *Origin) error {
+	return &MutuallyExclusiveFieldsError{
+		Field1: field1,
+		Field2: field2,
+		Cause:  leaf,
+		Origin: origin,
+	}
+}
+
+func newExampleValueExternalValueExclusive(origin *Origin) error {
+	const msg = "value and externalValue are mutually exclusive"
+	return newMutuallyExclusiveFields("value", "externalValue",
+		&ExampleValueExternalValueExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newMediaTypeExampleExamplesExclusive(origin *Origin) error {
+	const msg = "example and examples are mutually exclusive"
+	return newMutuallyExclusiveFields("example", "examples",
+		&MediaTypeExampleExamplesExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newLicenseURLIdentifierExclusive(origin *Origin) error {
+	const msg = "license must not specify both 'url' and 'identifier'"
+	return newMutuallyExclusiveFields("url", "identifier",
+		&LicenseURLIdentifierExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newLinkOperationIDRefExclusive(operationID, operationRef string, origin *Origin) error {
+	msg := fmt.Sprintf("operationId %q and operationRef %q are mutually exclusive", operationID, operationRef)
+	return newMutuallyExclusiveFields("operationId", "operationRef",
+		&LinkOperationIDRefExclusive{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -286,6 +286,12 @@ func (e *LinkOperationIDRefExclusive) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
+
+func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // FieldVersionMismatchError leaves — non-schema fields.
 
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
@@ -570,6 +576,12 @@ func newLinkOperationIDRefExclusive(operationID, operationRef string, origin *Or
 	msg := fmt.Sprintf("operationId %q and operationRef %q are mutually exclusive", operationID, operationRef)
 	return newMutuallyExclusiveFields("operationId", "operationRef",
 		&LinkOperationIDRefExclusive{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaReadOnlyWriteOnlyExclusive(origin *Origin) error {
+	const msg = "a property MUST NOT be marked as both readOnly and writeOnly being true"
+	return newMutuallyExclusiveFields("readOnly", "writeOnly",
+		&SchemaReadOnlyWriteOnlyExclusive{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -171,6 +171,23 @@ type ServerURLTemplateError struct {
 func (e *ServerURLTemplateError) Error() string { return e.Cause.Error() }
 func (e *ServerURLTemplateError) Unwrap() error { return e.Cause }
 
+// EitherFieldRequiredError clusters "at least one of these fields must
+// be set" failures (example.value vs externalValue, link.operationId
+// vs operationRef).
+type EitherFieldRequiredError struct {
+	// Fields is the set of field names, at least one of which must be
+	// set (e.g. ["value", "externalValue"]).
+	Fields []string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *EitherFieldRequiredError) Error() string { return e.Cause.Error() }
+func (e *EitherFieldRequiredError) Unwrap() error { return e.Cause }
+
 // MutuallyExclusiveFieldsError clusters "fields X and Y are both set,
 // only one is allowed" failures (example.value vs externalValue,
 // mediaType.example vs examples, license.url vs identifier,
@@ -262,6 +279,26 @@ func (e *ServerURLMismatchedBraces) As(target any) bool {
 type ServerURLUndeclaredVariables struct{ ValidationError }
 
 func (e *ServerURLUndeclaredVariables) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type SchemaItemsRequired struct{ ValidationError }
+
+func (e *SchemaItemsRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// EitherFieldRequiredError leaves.
+
+type ExampleValueOrExternalValueRequired struct{ ValidationError }
+
+func (e *ExampleValueOrExternalValueRequired) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type LinkOperationIDOrRefRequired struct{ ValidationError }
+
+func (e *LinkOperationIDOrRefRequired) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -615,6 +652,30 @@ func newServerURLUndeclaredVariables(serverURL string, origin *Origin) error {
 	const msg = "server has undeclared variables"
 	return newServerURLTemplateError(serverURL,
 		&ServerURLUndeclaredVariables{ValidationError{Message: msg}}, origin)
+}
+
+func newSchemaItemsRequired(origin *Origin) error {
+	const msg = "when schema type is 'array', schema 'items' must be non-null"
+	return newRequiredField("schema.items",
+		&SchemaItemsRequired{ValidationError{Message: msg}}, origin)
+}
+
+// newEitherFieldRequired wraps leaf in an *EitherFieldRequiredError
+// carrying the set of field names, at least one of which must be set.
+func newEitherFieldRequired(fields []string, leaf error, origin *Origin) error {
+	return &EitherFieldRequiredError{Fields: fields, Cause: leaf, Origin: origin}
+}
+
+func newExampleValueOrExternalValueRequired(origin *Origin) error {
+	const msg = "no value or externalValue field"
+	return newEitherFieldRequired([]string{"value", "externalValue"},
+		&ExampleValueOrExternalValueRequired{ValidationError{Message: msg}}, origin)
+}
+
+func newLinkOperationIDOrRefRequired(origin *Origin) error {
+	const msg = "missing operationId or operationRef on link"
+	return newEitherFieldRequired([]string{"operationId", "operationRef"},
+		&LinkOperationIDOrRefRequired{ValidationError{Message: msg}}, origin)
 }
 
 func newExternalDocsURLRequired(origin *Origin) error {

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -175,6 +175,23 @@ type MutuallyExclusiveFieldsError struct {
 func (e *MutuallyExclusiveFieldsError) Error() string { return e.Cause.Error() }
 func (e *MutuallyExclusiveFieldsError) Unwrap() error { return e.Cause }
 
+// ForbiddenFieldError clusters "field X must not be set in this
+// context" failures (header.name and header.in inside a Headers map,
+// OAuth flow URLs that don't apply to the chosen flow type).
+type ForbiddenFieldError struct {
+	// Field is the name of the forbidden field (e.g. "name", "in",
+	// "authorizationUrl", "tokenUrl").
+	Field string
+	// Cause is the underlying leaf error. Walked by errors.Unwrap.
+	Cause error
+	// Origin is the source location of the offending element when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *ForbiddenFieldError) Error() string { return e.Cause.Error() }
+func (e *ForbiddenFieldError) Unwrap() error { return e.Cause }
+
 // ---------------------------------------------------------------------
 // Leaf types — one per call site. Each embeds ValidationError for
 // Error() and As-to-base, and is wrapped in its cluster type when
@@ -289,6 +306,32 @@ func (e *LinkOperationIDRefExclusive) As(target any) bool {
 type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
 
 func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+// ForbiddenFieldError leaves.
+
+type HeaderNameForbidden struct{ ValidationError }
+
+func (e *HeaderNameForbidden) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type HeaderInForbidden struct{ ValidationError }
+
+func (e *HeaderInForbidden) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowAuthorizationURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowAuthorizationURLForbidden) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type OAuthFlowTokenURLForbidden struct{ ValidationError }
+
+func (e *OAuthFlowTokenURLForbidden) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -582,6 +625,36 @@ func newSchemaReadOnlyWriteOnlyExclusive(origin *Origin) error {
 	const msg = "a property MUST NOT be marked as both readOnly and writeOnly being true"
 	return newMutuallyExclusiveFields("readOnly", "writeOnly",
 		&SchemaReadOnlyWriteOnlyExclusive{ValidationError{Message: msg}}, origin)
+}
+
+// newForbiddenField wraps leaf in a *ForbiddenFieldError carrying the
+// name of the field that the spec forbids in the current context.
+func newForbiddenField(field string, leaf error, origin *Origin) error {
+	return &ForbiddenFieldError{Field: field, Cause: leaf, Origin: origin}
+}
+
+func newHeaderNameForbidden(origin *Origin) error {
+	const msg = "header 'name' MUST NOT be specified, it is given in the corresponding headers map"
+	return newForbiddenField("name",
+		&HeaderNameForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newHeaderInForbidden(origin *Origin) error {
+	const msg = "header 'in' MUST NOT be specified, it is implicitly in header"
+	return newForbiddenField("in",
+		&HeaderInForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newOAuthFlowAuthorizationURLForbidden(origin *Origin) error {
+	const msg = "field 'authorizationUrl' should not be set"
+	return newForbiddenField("authorizationUrl",
+		&OAuthFlowAuthorizationURLForbidden{ValidationError{Message: msg}}, origin)
+}
+
+func newOAuthFlowTokenURLForbidden(origin *Origin) error {
+	const msg = "field 'tokenUrl' should not be set"
+	return newForbiddenField("tokenUrl",
+		&OAuthFlowTokenURLForbidden{ValidationError{Message: msg}}, origin)
 }
 
 // newSchemaValueError wraps the result of schema.VisitJSON in a

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -918,3 +918,26 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 		require.True(t, errors.As(err, &leaf))
 	})
 }
+
+// Pin WebhookNilError cluster + leaf reachability for the
+// nil-pathitem webhook check in T.Validate.
+func TestValidationError_WebhookNilLeaf(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI:  "3.1.0",
+		Info:     &openapi3.Info{Title: "x", Version: "1.0.0"},
+		Paths:    openapi3.NewPaths(),
+		Webhooks: map[string]*openapi3.PathItem{"onEvent": nil},
+	}
+	err := doc.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+	require.EqualError(t, err, `invalid webhooks: webhook "onEvent" is nil`)
+
+	var wne *openapi3.WebhookNilError
+	require.True(t, errors.As(err, &wne))
+	require.Equal(t, "onEvent", wne.Name)
+
+	var leaf *openapi3.WebhookNil
+	require.True(t, errors.As(err, &leaf))
+
+	var ve *openapi3.ValidationError
+	require.True(t, errors.As(err, &ve))
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -490,3 +490,54 @@ func TestValidationError_FlowsThroughMultiError(t *testing.T) {
 	var ve *openapi3.ValidationError
 	require.True(t, errors.As(me, &ve))
 }
+
+// Pin MutuallyExclusiveFieldsError cluster + leaf reachability for the
+// four sites where two fields are forbidden from being set together.
+func TestValidationError_MutuallyExclusiveFieldsLeaves(t *testing.T) {
+	t.Run("example value vs externalValue", func(t *testing.T) {
+		ex := &openapi3.Example{Value: "v", ExternalValue: "https://x"}
+		err := ex.Validate(context.Background())
+		require.EqualError(t, err, "value and externalValue are mutually exclusive")
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "value", mef.Field1)
+		require.Equal(t, "externalValue", mef.Field2)
+
+		var leaf *openapi3.ExampleValueExternalValueExclusive
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("license url vs identifier", func(t *testing.T) {
+		// identifier is a 3.1+ field; opt in so the URL/identifier check
+		// is the one that fires.
+		lic := &openapi3.License{Name: "MIT", URL: "https://x", Identifier: "MIT"}
+		err := lic.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "license must not specify both 'url' and 'identifier'")
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "url", mef.Field1)
+		require.Equal(t, "identifier", mef.Field2)
+
+		var leaf *openapi3.LicenseURLIdentifierExclusive
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("link operationId vs operationRef", func(t *testing.T) {
+		link := &openapi3.Link{OperationID: "getX", OperationRef: "#/x"}
+		err := link.Validate(context.Background())
+		require.EqualError(t, err, `operationId "getX" and operationRef "#/x" are mutually exclusive`)
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "operationId", mef.Field1)
+		require.Equal(t, "operationRef", mef.Field2)
+
+		var leaf *openapi3.LinkOperationIDRefExclusive
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -856,7 +856,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 	t.Run("parameter content/schema exactly one (neither set)", func(t *testing.T) {
 		p := &openapi3.Parameter{Name: "p", In: "query"}
 		err := p.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+		require.ErrorContains(t, err, "parameter must contain exactly one of content and schema")
 
 		var efe *openapi3.ExactlyOneFieldError
 		require.True(t, errors.As(err, &efe))
@@ -875,7 +875,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 			},
 		}
 		err := p.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+		require.ErrorContains(t, err, "parameter content must only contain one entry")
 
 		var sec *openapi3.SingleEntryContentError
 		require.True(t, errors.As(err, &sec))
@@ -888,7 +888,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 	t.Run("header content/schema exactly one (neither set)", func(t *testing.T) {
 		h := &openapi3.Header{}
 		err := h.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+		require.ErrorContains(t, err, "parameter must contain exactly one of content and schema")
 
 		var efe *openapi3.ExactlyOneFieldError
 		require.True(t, errors.As(err, &efe))
@@ -908,7 +908,7 @@ func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
 			},
 		}
 		err := h.Validate(context.Background())
-		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+		require.ErrorContains(t, err, "parameter content must only contain one entry")
 
 		var sec *openapi3.SingleEntryContentError
 		require.True(t, errors.As(err, &sec))

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -636,3 +636,48 @@ func TestValidationError_ParameterAndAPIKeyNameLeaves(t *testing.T) {
 		require.True(t, errors.As(err, &leaf))
 	})
 }
+
+// Pin ServerURLTemplateError cluster + leaf reachability for the three
+// server URL template sites (mismatched braces, undeclared variables
+// in two flavours).
+func TestValidationError_ServerURLTemplateLeaves(t *testing.T) {
+	t.Run("mismatched braces", func(t *testing.T) {
+		s := &openapi3.Server{URL: "https://example.com/{x"}
+		err := s.Validate(context.Background())
+		require.EqualError(t, err, "server URL has mismatched { and }")
+
+		var sue *openapi3.ServerURLTemplateError
+		require.True(t, errors.As(err, &sue))
+		require.Equal(t, "https://example.com/{x", sue.URL)
+
+		var leaf *openapi3.ServerURLMismatchedBraces
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("undeclared variables (count mismatch)", func(t *testing.T) {
+		s := &openapi3.Server{URL: "https://example.com/{x}"} // no Variables declared
+		err := s.Validate(context.Background())
+		require.EqualError(t, err, "server has undeclared variables")
+
+		var sue *openapi3.ServerURLTemplateError
+		require.True(t, errors.As(err, &sue))
+
+		var leaf *openapi3.ServerURLUndeclaredVariables
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("undeclared variables (name mismatch)", func(t *testing.T) {
+		s := &openapi3.Server{
+			URL:       "https://example.com/{x}",
+			Variables: map[string]*openapi3.ServerVariable{"y": {Default: "z"}},
+		}
+		err := s.Validate(context.Background())
+		require.EqualError(t, err, "server has undeclared variables")
+
+		var leaf *openapi3.ServerURLUndeclaredVariables
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -555,3 +555,38 @@ func TestValidationError_MutuallyExclusiveFieldsLeaves(t *testing.T) {
 		require.True(t, errors.As(err, &leaf))
 	})
 }
+
+// Pin ForbiddenFieldError cluster + leaf reachability for the four
+// sites where a field is set but the spec forbids it in that context.
+func TestValidationError_ForbiddenFieldLeaves(t *testing.T) {
+	t.Run("header.name forbidden", func(t *testing.T) {
+		h := &openapi3.Header{Parameter: openapi3.Parameter{Name: "X-Trace"}}
+		err := h.Validate(context.Background())
+		require.EqualError(t, err,
+			"header 'name' MUST NOT be specified, it is given in the corresponding headers map")
+
+		var ffe *openapi3.ForbiddenFieldError
+		require.True(t, errors.As(err, &ffe))
+		require.Equal(t, "name", ffe.Field)
+
+		var leaf *openapi3.HeaderNameForbidden
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("header.in forbidden", func(t *testing.T) {
+		h := &openapi3.Header{Parameter: openapi3.Parameter{In: "header"}}
+		err := h.Validate(context.Background())
+		require.EqualError(t, err,
+			"header 'in' MUST NOT be specified, it is implicitly in header")
+
+		var ffe *openapi3.ForbiddenFieldError
+		require.True(t, errors.As(err, &ffe))
+		require.Equal(t, "in", ffe.Field)
+
+		var leaf *openapi3.HeaderInForbidden
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -176,6 +176,22 @@ func TestValidationError_AllRequiredFieldLeaves(t *testing.T) {
 			field:   "server.url",
 			message: "value of url must be a non-empty string",
 		},
+		{
+			name: "responses non-empty required",
+			doc: &openapi3.T{
+				OpenAPI: "3.0.3",
+				Info:    &openapi3.Info{Title: "x", Version: "1.0.0"},
+				Paths: openapi3.NewPaths(openapi3.WithPath("/p", &openapi3.PathItem{
+					Get: &openapi3.Operation{Responses: openapi3.NewResponses()},
+				})),
+			},
+			leafCheck: func(t *testing.T, err error) {
+				var l *openapi3.ResponsesNonEmptyRequired
+				require.True(t, errors.As(err, &l))
+			},
+			field:   "responses",
+			message: "the responses object MUST contain at least one response code",
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -587,6 +603,36 @@ func TestValidationError_ForbiddenFieldLeaves(t *testing.T) {
 		require.Equal(t, "in", ffe.Field)
 
 		var leaf *openapi3.HeaderInForbidden
+		require.True(t, errors.As(err, &leaf))
+	})
+}
+
+// Pin parameter.name and apiKey securityScheme.name leaves directly:
+// these check Validate on a single component (without wiring a full
+// document around it).
+func TestValidationError_ParameterAndAPIKeyNameLeaves(t *testing.T) {
+	t.Run("parameter name required", func(t *testing.T) {
+		err := (&openapi3.Parameter{}).Validate(context.Background())
+		require.EqualError(t, err, "parameter name can't be blank")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "parameter.name", rfe.Field)
+
+		var leaf *openapi3.ParameterNameRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("apiKey securityScheme name required", func(t *testing.T) {
+		ss := &openapi3.SecurityScheme{Type: "apiKey", In: "header"}
+		err := ss.Validate(context.Background())
+		require.EqualError(t, err, "security scheme of type 'apiKey' should have 'name'")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "securityScheme.name", rfe.Field)
+
+		var leaf *openapi3.APIKeySecuritySchemeNameRequired
 		require.True(t, errors.As(err, &leaf))
 	})
 }

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -729,3 +729,56 @@ func TestValidationError_SchemaItemsRequiredLeaf(t *testing.T) {
 	var leaf *openapi3.SchemaItemsRequired
 	require.True(t, errors.As(err, &leaf))
 }
+
+// Pin doc-root RequiredFieldError leaves: info, paths,
+// jsonSchemaDialect-must-be-absolute-URI.
+func TestValidationError_DocRootRequiredLeaves(t *testing.T) {
+	t.Run("info required", func(t *testing.T) {
+		// doc with no Info — fails with the wrap "invalid info: must be an object".
+		doc := &openapi3.T{OpenAPI: "3.0.3", Paths: openapi3.NewPaths()}
+		err := doc.Validate(context.Background())
+		require.EqualError(t, err, "invalid info: must be an object")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "info", rfe.Field)
+
+		var leaf *openapi3.InfoRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("paths required (3.0)", func(t *testing.T) {
+		// 3.0 doc with no Paths — fails with "invalid paths: must be an object".
+		doc := &openapi3.T{
+			OpenAPI: "3.0.3",
+			Info:    &openapi3.Info{Title: "x", Version: "1.0.0"},
+		}
+		err := doc.Validate(context.Background())
+		require.EqualError(t, err, "invalid paths: must be an object")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "paths", rfe.Field)
+
+		var leaf *openapi3.PathsRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("jsonSchemaDialect must be absolute URI", func(t *testing.T) {
+		doc := &openapi3.T{
+			OpenAPI:           "3.1.0",
+			Info:              &openapi3.Info{Title: "x", Version: "1.0.0"},
+			Paths:             openapi3.NewPaths(),
+			JSONSchemaDialect: "no-scheme/relative",
+		}
+		err := doc.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "invalid jsonSchemaDialect: must be an absolute URI with a scheme")
+
+		var rfe *openapi3.RequiredFieldError
+		require.True(t, errors.As(err, &rfe))
+		require.Equal(t, "jsonSchemaDialect", rfe.Field)
+
+		var leaf *openapi3.JSONSchemaDialectAbsoluteURIRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -849,3 +849,72 @@ func TestValidationError_SchemaBothFormsLeaves(t *testing.T) {
 		require.True(t, errors.As(err, &leaf))
 	})
 }
+
+// Pin ExactlyOneFieldError and SingleEntryContentError clusters for
+// the four parameter/header content+schema sites.
+func TestValidationError_ParameterHeaderContentSchemaLeaves(t *testing.T) {
+	t.Run("parameter content/schema exactly one (neither set)", func(t *testing.T) {
+		p := &openapi3.Parameter{Name: "p", In: "query"}
+		err := p.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+
+		var efe *openapi3.ExactlyOneFieldError
+		require.True(t, errors.As(err, &efe))
+		require.Equal(t, []string{"content", "schema"}, efe.Fields)
+
+		var leaf *openapi3.ParameterContentSchemaExactlyOne
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("parameter content single entry", func(t *testing.T) {
+		p := &openapi3.Parameter{
+			Name: "p", In: "query",
+			Content: openapi3.Content{
+				"application/json": &openapi3.MediaType{},
+				"application/xml":  &openapi3.MediaType{},
+			},
+		}
+		err := p.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+
+		var sec *openapi3.SingleEntryContentError
+		require.True(t, errors.As(err, &sec))
+		require.Equal(t, "parameter", sec.Subject)
+
+		var leaf *openapi3.ParameterContentSingleEntry
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("header content/schema exactly one (neither set)", func(t *testing.T) {
+		h := &openapi3.Header{}
+		err := h.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter must contain exactly one of content and schema")
+
+		var efe *openapi3.ExactlyOneFieldError
+		require.True(t, errors.As(err, &efe))
+		require.Equal(t, []string{"content", "schema"}, efe.Fields)
+
+		var leaf *openapi3.HeaderContentSchemaExactlyOne
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("header content single entry", func(t *testing.T) {
+		h := &openapi3.Header{
+			Parameter: openapi3.Parameter{
+				Content: openapi3.Content{
+					"application/json": &openapi3.MediaType{},
+					"application/xml":  &openapi3.MediaType{},
+				},
+			},
+		}
+		err := h.Validate(context.Background())
+		require.Contains(t, err.Error(), "parameter content must only contain one entry")
+
+		var sec *openapi3.SingleEntryContentError
+		require.True(t, errors.As(err, &sec))
+		require.Equal(t, "header", sec.Subject)
+
+		var leaf *openapi3.HeaderContentSingleEntry
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -782,3 +782,70 @@ func TestValidationError_DocRootRequiredLeaves(t *testing.T) {
 		require.True(t, errors.As(err, &leaf))
 	})
 }
+
+// Pin SchemaBothFormsExclusive cluster + leaf reachability for the
+// three union-typed schema fields set to both boolean and schema forms.
+func TestValidationError_SchemaBothFormsLeaves(t *testing.T) {
+	t.Run("additionalProperties both forms", func(t *testing.T) {
+		yes := true
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			AdditionalProperties: openapi3.AdditionalProperties{
+				Has:    &yes,
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		err := schema.Validate(context.Background())
+		require.EqualError(t, err, "additionalProperties are set to both boolean and schema")
+
+		var sbf *openapi3.SchemaBothFormsExclusive
+		require.True(t, errors.As(err, &sbf))
+		require.Equal(t, "additionalProperties", sbf.Field)
+
+		var leaf *openapi3.SchemaAdditionalPropertiesBothForms
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("unevaluatedItems both forms", func(t *testing.T) {
+		yes := true
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			UnevaluatedItems: openapi3.BoolSchema{
+				Has:    &yes,
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "unevaluatedItems is set to both boolean and schema")
+
+		var sbf *openapi3.SchemaBothFormsExclusive
+		require.True(t, errors.As(err, &sbf))
+		require.Equal(t, "unevaluatedItems", sbf.Field)
+
+		var leaf *openapi3.SchemaUnevaluatedItemsBothForms
+		require.True(t, errors.As(err, &leaf))
+	})
+
+	t.Run("unevaluatedProperties both forms", func(t *testing.T) {
+		yes := true
+		schema := &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			UnevaluatedProperties: openapi3.BoolSchema{
+				Has:    &yes,
+				Schema: &openapi3.SchemaRef{Value: &openapi3.Schema{}},
+			},
+		}
+		err := schema.Validate(context.Background(), openapi3.IsOpenAPI31OrLater())
+		require.EqualError(t, err, "unevaluatedProperties is set to both boolean and schema")
+
+		var sbf *openapi3.SchemaBothFormsExclusive
+		require.True(t, errors.As(err, &sbf))
+		require.Equal(t, "unevaluatedProperties", sbf.Field)
+
+		var leaf *openapi3.SchemaUnevaluatedPropertiesBothForms
+		require.True(t, errors.As(err, &leaf))
+	})
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -681,3 +681,51 @@ func TestValidationError_ServerURLTemplateLeaves(t *testing.T) {
 		require.True(t, errors.As(err, &leaf))
 	})
 }
+
+// Pin EitherFieldRequiredError cluster + leaf reachability for the
+// two "at least one of these fields must be set" sites.
+func TestValidationError_EitherFieldRequiredLeaves(t *testing.T) {
+	t.Run("example value or externalValue", func(t *testing.T) {
+		ex := &openapi3.Example{}
+		err := ex.Validate(context.Background())
+		require.EqualError(t, err, "no value or externalValue field")
+
+		var efr *openapi3.EitherFieldRequiredError
+		require.True(t, errors.As(err, &efr))
+		require.Equal(t, []string{"value", "externalValue"}, efr.Fields)
+
+		var leaf *openapi3.ExampleValueOrExternalValueRequired
+		require.True(t, errors.As(err, &leaf))
+
+		var ve *openapi3.ValidationError
+		require.True(t, errors.As(err, &ve))
+	})
+
+	t.Run("link operationId or operationRef", func(t *testing.T) {
+		link := &openapi3.Link{}
+		err := link.Validate(context.Background())
+		require.EqualError(t, err, "missing operationId or operationRef on link")
+
+		var efr *openapi3.EitherFieldRequiredError
+		require.True(t, errors.As(err, &efr))
+		require.Equal(t, []string{"operationId", "operationRef"}, efr.Fields)
+
+		var leaf *openapi3.LinkOperationIDOrRefRequired
+		require.True(t, errors.As(err, &leaf))
+	})
+}
+
+// Pin SchemaItemsRequired leaf reachability via the existing
+// RequiredFieldError cluster.
+func TestValidationError_SchemaItemsRequiredLeaf(t *testing.T) {
+	schema := &openapi3.Schema{Type: &openapi3.Types{"array"}}
+	err := schema.Validate(context.Background())
+	require.EqualError(t, err, "when schema type is 'array', schema 'items' must be non-null")
+
+	var rfe *openapi3.RequiredFieldError
+	require.True(t, errors.As(err, &rfe))
+	require.Equal(t, "schema.items", rfe.Field)
+
+	var leaf *openapi3.SchemaItemsRequired
+	require.True(t, errors.As(err, &leaf))
+}

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -540,4 +540,18 @@ func TestValidationError_MutuallyExclusiveFieldsLeaves(t *testing.T) {
 		var leaf *openapi3.LinkOperationIDRefExclusive
 		require.True(t, errors.As(err, &leaf))
 	})
+
+	t.Run("schema readOnly vs writeOnly", func(t *testing.T) {
+		schema := &openapi3.Schema{ReadOnly: true, WriteOnly: true}
+		err := schema.Validate(context.Background())
+		require.EqualError(t, err, "a property MUST NOT be marked as both readOnly and writeOnly being true")
+
+		var mef *openapi3.MutuallyExclusiveFieldsError
+		require.True(t, errors.As(err, &mef))
+		require.Equal(t, "readOnly", mef.Field1)
+		require.Equal(t, "writeOnly", mef.Field2)
+
+		var leaf *openapi3.SchemaReadOnlyWriteOnlyExclusive
+		require.True(t, errors.As(err, &leaf))
+	})
 }


### PR DESCRIPTION
Per @fenollp's request on #1177, this combines the nine stacked typed-validation-error PRs (#1171-#1179) into a single branch to avoid rebase churn.

## What's combined

| Was | Cluster / leaves |
|---|---|
| #1171 | `MutuallyExclusiveFieldsError` — example.value/externalValue, mediaType.example/examples, license.url/identifier, link.operationId/operationRef, schema.readOnly/writeOnly |
| #1172 | `ForbiddenFieldError` — header.name, header.in, OAuth flow auth/token URLs |
| #1173 | `RequiredFieldError` leaves — parameter.name, responses non-empty, apiKey securityScheme.name |
| #1174 | `ServerURLTemplateError` — mismatched braces, undeclared variables (count + name flavours) |
| #1175 | `EitherFieldRequiredError` + `SchemaItemsRequired` — example value-or-externalValue, link operationId-or-Ref, schema.items required when type=array |
| #1176 | `RequiredFieldError` leaves — doc-root info, paths (3.0), jsonSchemaDialect URI |
| #1177 | `SchemaBothFormsExclusive` — additionalProperties, unevaluatedItems, unevaluatedProperties (boolean + schema both set) |
| #1178 | `ExactlyOneFieldError` + `SingleEntryContentError` — parameter/header content+schema sites |
| #1179 | `WebhookNilError` — nil pathitem in T.Validate webhook walk |

Each PR's commit is preserved as a separate commit on this branch (with one small `docs: regenerate openapi3.txt` commit at the tip and a `test: use require.ErrorContains per repo lint` follow-up that was on #1178). Author / date / commit message of each original commit are preserved.

## Verification

- `go test ./...` clean across all packages
- All cluster types and leaves grep-verifiable in `openapi3/validation_error.go`
- Backward-compat error strings preserved (existing string-matching consumers unaffected)
- `.github/docs/openapi3.txt` regenerated via `./docs.sh`

#1171-#1179 are closed in favour of this PR.