### PR TITLE
openapi3: enforce unique required entries and unique tag names in Validate()

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -608,6 +608,31 @@ type DuplicateParameterError struct {
 
 func (e *DuplicateParameterError) Error() string
 
+type DuplicateRequiredFieldError struct {
+	// Field is the field name listed more than once in `required`.
+	Field string
+	// Origin is the source location of the offending schema when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    DuplicateRequiredFieldError clusters "duplicate field in required" failures.
+    The elements of a schema's `required` array MUST be unique (JSON Schema
+    2020-12 §6.5.3 for OpenAPI 3.1, draft-04 for OpenAPI 3.0).
+
+func (e *DuplicateRequiredFieldError) Error() string
+
+type DuplicateTagError struct {
+	// Name is the tag name that appears more than once.
+	Name string
+	// Origin is the source location of the offending tag when the document
+	// was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    DuplicateTagError clusters "more than one tag has name X" failures. Each tag
+    name in the document-root `tags` list MUST be unique (OpenAPI Object).
+
+func (e *DuplicateTagError) Error() string
+
 type DynamicAnchorFieldFor31Plus struct{ ValidationError }
 
 func (e *DynamicAnchorFieldFor31Plus) As(target any) bool

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1406,6 +1406,18 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 		return stack, newSchemaReadOnlyWriteOnlyExclusive(schema.Origin)
 	}
 
+	// The elements of `required` MUST be unique (JSON Schema 2020-12 §6.5.3
+	// for OAS 3.1, draft-04 for OAS 3.0).
+	if len(schema.Required) > 1 {
+		seen := make(map[string]struct{}, len(schema.Required))
+		for _, name := range schema.Required {
+			if _, dup := seen[name]; dup {
+				return stack, &DuplicateRequiredFieldError{Field: name, Origin: schema.Origin}
+			}
+			seen[name] = struct{}{}
+		}
+	}
+
 	// Reject fields that only exist in OAS 3.1 / JSON Schema 2020-12 when the
 	// document is OAS 3.0. Fields explicitly allowed via AllowExtraSiblingFields
 	// are skipped (opt-in escape hatch for 3.0 docs that reference external

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -33,9 +33,8 @@ func (tags Tags) Validate(ctx context.Context, opts ...ValidationOption) error {
 				if err := me.emit(&DuplicateTagError{Name: v.Name, Origin: v.Origin}); err != nil {
 					return err
 				}
-			} else {
-				seen[v.Name] = struct{}{}
 			}
+			seen[v.Name] = struct{}{}
 		}
 		wrap := func(e error) error { return &TagValidationError{Name: v.Name, Cause: e} }
 		if err := me.emitWrapped(wrap, v.Validate(ctx)); err != nil {

--- a/openapi3/tag.go
+++ b/openapi3/tag.go
@@ -23,7 +23,20 @@ func (tags Tags) Validate(ctx context.Context, opts ...ValidationOption) error {
 	ctx = WithValidationOptions(ctx, opts...)
 	me := newErrCollector(ctx)
 
+	// Each tag name in the list MUST be unique (OpenAPI Object). Empty names
+	// are left to per-tag validation, not flagged as duplicates here.
+	seen := make(map[string]struct{}, len(tags))
+
 	for _, v := range tags {
+		if v.Name != "" {
+			if _, dup := seen[v.Name]; dup {
+				if err := me.emit(&DuplicateTagError{Name: v.Name, Origin: v.Origin}); err != nil {
+					return err
+				}
+			} else {
+				seen[v.Name] = struct{}{}
+			}
+		}
 		wrap := func(e error) error { return &TagValidationError{Name: v.Name, Cause: e} }
 		if err := me.emitWrapped(wrap, v.Validate(ctx)); err != nil {
 			return err

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -535,6 +535,35 @@ func (e *DuplicateParameterError) Error() string {
 	return fmt.Sprintf("more than one %q parameter has name %q", e.In, e.Name)
 }
 
+// DuplicateRequiredFieldError clusters "duplicate field in required" failures.
+// The elements of a schema's `required` array MUST be unique (JSON Schema
+// 2020-12 §6.5.3 for OpenAPI 3.1, draft-04 for OpenAPI 3.0).
+type DuplicateRequiredFieldError struct {
+	// Field is the field name listed more than once in `required`.
+	Field string
+	// Origin is the source location of the offending schema when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *DuplicateRequiredFieldError) Error() string {
+	return fmt.Sprintf("duplicate field %q in required", e.Field)
+}
+
+// DuplicateTagError clusters "more than one tag has name X" failures. Each tag
+// name in the document-root `tags` list MUST be unique (OpenAPI Object).
+type DuplicateTagError struct {
+	// Name is the tag name that appears more than once.
+	Name string
+	// Origin is the source location of the offending tag when the document
+	// was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *DuplicateTagError) Error() string {
+	return fmt.Sprintf("more than one tag has name %q", e.Name)
+}
+
 // InvalidSerializationMethodError clusters "serialization method with
 // style=X and explode=Y is not supported by Z" failures. Fires for
 // invalid (style, explode) combinations on encodings, parameters,

--- a/openapi3/validation_error_test.go
+++ b/openapi3/validation_error_test.go
@@ -2127,6 +2127,46 @@ func TestValidationError_SchemaCombinatorElementValidationError_NoStutter(t *tes
 	require.Equal(t, "invalid oneOf element: invalid allOf element: boom", mixed.Error())
 }
 
+func TestValidationError_DuplicateRequiredFieldError(t *testing.T) {
+	doc := loadDocFromYAML(t, `
+openapi: 3.0.3
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    Bad:
+      type: object
+      required: [id, id]
+      properties:
+        id: { type: string }
+`)
+	err := doc.Validate(context.Background())
+	require.Error(t, err)
+
+	var dup *openapi3.DuplicateRequiredFieldError
+	require.True(t, errors.As(err, &dup))
+	require.Equal(t, "id", dup.Field)
+	require.Contains(t, dup.Error(), `duplicate field "id" in required`)
+}
+
+func TestValidationError_DuplicateTagError(t *testing.T) {
+	doc := loadDocFromYAML(t, `
+openapi: 3.0.3
+info: { title: t, version: "1" }
+paths: {}
+tags:
+  - name: pet
+  - name: pet
+`)
+	err := doc.Validate(context.Background())
+	require.Error(t, err)
+
+	var dup *openapi3.DuplicateTagError
+	require.True(t, errors.As(err, &dup))
+	require.Equal(t, "pet", dup.Name)
+	require.Contains(t, dup.Error(), `more than one tag has name "pet"`)
+}
+
 func TestValidationError_TagValidationError(t *testing.T) {
 	doc := loadDocFromYAML(t, `
 openapi: 3.0.3


### PR DESCRIPTION
Closes #1200.

Two spec MUSTs that `Validate()` did not enforce:

1. **Unique `required` entries.** JSON Schema 2020-12 §6.5.3 (OAS 3.1) and draft-04 (OAS 3.0) both require the elements of a schema's `required` array to be unique. `schema.validate` now returns a `DuplicateRequiredFieldError` on a repeat.
2. **Unique tag names.** The OpenAPI Object says "Each tag name in the list MUST be unique." `Tags.Validate` now emits a `DuplicateTagError` on a repeat (empty names are left to per-tag validation, not flagged here).

Both new error types follow the existing `Duplicate*` cluster pattern (cf. `DuplicateParameterError` / `DuplicateOperationIDError`) and carry `Origin` when the document was loaded with `IncludeOrigin = true`.

```yaml
# now rejected
type: object
required: [id, id]
properties: { id: { type: string } }
```
```yaml
# now rejected
tags:
  - name: pet
  - name: pet
```

### Behavior change
As called out in #1200, this is a behavior change: documents carrying these duplicates that passed `Validate()` before will now fail. It is wired as a hard `Validate()` error to match the other `Duplicate*` checks. If you'd prefer it gated behind a `ValidationOption` instead, happy to switch.

### Tests / fixtures
- Unit tests for both errors (`errors.As` to the typed cluster + message).
- The full `openapi3` package passes, and **no apis-guru golden fixture changed** (the corpus trips neither check), so there is no fixture churn to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)