### PR TITLE
openapi3gen: Add an option to customize generated field names (properties) for structs

### DIFF
--- a/.github/docs/openapi3gen.txt
+++ b/.github/docs/openapi3gen.txt
@@ -33,6 +33,13 @@ type ExportComponentSchemasOptions struct {
 	ExportGenerics         bool
 }
 
+type FieldNameGenerator func(field reflect.StructField, defaultName string) string
+    FieldNameGenerator allows client to set custom name for struct fields in
+    the generated schema. defaultName is the name, determined by generator's
+    standard JSON, YAML and Go field name resolution rules. Useful for
+    processing custom binding tags, such as `form` or `xml`. Function should
+    always return non-empty string.
+
 type Generator struct {
 	Types map[reflect.Type]*openapi3.SchemaRef
 
@@ -59,6 +66,8 @@ type Option func(*generatorOpt)
 func CreateComponentSchemas(exso ExportComponentSchemasOptions) Option
     CreateComponents changes the default behavior to add all schemas as
     components Reduces duplicate schemas in routes
+
+func CreateFieldNameGenerator(fngnrt FieldNameGenerator) Option
 
 func CreateTypeNameGenerator(tngnrt TypeNameGenerator) Option
 

--- a/openapi3gen/openapi3gen.go
+++ b/openapi3gen/openapi3gen.go
@@ -52,12 +52,19 @@ type ExportComponentSchemasOptions struct {
 
 type TypeNameGenerator func(t reflect.Type) string
 
+// FieldNameGenerator allows client to set custom name for struct fields in the generated schema.
+// defaultName is the name, determined by generator's standard JSON, YAML and Go field name resolution rules.
+// Useful for processing custom binding tags, such as `form` or `xml`.
+// Function should always return non-empty string.
+type FieldNameGenerator func(field reflect.StructField, defaultName string) string
+
 type generatorOpt struct {
 	useAllExportedFields   bool
 	throwErrorOnCycle      bool
 	schemaCustomizer       SchemaCustomizerFn
 	exportComponentSchemas ExportComponentSchemasOptions
 	typeNameGenerator      TypeNameGenerator
+	fieldNameGenerator     FieldNameGenerator
 }
 
 // UseAllExportedFields changes the default behavior of only
@@ -68,6 +75,10 @@ func UseAllExportedFields() Option {
 
 func CreateTypeNameGenerator(tngnrt TypeNameGenerator) Option {
 	return func(x *generatorOpt) { x.typeNameGenerator = tngnrt }
+}
+
+func CreateFieldNameGenerator(fngnrt FieldNameGenerator) Option {
+	return func(x *generatorOpt) { x.fieldNameGenerator = fngnrt }
 }
 
 // ThrowErrorOnCycle changes the default behavior of creating cycle
@@ -342,28 +353,13 @@ func (g *Generator) generateWithoutSaving(parents []*theTypeInfo, t reflect.Type
 				if !fieldInfo.HasJSONTag && !g.opts.useAllExportedFields {
 					continue
 				}
+
 				// If asked, try to use yaml tag
 				fieldName, fType := fieldInfo.JSONName, fieldInfo.Type
+				ff := getStructField(t, fieldInfo)
 				if !fieldInfo.HasJSONTag && g.opts.useAllExportedFields {
-					// Handle anonymous fields/embedded structs
-					if t.Field(fieldInfo.Index[0]).Anonymous {
-						ref, err := g.generateSchemaRefFor(parents, fType, fieldName, tag)
-						if err != nil {
-							if _, ok := err.(*CycleError); ok && !g.opts.throwErrorOnCycle {
-								ref = g.generateCycleSchemaRef(fType, schema)
-							} else {
-								return nil, err
-							}
-						}
-						if ref != nil {
-							g.SchemaRefs[ref]++
-							schema.WithPropertyRef(fieldName, ref)
-						}
-					} else {
-						ff := getStructField(t, fieldInfo)
-						if tag, ok := ff.Tag.Lookup("yaml"); ok && tag != "-" {
-							fieldName, fType = tag, ff.Type
-						}
+					if tag, ok := ff.Tag.Lookup("yaml"); ok && tag != "-" {
+						fieldName = tag
 					}
 				}
 
@@ -372,6 +368,13 @@ func (g *Generator) generateWithoutSaving(parents []*theTypeInfo, t reflect.Type
 				if g.opts.schemaCustomizer != nil {
 					ff := getStructField(t, fieldInfo)
 					fieldTag = ff.Tag
+				}
+
+				if g.opts.fieldNameGenerator != nil {
+					fieldName = g.opts.fieldNameGenerator(ff, fieldName)
+					if fieldName == "" {
+						return nil, fmt.Errorf("field name can't be empty")
+					}
 				}
 
 				ref, err := g.generateSchemaRefFor(parents, fType, fieldName, fieldTag)

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -702,5 +704,161 @@ func TestExportComponentSchemasSkipsAnonymousType(t *testing.T) {
 
 	for key := range schemas {
 		assert.NotEmpty(t, key, "every component schema must have a non-empty key")
+	}
+}
+
+func TestEmbeddedFieldGeneratedOnce(t *testing.T) {
+	type Embedded struct {
+		Field string
+	}
+	type Container struct {
+		Embedded
+	}
+
+	calls := 0
+	g := openapi3gen.NewGenerator(
+		openapi3gen.UseAllExportedFields(),
+		openapi3gen.SchemaCustomizer(func(name string, _ reflect.Type, _ reflect.StructTag, _ *openapi3.Schema) error {
+			if name == "Field" {
+				calls++
+			}
+			return nil
+		}),
+	)
+
+	schemaRef, err := g.GenerateSchemaRef(reflect.TypeFor[Container]())
+	require.NoError(t, err)
+	require.Contains(t, schemaRef.Value.Properties, "Field")
+	require.Equal(t, 1, calls)
+}
+
+func TestFieldNameGenerator(t *testing.T) {
+	type Embedded struct {
+		EmbeddedField string
+	}
+	type Container struct {
+		PlainField  string
+		JSONField   string `json:"json_name"`
+		YAMLField   string `yaml:"yaml_name"`
+		TaggedField string `property:"custom_name"`
+		Embedded
+	}
+
+	tests := []struct {
+		name          string
+		generator     openapi3gen.FieldNameGenerator
+		wantFields    []string
+		wantDefaults  map[string]string
+		wantGoFields  []string
+		wantFieldTags map[string]string
+		wantErr       bool
+	}{
+		{
+			name:      "customizes untagged fields",
+			generator: func(_ reflect.StructField, defaultName string) string { return strings.ToLower(defaultName) },
+			wantFields: []string{
+				"plainfield",
+				"json_name",
+				"yaml_name",
+				"taggedfield",
+				"embeddedfield",
+			},
+		},
+		{
+			name:      "customizes explicit json and yaml names",
+			generator: func(_ reflect.StructField, defaultName string) string { return "prefix_" + defaultName },
+			wantFields: []string{
+				"prefix_PlainField",
+				"prefix_json_name",
+				"prefix_yaml_name",
+				"prefix_TaggedField",
+				"prefix_EmbeddedField",
+			},
+		},
+		{
+			name: "uses custom struct tag",
+			generator: func(f reflect.StructField, defaultName string) string {
+				if name := f.Tag.Get("property"); name != "" {
+					return name
+				}
+				return defaultName
+			},
+			wantFields:    []string{"PlainField", "json_name", "yaml_name", "custom_name", "EmbeddedField"},
+			wantFieldTags: map[string]string{"TaggedField": "custom_name"},
+		},
+		{
+			name:      "receives promoted embedded field",
+			generator: func(_ reflect.StructField, defaultName string) string { return defaultName },
+			wantFields: []string{
+				"PlainField",
+				"json_name",
+				"yaml_name",
+				"TaggedField",
+				"EmbeddedField",
+			},
+			wantGoFields: []string{"EmbeddedField"},
+		},
+		{
+			name:      "receives resolved default names",
+			generator: func(field reflect.StructField, defaultName string) string { return defaultName },
+			wantFields: []string{
+				"PlainField",
+				"json_name",
+				"yaml_name",
+				"TaggedField",
+				"EmbeddedField",
+			},
+			wantDefaults: map[string]string{
+				"JSONField":     "json_name",
+				"PlainField":    "PlainField",
+				"YAMLField":     "yaml_name",
+				"EmbeddedField": "EmbeddedField",
+			},
+		},
+		{
+			name:      "empty field names are rejected",
+			generator: func(field reflect.StructField, defaultName string) string { return "" },
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDefaults := make(map[string]string)
+			gotTags := make(map[string]string)
+			gotGoFields := make(map[string]bool)
+
+			g := openapi3gen.NewGenerator(
+				openapi3gen.UseAllExportedFields(),
+				openapi3gen.CreateFieldNameGenerator(func(f reflect.StructField, defaultName string) string {
+					gotDefaults[f.Name] = defaultName
+					gotTags[f.Name] = f.Tag.Get("property")
+					gotGoFields[f.Name] = true
+					return tt.generator(f, defaultName)
+				}),
+			)
+
+			schemaRef, err := g.GenerateSchemaRef(reflect.TypeFor[Container]())
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			require.ElementsMatch(t, tt.wantFields, slices.Collect(maps.Keys(schemaRef.Value.Properties)))
+
+			for field, want := range tt.wantDefaults {
+				require.Equal(t, want, gotDefaults[field])
+			}
+
+			for field, want := range tt.wantFieldTags {
+				require.Equal(t, want, gotTags[field])
+			}
+
+			for _, field := range tt.wantGoFields {
+				require.True(t, gotGoFields[field], "field name generator was not called for %s", field)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Description
This PR adds customizable schema property naming.

Currently, openapi3gen derives property names from JSON/YAML tags only, which makes it difficult to integrate with frameworks that use different binding tags (`form`, `query`, etc.) while still relying on `openapi3gen` for schema generation.

The new option allows callers to override the generated property name before it is added to `schema.Properties` and any customizers are called.

This is particularly useful for generators and framework integrations where request binding semantics differ from JSON serialization semantics, such as Echo's `form` and `xml` binding tags.

## Usage example
```go
package main

import (
	"encoding/json"
	"fmt"
	"reflect"

	"github.com/getkin/kin-openapi/openapi3"
	"github.com/getkin/kin-openapi/openapi3gen"
)

type AuthForm struct {
	Login    string `form:"login"`
	Password string `form:"password"`
	Ignore   string `json:"-" form:"-"`
}

func main() {
	schemas := make(openapi3.Schemas)
	g := openapi3gen.NewGenerator(
		openapi3gen.UseAllExportedFields(),
		openapi3gen.CreateFieldNameGenerator(func(field reflect.StructField, defaultName string) string {
			if tag := field.Tag.Get("form"); tag != "" && tag != "-" {
				return tag
			}
			return defaultName
		}),
	)

	ref, _ := g.NewSchemaRefForValue(&AuthForm{}, schemas)
	schema, _ := json.MarshalIndent(ref, "", "  ")
	fmt.Println(string(schema))
	// output:
	// {
	//   "properties": {
	//     "login": {
	//       "type": "string"
	//     },
	//     "password": {
	//       "type": "string"
	//     }
	//   },
	//   "type": "object"
	// }
}
```

## Changes
Existing behaviour remains unchanged when `CreateFieldNameGenerator` is not provided. 

Callback receives `defaultName`, allowing custom naming rules to preserve names resolved from existing JSON and YAML tags.

### Embedded Field Handling
While testing the new feature, I noticed that promoted fields from anonymous embedded structs were generated twice.

Anonymous structs without explicit `json` tag are already recursively exanded by `appendFields`:
https://github.com/getkin/kin-openapi/blob/6c01290ed1ab01f6c34d8d8f81e1761e44f3c108/openapi3gen/field_info.go#L39-L48

Each promoted field was then additionally processed by the dedicated embedded field branch inside `generateWithoutSaving`:
https://github.com/getkin/kin-openapi/blob/6c01290ed1ab01f6c34d8d8f81e1761e44f3c108/openapi3gen/openapi3gen.go#L347-L361

Execution subsequently continued through the common field generation path:
https://github.com/getkin/kin-openapi/blob/6c01290ed1ab01f6c34d8d8f81e1761e44f3c108/openapi3gen/openapi3gen.go#L377-L388

This caused the same field schema and `SchemaCustomizer` callbacks to be processed twice.

Previously, the duplication was hidden because both writes used the same map key. Field name customization exposed this behavior, so I removed the redundant processing branch from `generateWithoutSaving` and added a regression test.