### PR TITLE
openapi3: track Origin on the document root (T)

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -2824,6 +2824,7 @@ func (stringMap *StringMap[V]) UnmarshalJSON(data []byte) (err error)
 
 type T struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
+	Origin     *Origin        `json:"-" yaml:"-"`
 
 	OpenAPI           string               `json:"openapi" yaml:"openapi"` // Required
 	Components        *Components          `json:"components,omitempty" yaml:"components,omitempty"`

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -16,6 +16,7 @@ import (
 // and https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md#openapi-object
 type T struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
+	Origin     *Origin        `json:"-" yaml:"-"`
 
 	OpenAPI           string               `json:"openapi" yaml:"openapi"` // Required
 	Components        *Components          `json:"components,omitempty" yaml:"components,omitempty"`
@@ -268,14 +269,14 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 	ctx = WithValidationOptions(ctx, opts...)
 
 	if doc.OpenAPI == "" {
-		return newOpenAPIVersionRequired()
+		return newOpenAPIVersionRequired(doc.Origin)
 	}
 
 	if doc.Webhooks != nil && !doc.IsOpenAPI31OrLater() {
-		return newWebhooksFieldFor31Plus()
+		return newWebhooksFieldFor31Plus(doc.Origin)
 	}
 	if doc.JSONSchemaDialect != "" && !doc.IsOpenAPI31OrLater() {
-		return newJSONSchemaDialectFieldFor31Plus()
+		return newJSONSchemaDialectFieldFor31Plus(doc.Origin)
 	}
 
 	var wrap func(error) error
@@ -293,7 +294,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 	} else {
-		return wrap(newInfoRequired())
+		return wrap(newInfoRequired(doc.Origin))
 	}
 
 	wrap = func(e error) error { return &SectionValidationError{Section: "paths", Cause: e} }
@@ -302,7 +303,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 	} else if doc.IsOpenAPI30() {
-		return wrap(newPathsRequired())
+		return wrap(newPathsRequired(doc.Origin))
 	}
 
 	wrap = func(e error) error { return &SectionValidationError{Section: "security", Cause: e} }
@@ -351,7 +352,7 @@ func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 			return wrap(err)
 		}
 		if u.Scheme == "" {
-			return wrap(newJSONSchemaDialectAbsoluteURIRequired())
+			return wrap(newJSONSchemaDialectAbsoluteURIRequired(doc.Origin))
 		}
 	}
 

