### PR TITLE
openapi3: remove decimal128 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/perimeterx/marshmallow v1.1.5
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.9.0
-	github.com/woodsbury/decimal128 v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
 github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
-github.com/woodsbury/decimal128 v1.3.0 h1:8pffMNWIlC0O5vbyHWFZAt5yWvWcrHA+3ovIIjVWss0=
-github.com/woodsbury/decimal128 v1.3.0/go.mod h1:C5UTmyTjW3JftjUFzOVhC20BEQa2a4ZKOB5I6Zjb+ds=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -17,7 +17,6 @@ import (
 	"unicode/utf16"
 
 	"github.com/go-openapi/jsonpointer"
-	"github.com/woodsbury/decimal128"
 )
 
 const (
@@ -2552,10 +2551,10 @@ func (schema *Schema) visitJSONNumber(settings *schemaValidationSettings, value 
 	if v := schema.MultipleOf; v != nil {
 		// "A numeric instance is valid only if division by this keyword's
 		//    value results in an integer."
-		numParsed, _ := decimal128.Parse(fmt.Sprintf("%.10f", value))
-		denParsed, _ := decimal128.Parse(fmt.Sprintf("%.10f", *v))
-		_, remainder := numParsed.QuoRem(denParsed)
-		if !remainder.IsZero() {
+		numRat, denRat := &big.Rat{}, &big.Rat{}
+		numRat.SetString(fmt.Sprintf("%.10f", value))
+		denRat.SetString(fmt.Sprintf("%.10f", *v))
+		if !(&big.Rat{}).Quo(numRat, denRat).IsInt() {
 			if settings.failfast {
 				return errSchema
 			}


### PR DESCRIPTION
The PR replaces `decimal128` with `math/big.Rat` for `multipleOf` validation. `decimal128` was added in #1068 by fixing #817.

`math/big.Rat` was actually the first fix suggested in #817. It works correctly here because both values are formatted via `fmt.Sprintf("%.10f", ...)` before any arithmetic, converting `float64` to an exact decimal string that `big.Rat` parses without binary floating-point error.

The regression test `TestIssue817` (added in #1068) passes with the new implementation.