### PR TITLE
openapi3filter: honor comma-separated and wildcard encoding.contentType

### DIFF
--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1243,6 +1243,39 @@ func getEncodingContentType(encFn EncodingFn) string {
 	return enc.ContentType
 }
 
+// contentTypeAllowedByEncoding reports whether mediaType satisfies the
+// encoding.contentType, which per OAS 3.0 may be a single media type, a wildcard
+// (e.g. image/*), or a comma-separated list of those. mediaType must be a base
+// type; parameters on encoding entries (e.g. "; charset=utf-8") are ignored.
+func contentTypeAllowedByEncoding(mediaType, encodingContentType string) bool {
+	for raw := range strings.SplitSeq(encodingContentType, ",") {
+		want := strings.TrimSpace(raw)
+		if want == "" {
+			continue
+		}
+		if base, _, err := mime.ParseMediaType(want); err == nil {
+			want = base
+		}
+		if mediaTypeMatches(mediaType, want) {
+			return true
+		}
+	}
+	return false
+}
+
+// mediaTypeMatches reports whether got matches want (exact, type/* or */* wildcard,
+// case-insensitive). Both must be base media types without parameters.
+func mediaTypeMatches(got, want string) bool {
+	if want == "*/*" || strings.EqualFold(want, got) {
+		return true
+	}
+	if prefix, ok := strings.CutSuffix(want, "/*"); ok {
+		gotType, _, found := strings.Cut(got, "/")
+		return found && strings.EqualFold(gotType, prefix)
+	}
+	return false
+}
+
 // decodeBody returns a decoded body.
 // The function returns ParseError when a body is invalid.
 func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, encFn EncodingFn) (
@@ -1265,7 +1298,7 @@ func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, 
 	}
 
 	if encodingContentType != "" &&
