### PR TITLE
openapi3: support OAS 3.2 itemSchema

### DIFF
--- a/openapi3/doc.go
+++ b/openapi3/doc.go
@@ -1,8 +1,9 @@
 // Package openapi3 parses and writes OpenAPI 3 specification documents.
 //
-// Supports both OpenAPI 3.0 and OpenAPI 3.1:
+// Supports OpenAPI 3.0, OpenAPI 3.1, and OpenAPI 3.2:
 //   - OpenAPI 3.0.x: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md
 //   - OpenAPI 3.1.x: https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md
+//   - OpenAPI 3.2.x: https://spec.openapis.org/oas/v3.2.0.html
 //
 // OpenAPI 3.1 Features:
 //   - Type arrays with null support (e.g., ["string", "null"])
@@ -10,6 +11,9 @@
 //   - Webhooks for defining callback operations
 //   - JSON Schema dialect specification
 //   - SPDX license identifiers
+//
+// OpenAPI 3.2 Features:
+//   - Media Type Object itemSchema for streaming sequential media types
 //
 // The implementation maintains 100% backward compatibility with OpenAPI 3.0.
 //
@@ -21,5 +25,8 @@
 //
 //	if doc.IsOpenAPI31OrLater() {
 //	    // Handle OpenAPI 3.1 specific features
+//	}
+//	if doc.IsOpenAPI32OrLater() {
+//	    // Handle OpenAPI 3.2 specific features
 //	}
 package openapi3

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -756,16 +756,8 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 		return errors.New("cannot contain both schema and content in a parameter")
 	}
 	for _, name := range componentNames(value.Content) {
-		contentType := value.Content[name]
-		if schema := contentType.Schema; schema != nil {
-			if err := loader.resolveSchemaRef(doc, schema, documentPath, []string{}); err != nil {
-				return err
-			}
-		}
-		for _, k := range componentNames(contentType.Examples) {
-			if err := loader.resolveExampleRef(doc, contentType.Examples[k], documentPath); err != nil {
-				return err
-			}
+		if err := loader.resolveMediaTypeRefs(doc, value.Content[name], documentPath); err != nil {
+			return err
 		}
 	}
 	if schema := value.Schema; schema != nil {
@@ -828,21 +820,8 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 	}
 
 	for _, name := range componentNames(value.Content) {
-		contentType := value.Content[name]
-		if contentType == nil {
-			continue
-		}
-		for _, name := range componentNames(contentType.Examples) {
-			example := contentType.Examples[name]
-			if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
-				return err
-			}
-			contentType.Examples[name] = example
-		}
-		if schema := contentType.Schema; schema != nil {
-			if err := loader.resolveSchemaRef(doc, schema, documentPath, []string{}); err != nil {
-				return err
-			}
+		if err := loader.resolveMediaTypeRefs(doc, value.Content[name], documentPath); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -901,27 +880,37 @@ func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documen
 		}
 	}
 	for _, name := range componentNames(value.Content) {
-		contentType := value.Content[name]
-		if contentType == nil {
-			continue
-		}
-		for _, name := range componentNames(contentType.Examples) {
-			example := contentType.Examples[name]
-			if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
-				return err
-			}
-			contentType.Examples[name] = example
-		}
-		if schema := contentType.Schema; schema != nil {
-			if err := loader.resolveSchemaRef(doc, schema, documentPath, []string{}); err != nil {
-				return err
-			}
-			contentType.Schema = schema
+		if err := loader.resolveMediaTypeRefs(doc, value.Content[name], documentPath); err != nil {
+			return err
 		}
 	}
 	for _, name := range componentNames(value.Links) {
 		link := value.Links[name]
 		if err := loader.resolveLinkRef(doc, link, documentPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (loader *Loader) resolveMediaTypeRefs(doc *T, mediaType *MediaType, documentPath *url.URL) error {
+	if mediaType == nil {
+		return nil
+	}
+	for _, name := range componentNames(mediaType.Examples) {
+		example := mediaType.Examples[name]
+		if err := loader.resolveExampleRef(doc, example, documentPath); err != nil {
+			return err
+		}
+		mediaType.Examples[name] = example
+	}
+	if schema := mediaType.Schema; schema != nil {
+		if err := loader.resolveSchemaRef(doc, schema, documentPath, []string{}); err != nil {
+			return err
+		}
+	}
+	if itemSchema := mediaType.ItemSchema; itemSchema != nil {
+		if err := loader.resolveSchemaRef(doc, itemSchema, documentPath, []string{}); err != nil {
 			return err
 		}
 	}

--- a/openapi3/loader_32_item_schema_test.go
+++ b/openapi3/loader_32_item_schema_test.go
@@ -1,0 +1,83 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestOpenAPI32MediaTypeItemSchema(t *testing.T) {
+	doc, err := openapi3.NewLoader().LoadFromData([]byte(`
+openapi: 3.2.0
+info:
+  title: SSE API
+  version: 1.0.0
+paths:
+  /events:
+    get:
+      responses:
+        "200":
+          description: event stream
+          content:
+            text/event-stream:
+              itemSchema:
+                $ref: "#/components/schemas/SseEvent"
+components:
+  schemas:
+    SseEvent:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: string
+        event:
+          type: string
+        id:
+          type: string
+        retry:
+          type: integer
+          minimum: 0
+`))
+	require.NoError(t, err)
+
+	media := doc.Paths.Value("/events").Get.Responses.Status(200).Value.Content.Get("text/event-stream")
+	require.NotNil(t, media)
+	require.NotNil(t, media.ItemSchema)
+	require.Equal(t, "#/components/schemas/SseEvent", media.ItemSchema.Ref)
+	require.NotNil(t, media.ItemSchema.Value)
+	require.True(t, media.ItemSchema.Value.Type.Is(openapi3.TypeObject))
+
+	err = doc.Validate(t.Context())
+	require.NoError(t, err)
+}
+
+func TestWalkSchemasVisitsMediaTypeItemSchema(t *testing.T) {
+	itemSchema := &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{openapi3.TypeObject}}}
+	doc := &openapi3.T{
+		OpenAPI: "3.2.0",
+		Info:    &openapi3.Info{Title: "SSE API", Version: "1.0.0"},
+		Paths: openapi3.NewPaths(openapi3.WithPath("/events", &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				Responses: openapi3.NewResponses(openapi3.WithStatus(200, &openapi3.ResponseRef{
+					Value: &openapi3.Response{
+						Description: openapi3.Ptr("event stream"),
+						Content: openapi3.Content{
+							"text/event-stream": {ItemSchema: itemSchema},
+						},
+					},
+				})),
+			},
+		})),
+	}
+
+	var got []string
+	err := doc.WalkSchemas(func(jsonPointer string, schema *openapi3.SchemaRef) error {
+		got = append(got, jsonPointer)
+		return nil
+	})
+	require.NoError(t, err)
+	require.Contains(t, got, "/paths/~1events/get/responses/200/content/text~1event-stream/itemSchema")
+}

