### PR TITLE
openapi2,openapi3: replace marshmallow with encoding/json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/oasdiff/yaml v0.1.0
 	github.com/oasdiff/yaml3 v0.0.13
-	github.com/perimeterx/marshmallow v1.1.5
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/swag v0.23.0 h1:vsEVJDUo2hPJ2tu0/Xc+4noaxyEffXNIs3cOULZ+GrE=
 github.com/go-openapi/swag v0.23.0/go.mod h1:esZ8ITTYEsH1V2trKHjAN8Ai7xHb8RV+YSZ577vPjgQ=
-github.com/go-test/deep v1.0.8 h1:TDsG77qcSprGbC6vTN8OuXp5g+J+b5Pcguhf7Zt61VM=
-github.com/go-test/deep v1.0.8/go.mod h1:5C2ZWiW0ErCdrYzpqxLbTX7MG14M9iiw8DgHncVwcsE=
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -22,8 +20,6 @@ github.com/oasdiff/yaml v0.1.0 h1:0bqZjfKc/8S9urj4JuwepX41WX9EoA6ifhU3SV06cXg=
 github.com/oasdiff/yaml v0.1.0/go.mod h1:kOlRmMdL2X3vucLCEQO5u61SU22RysnfXvcttrZA1O0=
 github.com/oasdiff/yaml3 v0.0.13 h1:06svmvOHOVBqF81+sY2EUScvUI/iS/vl2VIeUUxZQwg=
 github.com/oasdiff/yaml3 v0.0.13/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
-github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
-github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
@@ -32,8 +28,6 @@ github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEV
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/ugorji/go/codec v1.2.7 h1:YPXUKf7fYbp/y8xloBqZOw2qaVggbfwMlI8WM3wZUJ0=
-github.com/ugorji/go/codec v1.2.7/go.mod h1:WGN1fab3R1fzQlVQTkfxVtIBhWDRqOviHU95kRgeqEY=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/openapi2/refs.go
+++ b/openapi2/refs.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/go-openapi/jsonpointer"
-	"github.com/perimeterx/marshmallow"
 )
 
 // SchemaRef represents either a Schema or a $ref to a Schema.
@@ -55,7 +54,10 @@ func (x SchemaRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets SchemaRef to a copy of data.
 func (x *SchemaRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		if len(extra) != 0 {
 			x.extra = make([]string, 0, len(extra))

--- a/openapi2/refs_test.go
+++ b/openapi2/refs_test.go
@@ -1,0 +1,44 @@
+package openapi2_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi2"
+)
+
+func TestSchemaRef_UnmarshalJSON_Ref(t *testing.T) {
+	data := []byte(`{"$ref":"#/definitions/Pet"}`)
+
+	var ref openapi2.SchemaRef
+	require.NoError(t, json.Unmarshal(data, &ref))
+
+	assert.Equal(t, "#/definitions/Pet", ref.Ref)
+	assert.Nil(t, ref.Value)
+}
+
+func TestSchemaRef_UnmarshalJSON_RefWithExtensions(t *testing.T) {
+	data := []byte(`{"$ref":"#/definitions/Pet","x-order":1,"something":"extra"}`)
+
+	var ref openapi2.SchemaRef
+	require.NoError(t, json.Unmarshal(data, &ref))
+
+	assert.Equal(t, "#/definitions/Pet", ref.Ref)
+	assert.Equal(t, float64(1), ref.Extensions["x-order"])
+	assert.Nil(t, ref.Extensions["something"])
+}
+
+func TestSchemaRef_UnmarshalJSON_Value(t *testing.T) {
+	data := []byte(`{"type":"string"}`)
+
+	var ref openapi2.SchemaRef
+	require.NoError(t, json.Unmarshal(data, &ref))
+
+	assert.Empty(t, ref.Ref)
+	require.NotNil(t, ref.Value)
+	require.NotNil(t, ref.Value.Type)
+	assert.Contains(t, *ref.Value.Type, "string")
+}

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/go-openapi/jsonpointer"
-	"github.com/perimeterx/marshmallow"
 )
 
 // CallbackRef represents either a Callback or a $ref to a Callback.
@@ -69,7 +68,10 @@ func (x CallbackRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets CallbackRef to a copy of data.
 func (x *CallbackRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -208,7 +210,10 @@ func (x ExampleRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets ExampleRef to a copy of data.
 func (x *ExampleRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -347,7 +352,10 @@ func (x HeaderRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets HeaderRef to a copy of data.
 func (x *HeaderRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -486,7 +494,10 @@ func (x LinkRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets LinkRef to a copy of data.
 func (x *LinkRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -625,7 +636,10 @@ func (x ParameterRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets ParameterRef to a copy of data.
 func (x *ParameterRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -764,7 +778,10 @@ func (x RequestBodyRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets RequestBodyRef to a copy of data.
 func (x *RequestBodyRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -903,7 +920,10 @@ func (x ResponseRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets ResponseRef to a copy of data.
 func (x *ResponseRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -1045,7 +1065,10 @@ func (x SchemaRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets SchemaRef to a copy of data.
 func (x *SchemaRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {
@@ -1202,7 +1225,10 @@ func (x SecuritySchemeRef) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets SecuritySchemeRef to a copy of data.
 func (x *SecuritySchemeRef) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {

--- a/openapi3/refs.tmpl
+++ b/openapi3/refs.tmpl
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/go-openapi/jsonpointer"
-	"github.com/perimeterx/marshmallow"
 )
 {{ range $type := .Types }}
 // {{ $type.Name }}Ref represents either a {{ $type.Name }} or a $ref to a {{ $type.Name }}.
@@ -74,7 +73,10 @@ func (x {{ $type.Name }}Ref) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON sets {{ $type.Name }}Ref to a copy of data.
 func (x *{{ $type.Name }}Ref) UnmarshalJSON(data []byte) error {
 	var refOnly Ref
-	if extra, err := marshmallow.Unmarshal(data, &refOnly, marshmallow.WithExcludeKnownFieldsFromMap(true)); err == nil && refOnly.Ref != "" {
+	if err := json.Unmarshal(data, &refOnly); err == nil && refOnly.Ref != "" {
+		extra := map[string]any{}
+		_ = json.Unmarshal(data, &extra)
+		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
 		if len(extra) != 0 {


### PR DESCRIPTION
The PR removes the external `marshmallow` dependency by replacing its single-use pattern with two `json.Unmarshal` calls. Also adds `openapi2` SchemaRef unmarshal tests which had no prior coverage.

This is needed for #1192.