-		mediaType != encodingContentType {
+		!contentTypeAllowedByEncoding(mediaType, encodingContentType) {
 		return "", nil, &ParseError{
 			Kind: KindOther,
 			Reason: fmt.Sprintf(
@@ -1279,6 +1312,13 @@ func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, 
 
 	decoder, ok := bodyDecoders[mediaType]
 	if !ok {
+		// A binary part with no registered decoder (e.g. image/png) is read as
+		// raw bytes: encoding.contentType restricts the accepted media types but
+		// does not require a registered decoder.
+		if isBinary(schema) {
+			value, err := FileBodyDecoder(body, header, schema, encFn)
+			return mediaType, value, err
+		}
 		return "", nil, &ParseError{
 			Kind:   KindUnsupportedFormat,
 			Reason: fmt.Sprintf("%s %q", prefixUnsupportedCT, mediaType),

--- a/openapi3filter/req_resp_decoder_test.go
+++ b/openapi3filter/req_resp_decoder_test.go
@@ -1676,7 +1676,7 @@ func TestDecodeBody(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	multipartBinaryEncodingCTUnsupported, multipartMimeBinaryEncodingCTUnsupported, err := newTestMultipartForm([]*testFormPart{
+	multipartBinaryEncodingCTFallback, multipartMimeBinaryEncodingCTFallback, err := newTestMultipartForm([]*testFormPart{
 		{name: "b", contentType: "application/json", data: strings.NewReader(`{"bar1": "bar1"}`), filename: "b1"},
 		{name: "d", contentType: "application/pdf", data: strings.NewReader("doo1"), filename: "d1"},
 	})
@@ -1685,6 +1685,12 @@ func TestDecodeBody(t *testing.T) {
 	multipartBinaryEncodingCTNotMatching, multipartMimeBinaryEncodingCTNotMatching, err := newTestMultipartForm([]*testFormPart{
 		{name: "b", contentType: "application/json", data: strings.NewReader(`{"bar1": "bar1"}`), filename: "b1"},
 		{name: "d", contentType: "application/pdf", data: strings.NewReader("doo1"), filename: "d1"},
+	})
+	require.NoError(t, err)
+
+	multipartBinaryEncodingCTList, multipartMimeBinaryEncodingCTList, err := newTestMultipartForm([]*testFormPart{
+		{name: "b", contentType: "text/plain", data: strings.NewReader("b1data"), filename: "b1"},
+		{name: "d", contentType: "application/json", data: strings.NewReader(`{"d1": "d1"}`), filename: "d1"},
 	})
 	require.NoError(t, err)
 
@@ -1839,9 +1845,9 @@ func TestDecodeBody(t *testing.T) {
 			want: map[string]any{"b": `{"bar1": "bar1"}`, "d": "doo1", "f": []any{`{"foo1": "foo1"}`, "foo2"}},
 		},
 		{
-			name: "multipartEncodingCTUnsupported",
-			mime: multipartMimeBinaryEncodingCTUnsupported,
-			body: multipartBinaryEncodingCTUnsupported,
+			name: "multipartEncodingCTBinaryFallback",
+			mime: multipartMimeBinaryEncodingCTFallback,
+			body: multipartBinaryEncodingCTFallback,
 			schema: openapi3.NewObjectSchema().
 				WithProperty("b", openapi3.NewStringSchema().WithFormat("binary")).
 				WithProperty("d", openapi3.NewStringSchema().WithFormat("binary")),
@@ -1849,15 +1855,7 @@ func TestDecodeBody(t *testing.T) {
 				"b": {ContentType: "application/json"},
 				"d": {ContentType: "application/pdf"},
 			},
-			want: map[string]any{"b": map[string]any{"bar1": "bar1"}},
-			wantErr: &ParseError{
-				Kind: KindOther,
-				Cause: &ParseError{
-					Kind:   KindUnsupportedFormat,
-					Reason: fmt.Sprintf("%s %q", prefixUnsupportedCT, "application/pdf"),
-				},
-				path: []any{"d"},
-			},
+			want: map[string]any{"b": map[string]any{"bar1": "bar1"}, "d": "doo1"},
 		},
 		{
 			name: "multipartEncodingCTNotMatching",
@@ -1885,6 +1883,19 @@ func TestDecodeBody(t *testing.T) {
 				path: []any{"d"},
 			},
 		},
+		{
+			name: "multipartEncodingCTList",
+			mime: multipartMimeBinaryEncodingCTList,
+			body: multipartBinaryEncodingCTList,
+			schema: openapi3.NewObjectSchema().
+				WithProperty("b", openapi3.NewStringSchema().WithFormat("binary")).
+				WithProperty("d", openapi3.NewStringSchema().WithFormat("binary")),
+			encoding: map[string]*openapi3.Encoding{
+				"b": {ContentType: "application/json, text/plain"},
+				"d": {ContentType: "application/*"},
+			},
+			want: map[string]any{"b": "b1data", "d": map[string]any{"d1": "d1"}},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1910,6 +1921,33 @@ func TestDecodeBody(t *testing.T) {
 
 			require.NoError(t, err)
 			require.Truef(t, reflect.DeepEqual(got, tc.want), "got %v, want %v", got, tc.want)
+		})
+	}
+}
+
+func TestContentTypeAllowedByEncoding(t *testing.T) {
+	testCases := []struct {
+		name                string
+		mediaType           string
+		encodingContentType string
+		want                bool
+	}{
+		{name: "exact match", mediaType: "application/json", encodingContentType: "application/json", want: true},
+		{name: "exact mismatch", mediaType: "application/json", encodingContentType: "application/xml", want: false},
+		{name: "comma list first", mediaType: "image/jpeg", encodingContentType: "image/jpeg, image/png", want: true},
+		{name: "comma list second", mediaType: "image/png", encodingContentType: "image/jpeg, image/png", want: true},
+		{name: "comma list miss", mediaType: "image/gif", encodingContentType: "image/jpeg, image/png", want: false},
+		{name: "comma list no spaces", mediaType: "image/png", encodingContentType: "image/jpeg,image/png", want: true},
+		{name: "subtype wildcard match", mediaType: "image/png", encodingContentType: "image/*", want: true},
+		{name: "subtype wildcard miss", mediaType: "application/pdf", encodingContentType: "image/*", want: false},
+		{name: "full wildcard", mediaType: "application/octet-stream", encodingContentType: "*/*", want: true},
+		{name: "case insensitive", mediaType: "Image/PNG", encodingContentType: "image/png", want: true},
+		{name: "entry with parameters base match", mediaType: "application/xml", encodingContentType: "application/xml; charset=utf-8", want: true},
+		{name: "empty entries ignored", mediaType: "image/png", encodingContentType: " , image/png , ", want: true},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, contentTypeAllowedByEncoding(tc.mediaType, tc.encodingContentType))
 		})
 	}
 }


### PR DESCRIPTION
## Bug

In `multipart/form-data` request validation, `decodeBody` compares a part's media type against `encoding.contentType` with an exact string match:

```go
mediaType := parseMediaType(contentType)          // e.g. "image/png"
encodingContentType := getEncodingContentType(encFn) // e.g. "image/png, image/jpeg"
...
if encodingContentType != "" && mediaType != encodingContentType {
    return ... prefixNotMatchingCT ...            // "not matching content types"
}
```

But per the [Encoding Object spec](https://spec.openapis.org/oas/v3.0.3#encoding-object), `contentType` "can be a specific media type (e.g. `application/json`), a wildcard media type (e.g. `image/*`), or a comma-separated list of the two types" — and the official example uses `contentType: image/png, image/jpeg`.

So any part declared with a comma-separated list or a wildcard is rejected even when its `Content-Type` is one of the declared types. A part with `Content-Type: image/png` fails against `image/png, image/jpeg`.

## Fix

- Match per the spec: split `encoding.contentType` on commas and accept the part if its media type matches any entry — supporting `type/*` and `*/*` wildcards, comparing case-insensitively, and ignoring parameters.
- Read matched binary parts as raw bytes: a binary part (`format: binary`) whose matched content type has no registered decoder (e.g. `image/png`) is now read via `FileBodyDecoder` instead of failing with "unsupported content type" — the same handling binary parts already get when no `encoding.contentType` is set.

## Compatibility

Single exact-value encodings and genuine mismatches behave exactly as before (same error and text); only previously-rejected valid cases now pass.

## Tests

Added matching and binary-fallback table tests, and updated the existing multipart encoding test.