--- a/openapi3/media_type.go
+++ b/openapi3/media_type.go
@@ -14,10 +14,11 @@ type MediaType struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
 
-	Schema   *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Example  any        `json:"example,omitempty" yaml:"example,omitempty"`
-	Examples Examples   `json:"examples,omitempty" yaml:"examples,omitempty"`
-	Encoding Encodings  `json:"encoding,omitempty" yaml:"encoding,omitempty"`
+	Schema     *SchemaRef `json:"schema,omitempty" yaml:"schema,omitempty"`
+	ItemSchema *SchemaRef `json:"itemSchema,omitempty" yaml:"itemSchema,omitempty"`
+	Example    any        `json:"example,omitempty" yaml:"example,omitempty"`
+	Examples   Examples   `json:"examples,omitempty" yaml:"examples,omitempty"`
+	Encoding   Encodings  `json:"encoding,omitempty" yaml:"encoding,omitempty"`
 }
 
 var _ jsonpointer.JSONPointable = (*MediaType)(nil)
@@ -73,10 +74,13 @@ func (mediaType MediaType) MarshalJSON() ([]byte, error) {
 
 // MarshalYAML returns the YAML encoding of MediaType.
 func (mediaType MediaType) MarshalYAML() (any, error) {
-	m := make(map[string]any, 4+len(mediaType.Extensions))
+	m := make(map[string]any, 5+len(mediaType.Extensions))
 	maps.Copy(m, mediaType.Extensions)
 	if x := mediaType.Schema; x != nil {
 		m["schema"] = x
+	}
+	if x := mediaType.ItemSchema; x != nil {
+		m["itemSchema"] = x
 	}
 	if x := mediaType.Example; x != nil {
 		m["example"] = x
@@ -99,6 +103,7 @@ func (mediaType *MediaType) UnmarshalJSON(data []byte) error {
 	}
 	_ = json.Unmarshal(data, &x.Extensions)
 	delete(x.Extensions, "schema")
+	delete(x.Extensions, "itemSchema")
 	delete(x.Extensions, "example")
 	delete(x.Extensions, "examples")
 	delete(x.Extensions, "encoding")
@@ -148,6 +153,14 @@ func (mediaType *MediaType) Validate(ctx context.Context, opts ...ValidationOpti
 			}
 		}
 	}
+	if itemSchema := mediaType.ItemSchema; itemSchema != nil {
+		if !getValidationOptions(ctx).isOpenAPI32OrLater {
+			return errFieldFor32Plus("itemSchema", mediaType.Origin)
+		}
+		if err := itemSchema.Validate(ctx); err != nil {
+			return err
+		}
+	}
 
 	return validateExtensions(ctx, mediaType.Extensions, mediaType.Origin)
 }
