### PR TITLE
openapi3: document that a custom ReadFromURIFunc bypasses IsExternalRefsAllowed

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -1276,7 +1276,9 @@ func (links *Links) UnmarshalJSON(data []byte) (err error)
     UnmarshalJSON sets Links to a copy of data.
 
 type Loader struct {
-	// IsExternalRefsAllowed enables visiting other files
+	// IsExternalRefsAllowed enables visiting other files. Enforced only when
+	// ReadFromURIFunc is nil; a custom ReadFromURIFunc bypasses this flag and
+	// owns the access policy itself — see ReadFromURIFunc.
 	IsExternalRefsAllowed bool
 
 	// IncludeOrigin enables recording the file/line/column of each OpenAPI element.
@@ -1284,7 +1286,16 @@ type Loader struct {
 	// concurrent use.
 	IncludeOrigin bool
 
-	// ReadFromURIFunc allows overriding the any file/URL reading func
+	// ReadFromURIFunc overrides how the loader reads a referenced file or URL.
+	//
+	// SECURITY: when a custom ReadFromURIFunc is set, IsExternalRefsAllowed is
+	// NOT enforced — this function alone decides which locations may be read. A
+	// func that reads whatever URI it is handed (e.g. by delegating to
+	// DefaultReadFromURI) resolves external $refs even when IsExternalRefsAllowed
+	// is false, which on untrusted documents enables local file reads
+	// (`$ref: "/etc/passwd"`) and SSRF (`$ref: "http://169.254.169.254/..."`).
+	// A custom func must apply its own scheme/host allowlist, or re-check
+	// IsExternalRefsAllowed, before reading.
 	ReadFromURIFunc ReadFromURIFunc
 
 	// JoinFunc allows overriding how relative $ref paths are resolved against

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -101,9 +101,18 @@ func (loader *Loader) allowsExternalRefs(ref string) (err error) {
 }
 
 func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, element any) (*url.URL, error) {
-	// When a custom ReadFromURIFunc is installed, defer the external-ref decision to it;
-	// the function itself is responsible for enforcing any access policy.
-	// Otherwise enforce IsExternalRefsAllowed here before attempting any I/O.
+	// When a custom ReadFromURIFunc is installed, the external-ref policy
+	// (IsExternalRefsAllowed) is NOT enforced here: the function itself is fully
+	// responsible for deciding which locations it will read.
+	//
+	// SECURITY: a custom ReadFromURIFunc that reads whatever location it is handed
+	// (for example by delegating straight to DefaultReadFromURI) will resolve
+	// external $refs even when IsExternalRefsAllowed is false. On untrusted
+	// documents that enables local file reads (`$ref: "/etc/passwd"`) and SSRF
+	// (`$ref: "http://169.254.169.254/..."`). A custom func must apply its own
+	// host/scheme allowlist, or re-check IsExternalRefsAllowed, before reading.
+	//
+	// When no custom func is set, enforce IsExternalRefsAllowed here before any I/O.
 	if loader.ReadFromURIFunc == nil {
 		if err := loader.allowsExternalRefs(ref); err != nil {
 			return nil, err
@@ -331,7 +340,11 @@ func (loader *Loader) resolveRefPath(ref string, path *url.URL) (*url.URL, error
 		return path, nil
 	}
 
-	// When a custom ReadFromURIFunc is installed, defer the external-ref decision to it.
+	// When a custom ReadFromURIFunc is installed, IsExternalRefsAllowed is NOT
+	// enforced here — the custom func owns the access policy. See the SECURITY
+	// note on loadSingleElementFromURI: a func that reads any location it is given
+	// resolves external $refs regardless of IsExternalRefsAllowed, enabling local
+	// file reads / SSRF on untrusted documents.
 	if loader.ReadFromURIFunc == nil {
 		if err := loader.allowsExternalRefs(ref); err != nil {
 			return nil, err

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -26,7 +26,9 @@ func failedToResolveRefFragmentPart(value, what string) error {
 
 // Loader helps deserialize an OpenAPIv3 document
 type Loader struct {
-	// IsExternalRefsAllowed enables visiting other files
+	// IsExternalRefsAllowed enables visiting other files. Enforced only when
+	// ReadFromURIFunc is nil; a custom ReadFromURIFunc bypasses this flag and
+	// owns the access policy itself — see ReadFromURIFunc.
 	IsExternalRefsAllowed bool
 
 	// IncludeOrigin enables recording the file/line/column of each OpenAPI element.
@@ -34,7 +36,16 @@ type Loader struct {
 	// concurrent use.
 	IncludeOrigin bool
 
-	// ReadFromURIFunc allows overriding the any file/URL reading func
+	// ReadFromURIFunc overrides how the loader reads a referenced file or URL.
+	//
+	// SECURITY: when a custom ReadFromURIFunc is set, IsExternalRefsAllowed is
+	// NOT enforced — this function alone decides which locations may be read. A
+	// func that reads whatever URI it is handed (e.g. by delegating to
+	// DefaultReadFromURI) resolves external $refs even when IsExternalRefsAllowed
+	// is false, which on untrusted documents enables local file reads
+	// (`$ref: "/etc/passwd"`) and SSRF (`$ref: "http://169.254.169.254/..."`).
+	// A custom func must apply its own scheme/host allowlist, or re-check
+	// IsExternalRefsAllowed, before reading.
 	ReadFromURIFunc ReadFromURIFunc
 
 	// JoinFunc allows overriding how relative $ref paths are resolved against
@@ -101,18 +112,9 @@ func (loader *Loader) allowsExternalRefs(ref string) (err error) {
 }
 
 func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, element any) (*url.URL, error) {
-	// When a custom ReadFromURIFunc is installed, the external-ref policy
-	// (IsExternalRefsAllowed) is NOT enforced here: the function itself is fully
-	// responsible for deciding which locations it will read.
-	//
-	// SECURITY: a custom ReadFromURIFunc that reads whatever location it is handed
-	// (for example by delegating straight to DefaultReadFromURI) will resolve
-	// external $refs even when IsExternalRefsAllowed is false. On untrusted
-	// documents that enables local file reads (`$ref: "/etc/passwd"`) and SSRF
-	// (`$ref: "http://169.254.169.254/..."`). A custom func must apply its own
-	// host/scheme allowlist, or re-check IsExternalRefsAllowed, before reading.
-	//
-	// When no custom func is set, enforce IsExternalRefsAllowed here before any I/O.
+	// IsExternalRefsAllowed is enforced here only when no custom ReadFromURIFunc
+	// is installed; otherwise the custom func owns the access policy (see the
+	// SECURITY note on the ReadFromURIFunc field).
 	if loader.ReadFromURIFunc == nil {
 		if err := loader.allowsExternalRefs(ref); err != nil {
 			return nil, err
@@ -340,11 +342,9 @@ func (loader *Loader) resolveRefPath(ref string, path *url.URL) (*url.URL, error
 		return path, nil
 	}
 
-	// When a custom ReadFromURIFunc is installed, IsExternalRefsAllowed is NOT
-	// enforced here — the custom func owns the access policy. See the SECURITY
-	// note on loadSingleElementFromURI: a func that reads any location it is given
-	// resolves external $refs regardless of IsExternalRefsAllowed, enabling local
-	// file reads / SSRF on untrusted documents.
+	// IsExternalRefsAllowed is enforced here only when no custom ReadFromURIFunc
+	// is installed; otherwise the custom func owns the access policy (see the
+	// SECURITY note on the ReadFromURIFunc field).
 	if loader.ReadFromURIFunc == nil {
 		if err := loader.allowsExternalRefs(ref); err != nil {
 			return nil, err


### PR DESCRIPTION
## What

Clarifies, at both ref-resolution sites in `loader.go` (`loadSingleElementFromURI` and `resolveRefPath`), that installing a custom `ReadFromURIFunc` disables the built-in `IsExternalRefsAllowed` enforcement, and that the custom reader is then fully responsible for its own access policy. Comment-only — no behavior change.

## Why

The loader only calls `allowsExternalRefs` when `ReadFromURIFunc == nil`:

```go
if loader.ReadFromURIFunc == nil {
    if err := loader.allowsExternalRefs(ref); err != nil {
        return nil, err
    }
}
```

So a custom `ReadFromURIFunc` owns the external-reference decision entirely. This is reasonable — a custom reader often *needs* to resolve cross-document references that `allowsExternalRefs` would reject (it treats every cross-document `$ref` as "external"), so the policy can't be enforced ahead of the reader without breaking those readers.

The risk is that it's silent. A natural way to write a custom reader is to handle the special cases and delegate the rest to `DefaultReadFromURI`:

```go
loader.ReadFromURIFunc = func(l *openapi3.Loader, u *url.URL) ([]byte, error) {
    if isSpecialCase(u) { return readSpecialCase(u) }
    return openapi3.DefaultReadFromURI(l, u) // reads http(s) AND local files, unconditionally
}
```

That reader resolves external `$refs` **even when the caller set `IsExternalRefsAllowed = false`**, because the built-in gate was skipped. On untrusted documents this is a local-file-read (`$ref: "/etc/passwd"`) and SSRF (`$ref: "http://169.254.169.254/..."`) vector. The existing comment ("defer the external-ref decision to it") describes the behavior but not this consequence, so the footgun is easy to miss.

This PR spells out the consequence and the responsibility at both sites, so anyone writing a custom reader knows they must apply their own host/scheme allowlist or re-check `IsExternalRefsAllowed`.

## Scope

Documentation only. I deliberately did **not** change the behavior: enforcing `allowsExternalRefs` ahead of a custom reader would break readers that legitimately resolve cross-document refs the built-in gate rejects. If a safe-by-default lever is desired (e.g. an opt-in `Loader` field to re-apply the gate even with a custom reader), happy to discuss separately.