### PR TITLE
openapi3: cache compiled JSON Schema 2020-12 validator per *Schema

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -45,7 +45,8 @@ var (
 	// ErrSchemaInputInf may be returned when validating a number
 	ErrSchemaInputInf = errors.New("floating point Inf is not allowed")
 
-	compiledPatterns sync.Map
+	compiledPatterns             sync.Map // map[string]*regexp.Regexp
+	compiledJSONSchemaValidators sync.Map // map[*Schema]*jsonSchemaValidator
 )
 
 // NewSchemaRef simply builds a SchemaRef

--- a/openapi3/schema_jsonschema_validator.go
+++ b/openapi3/schema_jsonschema_validator.go
@@ -200,13 +200,31 @@ func formatValidationError(verr *jsonschema.ValidationError, parentPath string) 
 	}
 }
 
-// useJSONSchema2020 validates using the JSON Schema 2020-12 validator
+// useJSONSchema2020 validates using the JSON Schema 2020-12 validator.
+//
+// The compiled validator is cached in [compiledJSONSchemaValidators] so that
+// the (expensive) compilation cost is paid once per *Schema rather than once
+// per call. NOTE: racey WRT mutations to *Schema fields after the first
+// call -- mirrors the assumption already made by [compiledPatterns].
 func (schema *Schema) useJSONSchema2020(settings *schemaValidationSettings, value any) error {
+	if cached, ok := compiledJSONSchemaValidators.Load(schema); ok {
+		return cached.(*jsonSchemaValidator).validate(value)
+	}
+
 	validator, err := newJSONSchemaValidator(schema)
 	if err != nil {
-		// Fall back to built-in validator if compilation fails
+		// Fall back to built-in validator if compilation fails. Compilation
+		// failures are not cached: the compiler is deterministic given the
+		// schema, so if it fails once it will fail again, but caching the
+		// failure would require a sentinel value and the fall-through path
+		// is rare enough that the extra complexity is not worth it.
 		return schema.visitJSON(settings, value)
 	}
 
-	return validator.validate(value)
+	// LoadOrStore so that two goroutines racing on the first compilation for
+	// a given schema converge on a single cached validator. Either compiled
+	// validator is functionally identical, so it is safe to discard ours if
+	// another goroutine stored first.
+	actual, _ := compiledJSONSchemaValidators.LoadOrStore(schema, validator)
+	return actual.(*jsonSchemaValidator).validate(value)
 }

--- a/openapi3/schema_jsonschema_validator.go
+++ b/openapi3/schema_jsonschema_validator.go
@@ -202,10 +202,10 @@ func formatValidationError(verr *jsonschema.ValidationError, parentPath string) 
 
 // useJSONSchema2020 validates using the JSON Schema 2020-12 validator.
 //
