### PR TITLE
openapi3: add T.WalkSchemas to visit every schema in a document

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -118,6 +118,12 @@ var IncludeOrigin = false
     elements. Deprecated: set Loader.IncludeOrigin instead. This global is read
     by NewLoader for backward compatibility but is not safe for concurrent use.
 
+var SkipSubtree = errors.New("skip schema subtree")
+    SkipSubtree, when returned by a WalkSchemasFunc, tells WalkSchemas not to
+    descend into the current schema's sub-schemas. The schema itself has already
+    been visited. Any other non-nil error stops the walk and is returned by
+    WalkSchemas. It mirrors filepath.SkipDir.
+
 
 FUNCTIONS
 
@@ -3336,6 +3342,24 @@ func (doc *T) ValidateSchemaJSON(schema *Schema, value any, opts ...SchemaValida
     format validators. This is a convenience method that automatically applies
     the document's format validators.
 
+func (doc *T) WalkSchemas(fn WalkSchemasFunc) error
+    WalkSchemas visits every schema reachable from the document exactly once,
+    in document order, invoking fn for each. It follows resolved $ref targets
+    (schema.Value) and guards against reference cycles, so each distinct *Schema
+    is visited a single time regardless of how many references point at it.
+
+    It covers schemas under components (schemas, parameters, headers, request
+    bodies, responses, callbacks), the paths and their operations (parameters,
+    request bodies, responses, headers, callbacks), and webhooks, then recurses
+    through every sub-schema keyword: properties, items, allOf/anyOf/oneOf,
+    not, additionalProperties, prefixItems, contains, patternProperties,
+    dependentSchemas, propertyNames, if/then/else, and $defs.
+
+    It is useful for validation, code generation, schema transformation,
+    $ref/dependency analysis, and documentation: any consumer that needs to act
+    on every schema in a document without re-deriving the (easy to get wrong)
+    traversal itself.
+
 type Tag struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -3661,6 +3685,18 @@ type ValidationOptions struct {
 	// Has unexported fields.
 }
     ValidationOptions provides configuration for validating OpenAPI documents.
+
+type WalkSchemasFunc func(location string, schema *SchemaRef) error
+    WalkSchemasFunc is called once for each schema visited by WalkSchemas.
+
+    location is the JSON Pointer (RFC 6901) of the schema within
+    the document, e.g. "/components/schemas/Pet/properties/tag" or
+    "/paths/~1pets/get/responses/200/content/application~1json/schema". sr is
+    never nil and sr.Value is never nil; the callback may modify sr.Value in
+    place, so WalkSchemas serves transformers and not only read-only inspection.
+
+    Returning SkipSubtree skips this schema's sub-schemas; returning any other
+    error aborts the walk and is returned by WalkSchemas.
 
 type WebhookNil struct{ ValidationError }
 

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -3344,9 +3344,10 @@ func (doc *T) ValidateSchemaJSON(schema *Schema, value any, opts ...SchemaValida
 
 func (doc *T) WalkSchemas(fn WalkSchemasFunc) error
     WalkSchemas visits every schema reachable from the document exactly once,
-    in document order, invoking fn for each. It follows resolved $ref targets
-    (schema.Value) and guards against reference cycles, so each distinct *Schema
-    is visited a single time regardless of how many references point at it.
+    invoking fn for each. It follows resolved $ref targets (schema.Value) and
+    guards against reference cycles, so each distinct *Schema is visited a
+    single time regardless of how many references point at it. Maps are visited
+    in sorted key order, so the traversal is deterministic.
 
     It covers schemas under components (schemas, parameters, headers, request
     bodies, responses, callbacks), the paths and their operations (parameters,
@@ -3686,14 +3687,17 @@ type ValidationOptions struct {
 }
     ValidationOptions provides configuration for validating OpenAPI documents.
 
-type WalkSchemasFunc func(location string, schema *SchemaRef) error
+type WalkSchemasFunc func(jsonPointer string, schema *SchemaRef) error
     WalkSchemasFunc is called once for each schema visited by WalkSchemas.
 
-    location is the JSON Pointer (RFC 6901) of the schema within
+    jsonPointer is the RFC 6901 JSON Pointer of the schema within
     the document, e.g. "/components/schemas/Pet/properties/tag" or
-    "/paths/~1pets/get/responses/200/content/application~1json/schema". sr is
-    never nil and sr.Value is never nil; the callback may modify sr.Value in
-    place, so WalkSchemas serves transformers and not only read-only inspection.
+    "/paths/~1pets/get/responses/200/content/application~1json/schema". It is
+    file-agnostic: once the loader has resolved external $refs the document is
+    a single tree, so the pointer addresses a position in that tree and never
+    encodes a source file. schema is non-nil and schema.Value is non-nil;
+    the callback may modify schema.Value in place, so WalkSchemas serves
+    transformers and not only read-only inspection.
 
     Returning SkipSubtree skips this schema's sub-schemas; returning any other
     error aborts the walk and is returned by WalkSchemas.

--- a/openapi3/walk.go
+++ b/openapi3/walk.go
@@ -1,0 +1,304 @@
+package openapi3
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+// SkipSubtree, when returned by a WalkSchemasFunc, tells WalkSchemas not to
+// descend into the current schema's sub-schemas. The schema itself has already
+// been visited. Any other non-nil error stops the walk and is returned by
+// WalkSchemas. It mirrors filepath.SkipDir.
+var SkipSubtree = errors.New("skip schema subtree")
+
+// WalkSchemasFunc is called once for each schema visited by WalkSchemas.
+//
+// location is the JSON Pointer (RFC 6901) of the schema within the document,
+// e.g. "/components/schemas/Pet/properties/tag" or
+// "/paths/~1pets/get/responses/200/content/application~1json/schema". sr is
+// never nil and sr.Value is never nil; the callback may modify sr.Value in
+// place, so WalkSchemas serves transformers and not only read-only inspection.
+//
+// Returning SkipSubtree skips this schema's sub-schemas; returning any other
+// error aborts the walk and is returned by WalkSchemas.
+type WalkSchemasFunc func(location string, schema *SchemaRef) error
+
+// WalkSchemas visits every schema reachable from the document exactly once, in
+// document order, invoking fn for each. It follows resolved $ref targets
+// (schema.Value) and guards against reference cycles, so each distinct *Schema
+// is visited a single time regardless of how many references point at it.
+//
+// It covers schemas under components (schemas, parameters, headers, request
+// bodies, responses, callbacks), the paths and their operations (parameters,
+// request bodies, responses, headers, callbacks), and webhooks, then recurses
+// through every sub-schema keyword: properties, items, allOf/anyOf/oneOf, not,
+// additionalProperties, prefixItems, contains, patternProperties,
+// dependentSchemas, propertyNames, if/then/else, and $defs.
+//
+// It is useful for validation, code generation, schema transformation,
+// $ref/dependency analysis, and documentation: any consumer that needs to act
+// on every schema in a document without re-deriving the (easy to get wrong)
+// traversal itself.
+func (doc *T) WalkSchemas(fn WalkSchemasFunc) error {
+	if doc == nil {
+		return nil
+	}
+	w := schemaWalker{fn: fn, seen: make(map[*Schema]struct{})}
+	return w.document(doc)
+}
+
+type schemaWalker struct {
+	fn   WalkSchemasFunc
+	seen map[*Schema]struct{}
+}
+
+// escapeJSONPointerToken escapes a single JSON Pointer reference token per
+// RFC 6901: '~' becomes '~0' and '/' becomes '~1'.
+func escapeJSONPointerToken(s string) string {
+	if !strings.ContainsAny(s, "~/") {
+		return s
+	}
+	return strings.NewReplacer("~", "~0", "/", "~1").Replace(s)
+}
+
+func (w *schemaWalker) document(doc *T) error {
+	if c := doc.Components; c != nil {
+		for name, sr := range c.Schemas {
+			if err := w.schemaRef("/components/schemas/"+escapeJSONPointerToken(name), sr); err != nil {
+				return err
+			}
+		}
+		for name, pr := range c.Parameters {
+			if err := w.parameter("/components/parameters/"+escapeJSONPointerToken(name), pr); err != nil {
+				return err
+			}
+		}
+		for name, hr := range c.Headers {
+			if err := w.header("/components/headers/"+escapeJSONPointerToken(name), hr); err != nil {
+				return err
+			}
+		}
+		for name, rbr := range c.RequestBodies {
+			if rbr != nil && rbr.Value != nil {
+				if err := w.content("/components/requestBodies/"+escapeJSONPointerToken(name)+"/content", rbr.Value.Content); err != nil {
+					return err
+				}
+			}
+		}
+		for name, rr := range c.Responses {
+			if err := w.response("/components/responses/"+escapeJSONPointerToken(name), rr); err != nil {
+				return err
+			}
+		}
+		for name, cbr := range c.Callbacks {
+			if cbr != nil && cbr.Value != nil {
+				if err := w.callback("/components/callbacks/"+escapeJSONPointerToken(name), cbr.Value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	if doc.Paths != nil {
+		for path, item := range doc.Paths.Map() {
+			if err := w.pathItem("/paths/"+escapeJSONPointerToken(path), item); err != nil {
+				return err
+			}
+		}
+	}
+	for name, item := range doc.Webhooks {
+		if err := w.pathItem("/webhooks/"+escapeJSONPointerToken(name), item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *schemaWalker) pathItem(loc string, item *PathItem) error {
+	if item == nil {
+		return nil
+	}
+	for i, pr := range item.Parameters {
+		if err := w.parameter(loc+"/parameters/"+strconv.Itoa(i), pr); err != nil {
+			return err
+		}
+	}
+	for method, op := range item.Operations() {
+		if err := w.operation(loc+"/"+strings.ToLower(method), op); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *schemaWalker) operation(loc string, op *Operation) error {
+	if op == nil {
+		return nil
+	}
+	for i, pr := range op.Parameters {
+		if err := w.parameter(loc+"/parameters/"+strconv.Itoa(i), pr); err != nil {
+			return err
+		}
+	}
+	if op.RequestBody != nil && op.RequestBody.Value != nil {
+		if err := w.content(loc+"/requestBody/content", op.RequestBody.Value.Content); err != nil {
+			return err
+		}
+	}
+	if op.Responses != nil {
+		for code, rr := range op.Responses.Map() {
+			if err := w.response(loc+"/responses/"+escapeJSONPointerToken(code), rr); err != nil {
+				return err
+			}
+		}
+	}
+	for name, cbr := range op.Callbacks {
+		if cbr != nil && cbr.Value != nil {
+			if err := w.callback(loc+"/callbacks/"+escapeJSONPointerToken(name), cbr.Value); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (w *schemaWalker) callback(loc string, cb *Callback) error {
+	for expr, item := range cb.Map() {
+		if err := w.pathItem(loc+"/"+escapeJSONPointerToken(expr), item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *schemaWalker) parameter(loc string, pr *ParameterRef) error {
+	if pr == nil || pr.Value == nil {
+		return nil
+	}
+	if err := w.schemaRef(loc+"/schema", pr.Value.Schema); err != nil {
+		return err
+	}
+	return w.content(loc+"/content", pr.Value.Content)
+}
+
+func (w *schemaWalker) header(loc string, hr *HeaderRef) error {
+	if hr == nil || hr.Value == nil {
+		return nil
+	}
+	if err := w.schemaRef(loc+"/schema", hr.Value.Schema); err != nil {
+		return err
+	}
+	return w.content(loc+"/content", hr.Value.Content)
+}
+
+func (w *schemaWalker) response(loc string, rr *ResponseRef) error {
+	if rr == nil || rr.Value == nil {
+		return nil
+	}
+	for name, hr := range rr.Value.Headers {
+		if err := w.header(loc+"/headers/"+escapeJSONPointerToken(name), hr); err != nil {
+			return err
+		}
+	}
+	return w.content(loc+"/content", rr.Value.Content)
+}
+
+func (w *schemaWalker) content(loc string, content Content) error {
+	for mediaType, media := range content {
+		if media == nil {
+			continue
+		}
+		if err := w.schemaRef(loc+"/"+escapeJSONPointerToken(mediaType)+"/schema", media.Schema); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *schemaWalker) schemaRefs(loc string, refs SchemaRefs) error {
+	for i, sub := range refs {
+		if err := w.schemaRef(loc+"/"+strconv.Itoa(i), sub); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *schemaWalker) schemaRef(loc string, sr *SchemaRef) error {
+	if sr == nil || sr.Value == nil {
+		return nil
+	}
+	s := sr.Value
+	if _, ok := w.seen[s]; ok {
+		// Already visited (shared $ref target or reference cycle).
+		return nil
+	}
+	w.seen[s] = struct{}{}
+
+	if err := w.fn(loc, sr); err != nil {
+		if errors.Is(err, SkipSubtree) {
+			return nil
+		}
+		return err
+	}
+
+	for name, sub := range s.Properties {
+		if err := w.schemaRef(loc+"/properties/"+escapeJSONPointerToken(name), sub); err != nil {
+			return err
+		}
+	}
+	if err := w.schemaRef(loc+"/items", s.Items); err != nil {
+		return err
+	}
+	if s.AdditionalProperties.Schema != nil {
+		if err := w.schemaRef(loc+"/additionalProperties", s.AdditionalProperties.Schema); err != nil {
+			return err
+		}
+	}
+	if err := w.schemaRefs(loc+"/allOf", s.AllOf); err != nil {
+		return err
+	}
+	if err := w.schemaRefs(loc+"/anyOf", s.AnyOf); err != nil {
+		return err
+	}
+	if err := w.schemaRefs(loc+"/oneOf", s.OneOf); err != nil {
+		return err
+	}
+	if err := w.schemaRef(loc+"/not", s.Not); err != nil {
+		return err
+	}
+	if err := w.schemaRefs(loc+"/prefixItems", s.PrefixItems); err != nil {
+		return err
+	}
+	if err := w.schemaRef(loc+"/contains", s.Contains); err != nil {
+		return err
+	}
+	for name, sub := range s.PatternProperties {
+		if err := w.schemaRef(loc+"/patternProperties/"+escapeJSONPointerToken(name), sub); err != nil {
+			return err
+		}
+	}
+	for name, sub := range s.DependentSchemas {
+		if err := w.schemaRef(loc+"/dependentSchemas/"+escapeJSONPointerToken(name), sub); err != nil {
+			return err
+		}
+	}
+	if err := w.schemaRef(loc+"/propertyNames", s.PropertyNames); err != nil {
+		return err
+	}
+	if err := w.schemaRef(loc+"/if", s.If); err != nil {
+		return err
+	}
+	if err := w.schemaRef(loc+"/then", s.Then); err != nil {
+		return err
+	}
+	if err := w.schemaRef(loc+"/else", s.Else); err != nil {
+		return err
+	}
+	for name, sub := range s.Defs {
+		if err := w.schemaRef(loc+"/$defs/"+escapeJSONPointerToken(name), sub); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/openapi3/walk.go
+++ b/openapi3/walk.go
@@ -2,6 +2,8 @@ package openapi3
 
 import (
 	"errors"
+	"maps"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -14,20 +16,24 @@ var SkipSubtree = errors.New("skip schema subtree")
 
 // WalkSchemasFunc is called once for each schema visited by WalkSchemas.
 //
-// location is the JSON Pointer (RFC 6901) of the schema within the document,
+// jsonPointer is the RFC 6901 JSON Pointer of the schema within the document,
 // e.g. "/components/schemas/Pet/properties/tag" or
-// "/paths/~1pets/get/responses/200/content/application~1json/schema". sr is
-// never nil and sr.Value is never nil; the callback may modify sr.Value in
-// place, so WalkSchemas serves transformers and not only read-only inspection.
+// "/paths/~1pets/get/responses/200/content/application~1json/schema". It is
+// file-agnostic: once the loader has resolved external $refs the document is a
+// single tree, so the pointer addresses a position in that tree and never
+// encodes a source file. schema is non-nil and schema.Value is non-nil; the
+// callback may modify schema.Value in place, so WalkSchemas serves transformers
+// and not only read-only inspection.
 //
 // Returning SkipSubtree skips this schema's sub-schemas; returning any other
 // error aborts the walk and is returned by WalkSchemas.
-type WalkSchemasFunc func(location string, schema *SchemaRef) error
+type WalkSchemasFunc func(jsonPointer string, schema *SchemaRef) error
 
-// WalkSchemas visits every schema reachable from the document exactly once, in
-// document order, invoking fn for each. It follows resolved $ref targets
-// (schema.Value) and guards against reference cycles, so each distinct *Schema
-// is visited a single time regardless of how many references point at it.
+// WalkSchemas visits every schema reachable from the document exactly once,
+// invoking fn for each. It follows resolved $ref targets (schema.Value) and
+// guards against reference cycles, so each distinct *Schema is visited a single
+// time regardless of how many references point at it. Maps are visited in
+// sorted key order, so the traversal is deterministic.
 //
 // It covers schemas under components (schemas, parameters, headers, request
 // bodies, responses, callbacks), the paths and their operations (parameters,
@@ -53,9 +59,9 @@ type schemaWalker struct {
 	seen map[*Schema]struct{}
 }
 
-// escapeJSONPointerToken escapes a single JSON Pointer reference token per
-// RFC 6901: '~' becomes '~0' and '/' becomes '~1'.
-func escapeJSONPointerToken(s string) string {
+// escapeRefString escapes a single JSON Pointer reference token per RFC 6901:
+// '~' becomes '~0' and '/' becomes '~1'. It is the inverse of unescapeRefString.
+func escapeRefString(s string) string {
 	if !strings.ContainsAny(s, "~/") {
 		return s
 	}
@@ -64,97 +70,100 @@ func escapeJSONPointerToken(s string) string {
 
 func (w *schemaWalker) document(doc *T) error {
 	if c := doc.Components; c != nil {
-		for name, sr := range c.Schemas {
-			if err := w.schemaRef("/components/schemas/"+escapeJSONPointerToken(name), sr); err != nil {
+		for _, name := range slices.Sorted(maps.Keys(c.Schemas)) {
+			if err := w.schemaRef("/components/schemas/"+escapeRefString(name), c.Schemas[name]); err != nil {
 				return err
 			}
 		}
-		for name, pr := range c.Parameters {
-			if err := w.parameter("/components/parameters/"+escapeJSONPointerToken(name), pr); err != nil {
+		for _, name := range slices.Sorted(maps.Keys(c.Parameters)) {
+			if err := w.parameter("/components/parameters/"+escapeRefString(name), c.Parameters[name]); err != nil {
 				return err
 			}
 		}
-		for name, hr := range c.Headers {
-			if err := w.header("/components/headers/"+escapeJSONPointerToken(name), hr); err != nil {
+		for _, name := range slices.Sorted(maps.Keys(c.Headers)) {
+			if err := w.header("/components/headers/"+escapeRefString(name), c.Headers[name]); err != nil {
 				return err
 			}
 		}
-		for name, rbr := range c.RequestBodies {
-			if rbr != nil && rbr.Value != nil {
-				if err := w.content("/components/requestBodies/"+escapeJSONPointerToken(name)+"/content", rbr.Value.Content); err != nil {
+		for _, name := range slices.Sorted(maps.Keys(c.RequestBodies)) {
+			if rbr := c.RequestBodies[name]; rbr != nil && rbr.Value != nil {
+				if err := w.content("/components/requestBodies/"+escapeRefString(name)+"/content", rbr.Value.Content); err != nil {
 					return err
 				}
 			}
 		}
-		for name, rr := range c.Responses {
-			if err := w.response("/components/responses/"+escapeJSONPointerToken(name), rr); err != nil {
+		for _, name := range slices.Sorted(maps.Keys(c.Responses)) {
+			if err := w.response("/components/responses/"+escapeRefString(name), c.Responses[name]); err != nil {
 				return err
 			}
 		}
-		for name, cbr := range c.Callbacks {
-			if cbr != nil && cbr.Value != nil {
-				if err := w.callback("/components/callbacks/"+escapeJSONPointerToken(name), cbr.Value); err != nil {
+		for _, name := range slices.Sorted(maps.Keys(c.Callbacks)) {
+			if cbr := c.Callbacks[name]; cbr != nil && cbr.Value != nil {
+				if err := w.callback("/components/callbacks/"+escapeRefString(name), cbr.Value); err != nil {
 					return err
 				}
 			}
 		}
 	}
 	if doc.Paths != nil {
-		for path, item := range doc.Paths.Map() {
-			if err := w.pathItem("/paths/"+escapeJSONPointerToken(path), item); err != nil {
+		items := doc.Paths.Map()
+		for _, path := range slices.Sorted(maps.Keys(items)) {
+			if err := w.pathItem("/paths/"+escapeRefString(path), items[path]); err != nil {
 				return err
 			}
 		}
 	}
-	for name, item := range doc.Webhooks {
-		if err := w.pathItem("/webhooks/"+escapeJSONPointerToken(name), item); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(doc.Webhooks)) {
+		if err := w.pathItem("/webhooks/"+escapeRefString(name), doc.Webhooks[name]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *schemaWalker) pathItem(loc string, item *PathItem) error {
+func (w *schemaWalker) pathItem(ptr string, item *PathItem) error {
 	if item == nil {
 		return nil
 	}
 	for i, pr := range item.Parameters {
-		if err := w.parameter(loc+"/parameters/"+strconv.Itoa(i), pr); err != nil {
+		if err := w.parameter(ptr+"/parameters/"+strconv.Itoa(i), pr); err != nil {
 			return err
 		}
 	}
-	for method, op := range item.Operations() {
-		if err := w.operation(loc+"/"+strings.ToLower(method), op); err != nil {
+	ops := item.Operations()
+	for _, method := range slices.Sorted(maps.Keys(ops)) {
+		if err := w.operation(ptr+"/"+strings.ToLower(method), ops[method]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *schemaWalker) operation(loc string, op *Operation) error {
+func (w *schemaWalker) operation(ptr string, op *Operation) error {
 	if op == nil {
 		return nil
 	}
 	for i, pr := range op.Parameters {
-		if err := w.parameter(loc+"/parameters/"+strconv.Itoa(i), pr); err != nil {
+		if err := w.parameter(ptr+"/parameters/"+strconv.Itoa(i), pr); err != nil {
 			return err
 		}
 	}
 	if op.RequestBody != nil && op.RequestBody.Value != nil {
-		if err := w.content(loc+"/requestBody/content", op.RequestBody.Value.Content); err != nil {
+		if err := w.content(ptr+"/requestBody/content", op.RequestBody.Value.Content); err != nil {
 			return err
 		}
 	}
 	if op.Responses != nil {
-		for code, rr := range op.Responses.Map() {
-			if err := w.response(loc+"/responses/"+escapeJSONPointerToken(code), rr); err != nil {
+		responses := op.Responses.Map()
+		for _, code := range slices.Sorted(maps.Keys(responses)) {
+			if err := w.response(ptr+"/responses/"+escapeRefString(code), responses[code]); err != nil {
 				return err
 			}
 		}
 	}
-	for name, cbr := range op.Callbacks {
-		if cbr != nil && cbr.Value != nil {
-			if err := w.callback(loc+"/callbacks/"+escapeJSONPointerToken(name), cbr.Value); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(op.Callbacks)) {
+		if cbr := op.Callbacks[name]; cbr != nil && cbr.Value != nil {
+			if err := w.callback(ptr+"/callbacks/"+escapeRefString(name), cbr.Value); err != nil {
 				return err
 			}
 		}
@@ -162,69 +171,71 @@ func (w *schemaWalker) operation(loc string, op *Operation) error {
 	return nil
 }
 
-func (w *schemaWalker) callback(loc string, cb *Callback) error {
-	for expr, item := range cb.Map() {
-		if err := w.pathItem(loc+"/"+escapeJSONPointerToken(expr), item); err != nil {
+func (w *schemaWalker) callback(ptr string, cb *Callback) error {
+	items := cb.Map()
+	for _, expr := range slices.Sorted(maps.Keys(items)) {
+		if err := w.pathItem(ptr+"/"+escapeRefString(expr), items[expr]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *schemaWalker) parameter(loc string, pr *ParameterRef) error {
+func (w *schemaWalker) parameter(ptr string, pr *ParameterRef) error {
 	if pr == nil || pr.Value == nil {
 		return nil
 	}
-	if err := w.schemaRef(loc+"/schema", pr.Value.Schema); err != nil {
+	if err := w.schemaRef(ptr+"/schema", pr.Value.Schema); err != nil {
 		return err
 	}
-	return w.content(loc+"/content", pr.Value.Content)
+	return w.content(ptr+"/content", pr.Value.Content)
 }
 
-func (w *schemaWalker) header(loc string, hr *HeaderRef) error {
+func (w *schemaWalker) header(ptr string, hr *HeaderRef) error {
 	if hr == nil || hr.Value == nil {
 		return nil
 	}
-	if err := w.schemaRef(loc+"/schema", hr.Value.Schema); err != nil {
+	if err := w.schemaRef(ptr+"/schema", hr.Value.Schema); err != nil {
 		return err
 	}
-	return w.content(loc+"/content", hr.Value.Content)
+	return w.content(ptr+"/content", hr.Value.Content)
 }
 
-func (w *schemaWalker) response(loc string, rr *ResponseRef) error {
+func (w *schemaWalker) response(ptr string, rr *ResponseRef) error {
 	if rr == nil || rr.Value == nil {
 		return nil
 	}
-	for name, hr := range rr.Value.Headers {
-		if err := w.header(loc+"/headers/"+escapeJSONPointerToken(name), hr); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(rr.Value.Headers)) {
+		if err := w.header(ptr+"/headers/"+escapeRefString(name), rr.Value.Headers[name]); err != nil {
 			return err
 		}
 	}
-	return w.content(loc+"/content", rr.Value.Content)
+	return w.content(ptr+"/content", rr.Value.Content)
 }
 
-func (w *schemaWalker) content(loc string, content Content) error {
-	for mediaType, media := range content {
+func (w *schemaWalker) content(ptr string, content Content) error {
+	for _, mediaType := range slices.Sorted(maps.Keys(content)) {
+		media := content[mediaType]
 		if media == nil {
 			continue
 		}
-		if err := w.schemaRef(loc+"/"+escapeJSONPointerToken(mediaType)+"/schema", media.Schema); err != nil {
+		if err := w.schemaRef(ptr+"/"+escapeRefString(mediaType)+"/schema", media.Schema); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *schemaWalker) schemaRefs(loc string, refs SchemaRefs) error {
+func (w *schemaWalker) schemaRefs(ptr string, refs SchemaRefs) error {
 	for i, sub := range refs {
-		if err := w.schemaRef(loc+"/"+strconv.Itoa(i), sub); err != nil {
+		if err := w.schemaRef(ptr+"/"+strconv.Itoa(i), sub); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (w *schemaWalker) schemaRef(loc string, sr *SchemaRef) error {
+func (w *schemaWalker) schemaRef(ptr string, sr *SchemaRef) error {
 	if sr == nil || sr.Value == nil {
 		return nil
 	}
@@ -235,68 +246,68 @@ func (w *schemaWalker) schemaRef(loc string, sr *SchemaRef) error {
 	}
 	w.seen[s] = struct{}{}
 
-	if err := w.fn(loc, sr); err != nil {
+	if err := w.fn(ptr, sr); err != nil {
 		if errors.Is(err, SkipSubtree) {
 			return nil
 		}
 		return err
 	}
 
-	for name, sub := range s.Properties {
-		if err := w.schemaRef(loc+"/properties/"+escapeJSONPointerToken(name), sub); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(s.Properties)) {
+		if err := w.schemaRef(ptr+"/properties/"+escapeRefString(name), s.Properties[name]); err != nil {
 			return err
 		}
 	}
-	if err := w.schemaRef(loc+"/items", s.Items); err != nil {
+	if err := w.schemaRef(ptr+"/items", s.Items); err != nil {
 		return err
 	}
 	if s.AdditionalProperties.Schema != nil {
-		if err := w.schemaRef(loc+"/additionalProperties", s.AdditionalProperties.Schema); err != nil {
+		if err := w.schemaRef(ptr+"/additionalProperties", s.AdditionalProperties.Schema); err != nil {
 			return err
 		}
 	}
-	if err := w.schemaRefs(loc+"/allOf", s.AllOf); err != nil {
+	if err := w.schemaRefs(ptr+"/allOf", s.AllOf); err != nil {
 		return err
 	}
-	if err := w.schemaRefs(loc+"/anyOf", s.AnyOf); err != nil {
+	if err := w.schemaRefs(ptr+"/anyOf", s.AnyOf); err != nil {
 		return err
 	}
-	if err := w.schemaRefs(loc+"/oneOf", s.OneOf); err != nil {
+	if err := w.schemaRefs(ptr+"/oneOf", s.OneOf); err != nil {
 		return err
 	}
-	if err := w.schemaRef(loc+"/not", s.Not); err != nil {
+	if err := w.schemaRef(ptr+"/not", s.Not); err != nil {
 		return err
 	}
-	if err := w.schemaRefs(loc+"/prefixItems", s.PrefixItems); err != nil {
+	if err := w.schemaRefs(ptr+"/prefixItems", s.PrefixItems); err != nil {
 		return err
 	}
-	if err := w.schemaRef(loc+"/contains", s.Contains); err != nil {
+	if err := w.schemaRef(ptr+"/contains", s.Contains); err != nil {
 		return err
 	}
-	for name, sub := range s.PatternProperties {
-		if err := w.schemaRef(loc+"/patternProperties/"+escapeJSONPointerToken(name), sub); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(s.PatternProperties)) {
+		if err := w.schemaRef(ptr+"/patternProperties/"+escapeRefString(name), s.PatternProperties[name]); err != nil {
 			return err
 		}
 	}
-	for name, sub := range s.DependentSchemas {
-		if err := w.schemaRef(loc+"/dependentSchemas/"+escapeJSONPointerToken(name), sub); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(s.DependentSchemas)) {
+		if err := w.schemaRef(ptr+"/dependentSchemas/"+escapeRefString(name), s.DependentSchemas[name]); err != nil {
 			return err
 		}
 	}
-	if err := w.schemaRef(loc+"/propertyNames", s.PropertyNames); err != nil {
+	if err := w.schemaRef(ptr+"/propertyNames", s.PropertyNames); err != nil {
 		return err
 	}
-	if err := w.schemaRef(loc+"/if", s.If); err != nil {
+	if err := w.schemaRef(ptr+"/if", s.If); err != nil {
 		return err
 	}
-	if err := w.schemaRef(loc+"/then", s.Then); err != nil {
+	if err := w.schemaRef(ptr+"/then", s.Then); err != nil {
 		return err
 	}
-	if err := w.schemaRef(loc+"/else", s.Else); err != nil {
+	if err := w.schemaRef(ptr+"/else", s.Else); err != nil {
 		return err
 	}
-	for name, sub := range s.Defs {
-		if err := w.schemaRef(loc+"/$defs/"+escapeJSONPointerToken(name), sub); err != nil {
+	for _, name := range slices.Sorted(maps.Keys(s.Defs)) {
+		if err := w.schemaRef(ptr+"/$defs/"+escapeRefString(name), s.Defs[name]); err != nil {
 			return err
 		}
 	}

--- a/openapi3/walk_test.go
+++ b/openapi3/walk_test.go
@@ -4,8 +4,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // walkSpec exercises schemas in components and under a path operation

--- a/openapi3/walk_test.go
+++ b/openapi3/walk_test.go
@@ -2,6 +2,7 @@ package openapi3_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -129,4 +130,48 @@ func TestWalkSchemas_ErrorAborts(t *testing.T) {
 	})
 	require.ErrorIs(t, err, boom)
 	require.Equal(t, 1, count, "walk should stop at the first error")
+}
+
+// ExampleT_WalkSchemas lists where every schema in a document lives. The walk is
+// deterministic (maps are visited in sorted key order), and the `$ref` to Pet
+// from the response is deduped so Pet is reported once, at its component path.
+func ExampleT_WalkSchemas() {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(`
+openapi: 3.0.3
+info: {title: Pets, version: "1.0"}
+paths:
+  /pets:
+    get:
+      responses:
+        "200":
+          description: a list of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id: {type: integer}
+        name: {type: string}
+`))
+	if err != nil {
+		panic(err)
+	}
+
+	_ = doc.WalkSchemas(func(jsonPointer string, schema *openapi3.SchemaRef) error {
+		fmt.Println(jsonPointer)
+		return nil
+	})
+
+	// Output:
+	// /components/schemas/Pet
+	// /components/schemas/Pet/properties/id
+	// /components/schemas/Pet/properties/name
+	// /paths/~1pets/get/responses/200/content/application~1json/schema
 }

--- a/openapi3/walk_test.go
+++ b/openapi3/walk_test.go
@@ -1,0 +1,130 @@
+package openapi3_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+// walkSpec exercises schemas in components and under a path operation
+// (parameter, request body, response content and header), inline nested
+// sub-schemas (deterministic locations), a shared $ref (dedup), and a
+// self-referential schema (cycle safety).
+var walkSpec = []byte(`
+openapi: 3.0.3
+info: {title: t, version: "1"}
+paths:
+  /pets:
+    get:
+      parameters:
+        - name: limit
+          in: query
+          schema: {type: integer}
+      responses:
+        "200":
+          description: ok
+          headers:
+            X-Next:
+              schema: {type: string}
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      type: object
+      properties:
+        id: {type: integer}
+        friends:
+          type: array
+          items: {type: string}
+        tag:
+          $ref: '#/components/schemas/Tag'
+    Tag:
+      type: string
+    Node:
+      type: object
+      properties:
+        next:
+          $ref: '#/components/schemas/Node'
+`)
+
+func loadWalkSpec(t *testing.T) *openapi3.T {
+	t.Helper()
+	doc, err := openapi3.NewLoader().LoadFromData(walkSpec)
+	require.NoError(t, err)
+	return doc
+}
+
+func TestWalkSchemas(t *testing.T) {
+	doc := loadWalkSpec(t)
+
+	locsByPtr := map[*openapi3.Schema][]string{}
+	var visited []string
+	err := doc.WalkSchemas(func(loc string, sr *openapi3.SchemaRef) error {
+		require.NotNil(t, sr)
+		require.NotNil(t, sr.Value)
+		locsByPtr[sr.Value] = append(locsByPtr[sr.Value], loc)
+		visited = append(visited, loc)
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Every distinct schema is visited exactly once: shared $refs are deduped
+	// and the self-referential Node does not loop forever.
+	for s, locs := range locsByPtr {
+		require.Lenf(t, locs, 1, "schema %p visited %d times: %v", s, len(locs), locs)
+	}
+
+	// Deterministic locations for inline (non-$ref) schemas across components,
+	// nested sub-schemas, and the operation's parameter/response surfaces.
+	for _, want := range []string{
+		"/components/schemas/Pet",
+		"/components/schemas/Pet/properties/id",
+		"/components/schemas/Pet/properties/friends",
+		"/components/schemas/Pet/properties/friends/items",
+		"/components/schemas/Node",
+		"/paths/~1pets/get/parameters/0/schema",
+		"/paths/~1pets/get/responses/200/headers/X-Next/schema",
+		"/paths/~1pets/get/responses/200/content/application~1json/schema",
+	} {
+		require.Contains(t, visited, want)
+	}
+}
+
+func TestWalkSchemas_SkipSubtree(t *testing.T) {
+	doc := loadWalkSpec(t)
+
+	var visited []string
+	err := doc.WalkSchemas(func(loc string, sr *openapi3.SchemaRef) error {
+		visited = append(visited, loc)
+		if loc == "/components/schemas/Pet" {
+			return openapi3.SkipSubtree
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Pet itself is visited, but SkipSubtree prevents descent into its members.
+	require.Contains(t, visited, "/components/schemas/Pet")
+	require.NotContains(t, visited, "/components/schemas/Pet/properties/id")
+	require.NotContains(t, visited, "/components/schemas/Pet/properties/friends")
+}
+
+func TestWalkSchemas_ErrorAborts(t *testing.T) {
+	doc := loadWalkSpec(t)
+
+	boom := errors.New("boom")
+	count := 0
+	err := doc.WalkSchemas(func(loc string, sr *openapi3.SchemaRef) error {
+		count++
+		return boom
+	})
+	require.ErrorIs(t, err, boom)
+	require.Equal(t, 1, count, "walk should stop at the first error")
+}

--- a/openapi3/walk_test.go
+++ b/openapi3/walk_test.go
@@ -57,7 +57,8 @@ components:
 
 func loadWalkSpec(t *testing.T) *openapi3.T {
 	t.Helper()
-	doc, err := openapi3.NewLoader().LoadFromData(walkSpec)
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(walkSpec)
 	require.NoError(t, err)
 	return doc
 }


### PR DESCRIPTION
## What

Adds `(*T).WalkSchemas(fn)`, a general-purpose traversal that visits **every schema reachable from a document exactly once**, in document order.

```go
var SkipSubtree = errors.New("skip schema subtree")
type WalkSchemasFunc func(location string, schema *SchemaRef) error
func (doc *T) WalkSchemas(fn WalkSchemasFunc) error
```

- **Complete coverage.** Components (schemas, parameters, headers, request bodies, responses, callbacks), paths and their operations (parameters, request bodies, responses, headers, callbacks), webhooks, and every sub-schema keyword: `properties`, `items`, `allOf`/`anyOf`/`oneOf`, `not`, `additionalProperties`, `prefixItems`, `contains`, `patternProperties`, `dependentSchemas`, `propertyNames`, `if`/`then`/`else`, `$defs`.
- **Cycle-safe.** Each distinct `*Schema` is visited once, so shared `$ref` targets are deduped and self-referential schemas don't loop.
- **Locatable.** The callback gets each schema's JSON Pointer (RFC 6901), for example `/paths/~1pets/get/responses/200/content/application~1json/schema`.
- **Mutation-friendly.** It passes `*SchemaRef`, so the walk serves transformers, not only read-only inspection.
- **Familiar shape.** `SkipSubtree` mirrors `filepath.SkipDir`, and any other returned error aborts the walk.

## Why

Traversing every schema in a document is something many consumers need (validation, code generation, schema transformation, `$ref`/dependency analysis, documentation), and each one currently re-implements the same recursion, which is easy to get wrong (it is simple to miss `prefixItems`, `patternProperties`, `$defs`, or a component/callback entry point). Centralizing it here makes it correct once, tested once, and consistent across consumers.

Purely additive: one new file plus tests, no changes to existing types or behavior.

## Tests

`openapi3/walk_test.go` covers full traversal across the entry points, deterministic JSON Pointer locations for inline schemas, dedup of shared `$ref`s, cycle safety (a self-referential schema), `SkipSubtree` pruning, and error-abort.

## Status

Opening as a **draft** to get feedback on the API shape (the `WalkSchemasFunc(location, *SchemaRef)` signature and the `SkipSubtree` sentinel) before finalizing. Happy to adjust naming or semantics.