--- a/openapi3/origin_test.go
+++ b/openapi3/origin_test.go
@@ -10,6 +10,27 @@ import (
 
 const originKey = "__origin__"
 
+func TestOrigin_T(t *testing.T) {
+	loader := openapi3.NewLoader()
+	loader.IsExternalRefsAllowed = true
+	loader.IncludeOrigin = true
+	loader.Context = t.Context()
+
+	doc, err := loader.LoadFromFile("testdata/origin/simple.yaml")
+	require.NoError(t, err)
+
+	require.NotNil(t, doc.Origin)
+	require.NotNil(t, doc.Origin.Key)
+	require.Equal(t,
+		openapi3.Location{
+			File:   "testdata/origin/simple.yaml",
+			Line:   1,
+			Column: 1,
+			Name:   "openapi",
+		},
+		doc.Origin.Fields["openapi"])
+}
+
 func TestOrigin_Info(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IsExternalRefsAllowed = true

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -761,11 +761,9 @@ func newLicenseNameRequired(origin *Origin) error {
 		&LicenseNameRequired{ValidationError{Message: "value of license name must be a non-empty string"}}, origin)
 }
 
-// newOpenAPIVersionRequired has no Origin parameter: the OpenAPI version
-// string lives on the document root *T, which the loader doesn't track.
-func newOpenAPIVersionRequired() error {
+func newOpenAPIVersionRequired(origin *Origin) error {
 	return newRequiredField("openapi",
-		&OpenAPIVersionRequired{ValidationError{Message: "value of openapi must be a non-empty string"}}, nil)
+		&OpenAPIVersionRequired{ValidationError{Message: "value of openapi must be a non-empty string"}}, origin)
 }
 
 func newServerURLRequired(origin *Origin) error {
@@ -815,21 +813,19 @@ func newLinkOperationIDOrRefRequired(origin *Origin) error {
 		&LinkOperationIDOrRefRequired{ValidationError{Message: msg}}, origin)
 }
 
-// newInfoRequired and newPathsRequired don't take Origin: both fields
-// live on the document root *T, which the loader doesn't track.
-func newInfoRequired() error {
+func newInfoRequired(origin *Origin) error {
 	return newRequiredField("info",
-		&InfoRequired{ValidationError{Message: "must be an object"}}, nil)
+		&InfoRequired{ValidationError{Message: "must be an object"}}, origin)
 }
 
-func newPathsRequired() error {
+func newPathsRequired(origin *Origin) error {
 	return newRequiredField("paths",
-		&PathsRequired{ValidationError{Message: "must be an object"}}, nil)
+		&PathsRequired{ValidationError{Message: "must be an object"}}, origin)
 }
 
-func newJSONSchemaDialectAbsoluteURIRequired() error {
+func newJSONSchemaDialectAbsoluteURIRequired(origin *Origin) error {
 	return newRequiredField("jsonSchemaDialect",
-		&JSONSchemaDialectAbsoluteURIRequired{ValidationError{Message: "must be an absolute URI with a scheme"}}, nil)
+		&JSONSchemaDialectAbsoluteURIRequired{ValidationError{Message: "must be an absolute URI with a scheme"}}, origin)
 }
 
 // newSchemaBothForms wraps leaf in a *SchemaBothFormsExclusive carrying
@@ -1065,19 +1061,16 @@ func newLicenseIdentifierFieldFor31Plus(origin *Origin) error {
 		&LicenseIdentifierFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
-// newWebhooksFieldFor31Plus and newJSONSchemaDialectFieldFor31Plus have no
-// Origin parameter: both fields live on the document root *T, which the
-// loader doesn't track.
-func newWebhooksFieldFor31Plus() error {
+func newWebhooksFieldFor31Plus(origin *Origin) error {
 	const msg = "field webhooks is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("webhooks",
-		&WebhooksFieldFor31Plus{ValidationError{Message: msg}}, nil)
+		&WebhooksFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
-func newJSONSchemaDialectFieldFor31Plus() error {
+func newJSONSchemaDialectFieldFor31Plus(origin *Origin) error {
 	const msg = "field jsonschemadialect is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("jsonschemadialect",
-		&JSONSchemaDialectFieldFor31Plus{ValidationError{Message: msg}}, nil)
+		&JSONSchemaDialectFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
 // fieldFor31PlusLeaves maps field names (as passed to errFieldFor31Plus)

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -360,10 +360,11 @@ paths: {}
 }
 
 // Document-root fields (openapi, webhooks, jsonSchemaDialect) live on
-// *T which the loader doesn't track, so their Origin is always nil
-// even when IncludeOrigin is enabled. Pinned so callers know to fall
-// back to file-only when the field is at the doc root.
-func TestValidationError_OriginNilForDocumentRootFields(t *testing.T) {
+// *T, which now carries an Origin when IncludeOrigin is set. Their
+// RequiredFieldError / FieldVersionMismatchError therefore carries the
+// document's Origin: scalar root fields resolve precisely via
+// Origin.Fields; object/missing root fields fall back to Origin.Key.
+func TestValidationError_OriginForDocumentRootFields(t *testing.T) {
 	loader := openapi3.NewLoader()
 	loader.IncludeOrigin = true
 	doc, err := loader.LoadFromData([]byte(`
@@ -379,7 +380,10 @@ paths: {}
 	var rfe *openapi3.RequiredFieldError
 	require.True(t, errors.As(verr, &rfe))
 	require.Equal(t, "openapi", rfe.Field)
-	require.Nil(t, rfe.Origin, "doc-root fields have no Origin (loader doesn't track *T)")
+	require.NotNil(t, rfe.Origin, "doc-root fields now carry the document's Origin")
+	require.Same(t, doc.Origin, rfe.Origin, "the error carries T.Origin")
+	require.Greater(t, rfe.Origin.Fields["openapi"].Line, 0,
+		`Origin.Fields["openapi"] locates the openapi: line`)
 }
 
 // SchemaValueError clusters "<schema field>'s example/default value


### PR DESCRIPTION
## Why

Every element struct in `openapi3` (`Info`, `License`, `Paths`, `Operation`, ...) carries an `Origin` so consumers can attach file/line/column to it. `T` itself does not. As a result the document-root fields (`openapi`, `info`, `paths`, `webhooks`, `jsonSchemaDialect`) have no source location, even when the document is loaded with `Loader.IncludeOrigin = true`. A consumer reporting "openapi is required" can name the file but not the line.

## What

**Add `Origin *Origin` to `T`.** No loader change is needed: `yaml3` already injects an `__origin__` entry into the document's root mapping, `oasdiff/yaml` already surfaces it as the root `OriginTree.Origin`, and `applyOriginsToStruct` already sets the `Origin` field on any struct that has one tagged `json:"-"`. `T` simply never had the field.

**Wire it into the doc-root validation errors.** The six constructors for doc-root findings previously passed `nil` for origin (their comments said the loader "doesn't track" `*T`, now obsolete):

- `newOpenAPIVersionRequired`
- `newInfoRequired`
- `newPathsRequired`
- `newJSONSchemaDialectAbsoluteURIRequired`
- `newWebhooksFieldFor31Plus`
- `newJSONSchemaDialectFieldFor31Plus`

Each now takes an `origin *Origin`, and `T.Validate` passes `doc.Origin`. The resulting `RequiredFieldError` / `FieldVersionMismatchError` carries it like every other typed error.

Resolution granularity matches kin's existing `Origin` model:
- **Scalar** root fields (`openapi`, `jsonSchemaDialect`) resolve precisely via `Origin.Fields[name]`.
- **Object / missing** root fields (`info`, `paths`, `webhooks`) fall back to `Origin.Key` (the document root) — still a file and position, just not the exact key.

## Compatibility

`Error()` strings are unchanged. The new field is `json:"-" yaml:"-"`, so marshalling is unaffected, and `Origin` is only populated when `IncludeOrigin` is set (opt-in, as before).

## Tests

- `TestOrigin_T` — `doc.Origin` is populated; `Origin.Fields["openapi"]` resolves to the `openapi:` line.
- `TestValidationError_OriginForDocumentRootFields` — replaces `TestValidationError_OriginNilForDocumentRootFields`, which pinned the old "doc-root fields have nil Origin" behavior; now asserts the doc-root error carries `T.Origin`.

Full suite green; `.github/docs/openapi3.txt` regenerated.