-// The compiled validator is cached in [compiledJSONSchemaValidators] so that
-// the (expensive) compilation cost is paid once per *Schema rather than once
-// per call. NOTE: racey WRT mutations to *Schema fields after the first
-// call -- mirrors the assumption already made by [compiledPatterns].
+// The compiled validator is cached in compiledJSONSchemaValidators by the address
+// of the Schema object. Note that this validator is cached on first construction,
+// and any changes ot the Schema object will not be reflected in the validator used
+// later in the program.
 func (schema *Schema) useJSONSchema2020(settings *schemaValidationSettings, value any) error {
 	if cached, ok := compiledJSONSchemaValidators.Load(schema); ok {
 		return cached.(*jsonSchemaValidator).validate(value)

--- a/openapi3/schema_jsonschema_validator.go
+++ b/openapi3/schema_jsonschema_validator.go
@@ -216,10 +216,7 @@ func (schema *Schema) useJSONSchema2020(settings *schemaValidationSettings, valu
 		return schema.visitJSON(settings, value)
 	}
 
-	// LoadOrStore so that two goroutines racing on the first compilation for
-	// a given schema converge on a single cached validator. Either compiled
-	// validator is functionally identical, so it is safe to discard ours if
-	// another goroutine stored first.
-	actual, _ := compiledJSONSchemaValidators.LoadOrStore(schema, validator)
-	return actual.(*jsonSchemaValidator).validate(value)
+	compiledJSONSchemaValidators.Store(schema, validator)
+
+	return validator.validate(value)
 }

--- a/openapi3/schema_jsonschema_validator.go
+++ b/openapi3/schema_jsonschema_validator.go
@@ -213,11 +213,6 @@ func (schema *Schema) useJSONSchema2020(settings *schemaValidationSettings, valu
 
 	validator, err := newJSONSchemaValidator(schema)
 	if err != nil {
-		// Fall back to built-in validator if compilation fails. Compilation
-		// failures are not cached: the compiler is deterministic given the
-		// schema, so if it fails once it will fail again, but caching the
-		// failure would require a sentinel value and the fall-through path
-		// is rare enough that the extra complexity is not worth it.
 		return schema.visitJSON(settings, value)
 	}
 

--- a/openapi3/schema_jsonschema_validator_cache_test.go
+++ b/openapi3/schema_jsonschema_validator_cache_test.go
@@ -1,0 +1,24 @@
+package openapi3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaJSONSchema2020ValidatorCache(t *testing.T) {
+	schema := &Schema{Type: &Types{"string"}}
+
+	require.NoError(t, schema.useJSONSchema2020(&schemaValidationSettings{useJSONSchema2020: true}, "hello"))
+
+	// The compiled validator should be cached
+	v, ok := compiledJSONSchemaValidators.Load(schema)
+	require.True(t, ok)
+	require.NotNil(t, v)
+
+	// A second call should reuse the same compiled validator
+	require.NoError(t, schema.useJSONSchema2020(&schemaValidationSettings{useJSONSchema2020: true}, "world"))
+	v2, ok := compiledJSONSchemaValidators.Load(schema)
+	require.True(t, ok)
+	require.Same(t, v, v2)
+}


### PR DESCRIPTION
`useJSONSchema2020` calls `newJSONSchemaValidator(schema)` on every invocation. Compilation is expensive (marshal → unmarshal → keyword transform → `jsonschema.Compile`), and `openapi3filter` automatically takes this path for every OpenAPI 3.1 request, making it dominant per-request overhead for long-lived servers.

This PR caches the compiled `*jsonSchemaValidator` in a package-level `sync.Map` keyed by `*Schema`: first call compiles, subsequent calls do a single `Load`, races converge via `LoadOrStore`. Compilation failures are not cached (deterministic given the schema; sentinel value not worth the complexity).

## Benchmark

Scratch benchmark validating a small object schema repeatedly (`darwin/arm64`, M4 Pro, `-benchtime=2s`):

| | ns/op | B/op | allocs/op |
|---|---:|---:|---:|
| Before | 39,030 | 59,628 | 714 |
| After |    832 |  1,434 |  34 |
| | **~47×** | **~42×** | **~21×** |

<details><summary>benchmark source</summary>

```go
package openapi3_test

import (
    "testing"

    "github.com/getkin/kin-openapi/openapi3"
)

func BenchmarkJSONSchema2020Validator(b *testing.B) {
    maxLen := uint64(64)
    age0, age150 := float64(0), float64(150)
    schema := &openapi3.Schema{
        Type: &openapi3.Types{"object"},
        Properties: openapi3.Schemas{
            "name":  &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}, MinLength: 1, MaxLength: &maxLen}},
            "age":   &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}, Min: &age0, Max: &age150}},
            "email": &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}, Format: "email"}},
        },
        Required: []string{"name", "age"},
    }
    value := map[string]any{"name": "Jane Doe", "age": 30, "email": "jane@example.com"}

    if err := schema.VisitJSON(value, openapi3.EnableJSONSchema2020()); err != nil {
        b.Fatal(err)
    }
    b.ResetTimer()
    for i := 0; i < b.N; i++ {
        if err := schema.VisitJSON(value, openapi3.EnableJSONSchema2020()); err != nil {
            b.Fatal(err)
        }
    }
}
```

</details>