@@ -164,6 +177,13 @@ func (mediaType MediaType) JSONLookup(token string) (any, error) {
 		}
 	case "example":
 		return mediaType.Example, nil
+	case "itemSchema":
+		if mediaType.ItemSchema != nil {
+			if mediaType.ItemSchema.Ref != "" {
+				return &Ref{Ref: mediaType.ItemSchema.Ref}, nil
+			}
+			return mediaType.ItemSchema.Value, nil
+		}
 	case "examples":
 		return mediaType.Examples, nil
 	case "encoding":

--- a/openapi3/media_type_test.go
+++ b/openapi3/media_type_test.go
@@ -2,6 +2,7 @@ package openapi3
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -69,4 +70,44 @@ func mediaType() *MediaType {
 			},
 		},
 	}
+}
+
+func TestMediaTypeItemSchemaJSON(t *testing.T) {
+	data := []byte(`
+{
+   "itemSchema": {
+      "type": "object",
+      "properties": {
+         "data": {
+            "type": "string"
+         }
+      }
+   }
+}
+`)
+
+	mt := &MediaType{}
+	err := json.Unmarshal(data, mt)
+	require.NoError(t, err)
+	require.NotNil(t, mt.ItemSchema)
+	require.NotNil(t, mt.ItemSchema.Value)
+	require.True(t, mt.ItemSchema.Value.Type.Is(TypeObject))
+
+	err = mt.Validate(t.Context())
+	require.Error(t, err)
+	var fvm *FieldVersionMismatchError
+	require.True(t, errors.As(err, &fvm))
+	require.Equal(t, "itemSchema", fvm.Field)
+	require.Equal(t, "3.2", fvm.MinVersion)
+
+	err = mt.Validate(t.Context(), IsOpenAPI32OrLater())
+	require.NoError(t, err)
+
+	lookup, err := mt.JSONLookup("itemSchema")
+	require.NoError(t, err)
+	require.Same(t, mt.ItemSchema.Value, lookup)
+
+	encoded, err := json.Marshal(mt)
+	require.NoError(t, err)
+	require.JSONEq(t, string(data), string(encoded))
 }

--- a/openapi3/openapi3.go
+++ b/openapi3/openapi3.go
@@ -53,8 +53,19 @@ func (doc *T) IsOpenAPI31OrLater() bool {
 	return slices.Contains([]string{"3.1", "3.2"}, doc.OpenAPIMajorMinor())
 }
 
