### PR TITLE
openapi3: fix validation of duplicated path templates

### DIFF
--- a/openapi3/paths.go
+++ b/openapi3/paths.go
@@ -73,7 +73,7 @@ func (paths *Paths) Validate(ctx context.Context, opts ...ValidationOption) erro
 			// identical findings without new information.
 			continue
 		}
-		normalizedPaths[path] = path
+		normalizedPaths[normalizedPath] = path
 
 		var commonParams []string
 		for _, parameterRef := range pathItem.Parameters {

--- a/openapi3/testdata/apis_guru_openapi_directory/amazonaws_com_apigateway_2015_07_09_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/amazonaws_com_apigateway_2015_07_09_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/restapis/{restapi_id}/resources/{resource_id}" and "/restapis/{restapi_id}/resources/{parent_id}"

--- a/openapi3/testdata/apis_guru_openapi_directory/amazonaws_com_backup_2018_11_15_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/amazonaws_com_backup_2018_11_15_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/audit/report-jobs/{reportPlanName}" and "/audit/report-jobs/{reportJobId}"

--- a/openapi3/testdata/apis_guru_openapi_directory/carbone_io_1_2_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/carbone_io_1_2_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/render/{templateId}" and "/render/{renderId}"

--- a/openapi3/testdata/apis_guru_openapi_directory/circuitsandbox_net_2_9_235_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/circuitsandbox_net_2_9_235_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/spaces/{spaceId}/participant" and "/spaces/{id}/participant"

--- a/openapi3/testdata/apis_guru_openapi_directory/healthcare_gov_1_0_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/healthcare_gov_1_0_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/es/{stateName}{mediaTypeExtension}" and "/es/{pageName}{mediaTypeExtension}"

--- a/openapi3/testdata/apis_guru_openapi_directory/jellyfin_local_v1_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/jellyfin_local_v1_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/Items/{itemId}/RemoteSearch/Subtitles/{subtitleId}" and "/Items/{itemId}/RemoteSearch/Subtitles/{language}"

--- a/openapi3/testdata/apis_guru_openapi_directory/magento_com_2_2_10_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/magento_com_2_2_10_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/V1/bundle-products/{sku}/links/{optionId}" and "/V1/bundle-products/{sku}/links/{id}"

--- a/openapi3/testdata/apis_guru_openapi_directory/reverb_com_3_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/reverb_com_3_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/conversations/{id}/offer" and "/conversations/{conversation_id}/offer"

--- a/openapi3/testdata/apis_guru_openapi_directory/signl4_com_v1_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/signl4_com_v1_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/teams/{teamId}/schedules/{scheduleId}" and "/teams/{teamId}/schedules/{dutyId}"

--- a/openapi3/testdata/apis_guru_openapi_directory/trello_com_1_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/trello_com_1_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/boards/{idBoard}/cards/{idCard}" and "/boards/{idBoard}/cards/{filter}"

--- a/openapi3/testdata/apis_guru_openapi_directory/visma_net_9_66_02_1023_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/visma_net_9_66_02_1023_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/controller/api/v1/inventory/internal/{inventoryId}" and "/controller/api/v1/inventory/internal/{inventoryID}"

--- a/openapi3/testdata/apis_guru_openapi_directory/vtex_local_Catalog_API_1_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/vtex_local_Catalog_API_1_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/api/catalog/pvt/subcollection/{subCollectionId}/brand/{categoryId}" and "/api/catalog/pvt/subcollection/{subCollectionId}/brand/{brandId}"

--- a/openapi3/testdata/apis_guru_openapi_directory/vtex_local_Catalog_API_Seller_Portal_1_0_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/vtex_local_Catalog_API_Seller_Portal_1_0_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/api/catalog-seller-portal/products/{productId}" and "/api/catalog-seller-portal/products/{param}"

--- a/openapi3/testdata/apis_guru_openapi_directory/vtex_local_GiftCard_Hub_API_1_0_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/vtex_local_GiftCard_Hub_API_1_0_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid paths: conflicting paths "/giftcardproviders/{giftCardProviderId}" and "/giftcardproviders/{giftCardProviderID}"


### PR DESCRIPTION
Extracted from #1187 per @fenollp review.

## Bug

`Paths.Validate` keeps a dedup map to detect two paths that template to the same canonical form (`/users/{id}` vs `/users/{name}`). The lookup keys on the normalized path, but the insertion was keyed on the literal path:

```go
if oldPath, ok := normalizedPaths[normalizedPath]; ok {   // lookup: normalized
    return fmt.Errorf("conflicting paths %q and %q", path, oldPath)
}
normalizedPaths[path] = path                              // insert: literal  ← bug
```

Each conflicting path got its own literal-keyed entry, so the lookup never matched. The check was unreachable.

## Fix

One line: key the insertion on the normalized path, matching the lookup. Error text and types are unchanged; the path was just never being reached.

## Impact

Across `testdata/APIs-guru-openapi-directory`, 14 real-world specs are now correctly reported as having conflicting paths (their new `__validate` goldens pin the corrected behaviour). No other golden fixture moves.