+// IsOpenAPI32OrLater returns whether doc is an OpenAPI document version >=3.2.
+// Returns true for 3.2, 3.2.0, ...
+// And false for cases where IsOpenAPI31OrLater returns true for 3.1.x and for invalid strings.
+func (doc *T) IsOpenAPI32OrLater() bool {
+	return doc.OpenAPIMajorMinor() == "3.2"
+}
+
 func errFieldFor31Plus(field string, origin *Origin) error {
 	return newFieldFor31Plus(field, origin)
+}
+
+func errFieldFor32Plus(field string, origin *Origin) error {
+	return newFieldFor32Plus(field, origin)
 }
 
 func errValueOfFieldFor31Plus(value any, field string) error {
@@ -265,6 +276,9 @@ func (doc *T) GetSchemaValidationOptions() []SchemaValidationOption {
 func (doc *T) Validate(ctx context.Context, opts ...ValidationOption) error {
 	if doc.IsOpenAPI31OrLater() {
 		opts = append(opts, IsOpenAPI31OrLater())
+	}
+	if doc.IsOpenAPI32OrLater() {
+		opts = append(opts, IsOpenAPI32OrLater())
 	}
 	ctx = WithValidationOptions(ctx, opts...)
 	me := newErrCollector(ctx)

--- a/openapi3/openapi3_test.go
+++ b/openapi3/openapi3_test.go
@@ -484,16 +484,19 @@ func TestOpenAPIMajorMinor(t *testing.T) {
 	require.Equal(t, "", doc.OpenAPIMajorMinor())
 	require.False(t, doc.IsOpenAPI30())
 	require.False(t, doc.IsOpenAPI31OrLater())
+	require.False(t, doc.IsOpenAPI32OrLater())
 
 	doc = &openapi3.T{}
 	require.Equal(t, "", doc.OpenAPIMajorMinor())
 	require.False(t, doc.IsOpenAPI30())
 	require.False(t, doc.IsOpenAPI31OrLater())
+	require.False(t, doc.IsOpenAPI32OrLater())
 
 	semvers := []string{"3", "3.0", "3.0.0", "3.0.1", "3.0.2", "3.0.3", "3.0.4", "3.1", "3.1.0", "3.1.1", "3.1.2", "3.2", "3.2.0"}
 	mms := []string{"3.0", "3.0", "3.0", "3.0", "3.0", "3.0", "3.0", "3.1", "3.1", "3.1", "3.1", "3.2", "3.2"}
 	three0s := []bool{true, true, true, true, true, true, true, false, false, false, false, false, false}
 	three1plusses := []bool{false, false, false, false, false, false, false, true, true, true, true, true, true}
+	three2plusses := []bool{false, false, false, false, false, false, false, false, false, false, false, true, true}
 	for i := range len(semvers) {
 		t.Run(fmt.Sprintf("openapi:%s", semvers[i]), func(t *testing.T) {
 			t.Parallel()
@@ -501,6 +504,7 @@ func TestOpenAPIMajorMinor(t *testing.T) {
 			require.Equal(t, mms[i], doc.OpenAPIMajorMinor())
 			require.Equal(t, three0s[i], doc.IsOpenAPI30())
 			require.Equal(t, three1plusses[i], doc.IsOpenAPI31OrLater())
+			require.Equal(t, three2plusses[i], doc.IsOpenAPI32OrLater())
 		})
 	}
 }

--- a/openapi3/testdata/apis_guru_openapi_directory/openuv_io_v1_openapi_yaml__load
+++ b/openapi3/testdata/apis_guru_openapi_directory/openuv_io_v1_openapi_yaml__load
@@ -1,0 +1,1 @@
+map key "uvIndexResult" not found

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -1400,13 +1400,12 @@ func exampleValueOrigin(ex *Example, fallback *Origin) *Origin {
 }
 
 // newFieldVersionMismatch wraps leaf in a FieldVersionMismatchError for the
-// given field at minimum version 3.1. Used by per-call-site constructors
-// (newInfoSummaryFieldFor31Plus, etc.) and by the dispatch helper
-// newFieldFor31Plus that schema.go's reject closure goes through.
-func newFieldVersionMismatch(field string, leaf error, origin *Origin) error {
+// given field at minimum version. Used by per-call-site constructors
+// (newInfoSummaryFieldFor31Plus, etc.) and by dispatch helpers.
+func newFieldVersionMismatch(field, minVersion string, leaf error, origin *Origin) error {
 	return &FieldVersionMismatchError{
 		Field:      field,
-		MinVersion: "3.1",
+		MinVersion: minVersion,
 		Cause:      leaf,
 		Origin:     origin,
 	}
@@ -1420,25 +1419,25 @@ func newFieldVersionMismatch(field string, leaf error, origin *Origin) error {
 func newInfoSummaryFieldFor31Plus(origin *Origin) error {
 	const msg = "field summary is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("summary",
-		&InfoSummaryFieldFor31Plus{ValidationError{Message: msg}}, origin)
+		"3.1", &InfoSummaryFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
 func newLicenseIdentifierFieldFor31Plus(origin *Origin) error {
 	const msg = "field identifier is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("identifier",
-		&LicenseIdentifierFieldFor31Plus{ValidationError{Message: msg}}, origin)
+		"3.1", &LicenseIdentifierFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
 func newWebhooksFieldFor31Plus(origin *Origin) error {
 	const msg = "field webhooks is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("webhooks",
-		&WebhooksFieldFor31Plus{ValidationError{Message: msg}}, origin)
+		"3.1", &WebhooksFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
 func newJSONSchemaDialectFieldFor31Plus(origin *Origin) error {
 	const msg = "field jsonschemadialect is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("jsonschemadialect",
-		&JSONSchemaDialectFieldFor31Plus{ValidationError{Message: msg}}, origin)
+		"3.1", &JSONSchemaDialectFieldFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
 // fieldFor31PlusLeaves maps field names (as passed to errFieldFor31Plus)
@@ -1492,7 +1491,12 @@ func newFieldFor31Plus(field string, origin *Origin) error {
 	} else {
 		leaf = &ValidationError{Message: msg}
 	}
-	return newFieldVersionMismatch(field, leaf, origin)
+	return newFieldVersionMismatch(field, "3.1", leaf, origin)
+}
+
+func newFieldFor32Plus(field string, origin *Origin) error {
+	msg := "field " + field + " is for OpenAPI >=3.2"
+	return newFieldVersionMismatch(field, "3.2", &ValidationError{Message: msg}, origin)
 }
 
 func newPathParameterRequired(param string, origin *Origin) error {

--- a/openapi3/validation_options.go
+++ b/openapi3/validation_options.go
@@ -15,6 +15,7 @@ type ValidationOptions struct {
 	schemaExtensionsInRefProhibited                  bool
 	jsonSchema2020ValidationEnabled                  bool
 	isOpenAPI31OrLater                               bool
+	isOpenAPI32OrLater                               bool
 	multiErrorEnabled                                bool
 	regexCompilerFunc                                RegexCompilerFunc
 	extraSiblingFieldsAllowed                        map[string]struct{}
@@ -39,6 +40,15 @@ func IsOpenAPI31OrLater() ValidationOption {
 	return func(options *ValidationOptions) {
 		options.isOpenAPI31OrLater = true              // To distinguish from v3.0
 		options.jsonSchema2020ValidationEnabled = true // TODO: use even for v3.0
+	}
+}
+
+// IsOpenAPI32OrLater enables validation for OpenAPI 3.2 documents.
+func IsOpenAPI32OrLater() ValidationOption {
+	return func(options *ValidationOptions) {
+		options.isOpenAPI31OrLater = true
+		options.isOpenAPI32OrLater = true
+		options.jsonSchema2020ValidationEnabled = true
 	}
 }
 

--- a/openapi3/walk.go
+++ b/openapi3/walk.go
@@ -38,8 +38,8 @@ type WalkSchemasFunc func(jsonPointer string, schema *SchemaRef) error
 // It covers schemas under components (schemas, parameters, headers, request
 // bodies, responses, callbacks), the paths and their operations (parameters,
 // request bodies, responses, headers, callbacks), and webhooks, then recurses
-// through every sub-schema keyword: properties, items, allOf/anyOf/oneOf, not,
-// additionalProperties, prefixItems, contains, patternProperties,
+// through every sub-schema keyword: properties, items, itemSchema,
+// allOf/anyOf/oneOf, not, additionalProperties, prefixItems, contains, patternProperties,
 // dependentSchemas, propertyNames, if/then/else, and $defs.
 //
 // It is useful for validation, code generation, schema transformation,
@@ -220,6 +220,9 @@ func (w *schemaWalker) content(ptr string, content Content) error {
 			continue
 		}
 		if err := w.schemaRef(ptr+"/"+escapeRefString(mediaType)+"/schema", media.Schema); err != nil {
+			return err
+		}
+		if err := w.schemaRef(ptr+"/"+escapeRefString(mediaType)+"/itemSchema", media.ItemSchema); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Summary:
- add Media Type Object itemSchema support for OpenAPI 3.2
- resolve, validate, marshal, unmarshal, and walk itemSchema refs
- add SSE itemSchema regression coverage

Tests:
- task check
- verified regression tests fail on upstream/master without implementation