### PR TITLE
openapi3: make operation responses optional for 3.1+

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -1648,8 +1648,8 @@ type Operation struct {
 	// Optional body parameter.
 	RequestBody *RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 
-	// Responses.
-	Responses *Responses `json:"responses" yaml:"responses"` // Required
+	// Responses are required in OpenAPI 3.0 and optional in OpenAPI 3.1 and later.
+	Responses *Responses `json:"responses" yaml:"responses"`
 
 	// Optional callbacks
 	Callbacks Callbacks `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`

--- a/maps.sh
+++ b/maps.sh
@@ -163,10 +163,14 @@ maplike_UnMarsh() {
 		echo "TODO: impl non-pointer receiver YAML Marshaler"
 		exit 2
 	fi
+	local nil_condition="${name} == nil"
+	if [[ "$type" == '*Responses' ]]; then
+		nil_condition+=" || ${name}.isExplicitlyNull()"
+	fi
 	cat <<EOF >>"$maplike"
 // MarshalYAML returns the YAML encoding of ${type#'*'}.
 func (${name} ${type}) MarshalYAML() (any, error) {
-	if ${name} == nil {
+	if ${nil_condition} {
 		return nil, nil
 	}
 	m := make(map[string]any, ${name}.Len()+len(${name}.Extensions))

--- a/openapi3/maplike.go
+++ b/openapi3/maplike.go
@@ -80,7 +80,7 @@ func (responses Responses) JSONLookup(token string) (any, error) {
 
 // MarshalYAML returns the YAML encoding of Responses.
 func (responses *Responses) MarshalYAML() (any, error) {
-	if responses == nil {
+	if responses == nil || responses.isExplicitlyNull() {
 		return nil, nil
 	}
 	m := make(map[string]any, responses.Len()+len(responses.Extensions))

--- a/openapi3/operation.go
+++ b/openapi3/operation.go
@@ -33,8 +33,8 @@ type Operation struct {
 	// Optional body parameter.
 	RequestBody *RequestBodyRef `json:"requestBody,omitempty" yaml:"requestBody,omitempty"`
 
-	// Responses.
-	Responses *Responses `json:"responses" yaml:"responses"` // Required
+	// Responses are required in OpenAPI 3.0 and optional in OpenAPI 3.1 and later.
+	Responses *Responses `json:"responses" yaml:"responses"`
 
 	// Optional callbacks
 	Callbacks Callbacks `json:"callbacks,omitempty" yaml:"callbacks,omitempty"`
@@ -87,7 +87,9 @@ func (operation Operation) MarshalYAML() (any, error) {
 	if x := operation.RequestBody; x != nil {
 		m["requestBody"] = x
 	}
-	m["responses"] = operation.Responses
+	if x := operation.Responses; x != nil {
+		m["responses"] = x
+	}
 	if x := operation.Callbacks; len(x) != 0 {
 		m["callbacks"] = x
 	}
@@ -113,7 +115,11 @@ func (operation *Operation) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &x); err != nil {
 		return unmarshalError(err)
 	}
+
 	_ = json.Unmarshal(data, &x.Extensions)
+	if value, present := x.Extensions["responses"]; present && value == nil {
+		x.Responses = &Responses{explicitlyNull: true}
+	}
 	delete(x.Extensions, "tags")
 	delete(x.Extensions, "summary")
 	delete(x.Extensions, "description")
@@ -203,12 +209,14 @@ func (operation *Operation) Validate(ctx context.Context, opts ...ValidationOpti
 		}
 	}
 
-	if v := operation.Responses; v != nil {
+	if v := operation.Responses; v != nil && !v.isExplicitlyNull() {
 		if err := me.emit(v.Validate(ctx)); err != nil {
 			return err
 		}
-	} else if err := me.emit(newOperationResponsesRequired(operation.Origin)); err != nil {
-		return err
+	} else if v != nil || !getValidationOptions(ctx).isOpenAPI31OrLater {
+		if err := me.emit(newOperationResponsesRequired(operation.Origin)); err != nil {
+			return err
+		}
 	}
 
 	if v := operation.ExternalDocs; v != nil {

--- a/openapi3/operation_test.go
+++ b/openapi3/operation_test.go
@@ -1,6 +1,7 @@
 package openapi3_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -43,6 +44,18 @@ func operationWithResponses() *openapi3.Operation {
 	return operation
 }
 
+func loadOperationDocument(t *testing.T, operationJSON string) *openapi3.T {
+	t.Helper()
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(`{
+		"openapi": "3.1.0",
+		"info": {"title": "Test", "version": "1.0.0"},
+		"paths": {"/test": {"get": ` + operationJSON + `}}
+	}`))
+	require.NoError(t, err)
+	return doc
+}
+
 func TestOperationValidation(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -73,4 +86,112 @@ func TestOperationValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOperationResponsesValidationByOpenAPIVersion(t *testing.T) {
+	newDocument := func(version string, responses *openapi3.Responses) *openapi3.T {
+		return &openapi3.T{
+			OpenAPI: version,
+			Info:    &openapi3.Info{Title: "Test", Version: "1.0.0"},
+			Paths: openapi3.NewPaths(openapi3.WithPath("/test", &openapi3.PathItem{
+				Get: &openapi3.Operation{Responses: responses},
+			})),
+		}
+	}
+
+	t.Run("OpenAPI 3.0 requires responses", func(t *testing.T) {
+		err := newDocument("3.0.3", nil).Validate(t.Context())
+		var target *openapi3.OperationResponsesRequired
+		require.ErrorAs(t, err, &target)
+	})
+
+	t.Run("OpenAPI 3.1 allows responses to be omitted", func(t *testing.T) {
+		err := newDocument("3.1.0", nil).Validate(t.Context())
+		require.NoError(t, err)
+	})
+
+	t.Run("OpenAPI 3.2 allows responses to be omitted", func(t *testing.T) {
+		err := newDocument("3.2.0", nil).Validate(t.Context())
+		require.NoError(t, err)
+	})
+
+	t.Run("OpenAPI 3.1 rejects an empty responses object", func(t *testing.T) {
+		err := newDocument("3.1.0", openapi3.NewResponses()).Validate(t.Context())
+		var target *openapi3.ResponsesNonEmptyRequired
+		require.ErrorAs(t, err, &target)
+	})
+}
+
+func TestOperationResponsesParsedStates(t *testing.T) {
+	t.Run("omitted", func(t *testing.T) {
+		doc := loadOperationDocument(t, `{}`)
+		require.NoError(t, doc.Validate(t.Context()))
+	})
+
+	t.Run("null", func(t *testing.T) {
+		doc := loadOperationDocument(t, `{"responses": null}`)
+		err := doc.Validate(t.Context())
+		var target *openapi3.OperationResponsesRequired
+		require.ErrorAs(t, err, &target)
+	})
+
+	t.Run("empty object", func(t *testing.T) {
+		doc := loadOperationDocument(t, `{"responses": {}}`)
+		err := doc.Validate(t.Context())
+		var target *openapi3.ResponsesNonEmptyRequired
+		require.ErrorAs(t, err, &target)
+	})
+
+	t.Run("non-empty object", func(t *testing.T) {
+		doc := loadOperationDocument(t, `{"responses": {"200": {"description": "ok"}}}`)
+		require.NoError(t, doc.Validate(t.Context()))
+	})
+}
+
+func TestOperationResponsesCanBeOmittedAfterParsing(t *testing.T) {
+	for _, operationJSON := range []string{
+		`{"responses": {"200": {"description": "ok"}}}`,
+		`{"responses": null}`,
+	} {
+		doc := loadOperationDocument(t, operationJSON)
+		doc.Paths.Value("/test").Get.Responses = nil
+		require.NoError(t, doc.Validate(t.Context()))
+	}
+}
+
+func TestOperationMarshalResponses(t *testing.T) {
+	t.Run("omitted", func(t *testing.T) {
+		data, err := json.Marshal(openapi3.NewOperation())
+		require.NoError(t, err)
+		require.JSONEq(t, `{}`, string(data))
+	})
+
+	t.Run("null", func(t *testing.T) {
+		doc := loadOperationDocument(t, `{"responses": null}`)
+		operation := doc.Paths.Value("/test").Get
+		data, err := json.Marshal(operation)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"responses": null}`, string(data))
+
+		data, err = json.Marshal(operation.Responses)
+		require.NoError(t, err)
+		require.JSONEq(t, `null`, string(data))
+	})
+}
+
+func TestOperationResponsesCanBeRepairedAfterParsingNull(t *testing.T) {
+	doc := loadOperationDocument(t, `{"responses": null}`)
+	operation := doc.Paths.Value("/test").Get
+	operation.AddResponse(200, openapi3.NewResponse().WithDescription("ok"))
+	require.NoError(t, doc.Validate(t.Context()))
+
+	data, err := json.Marshal(operation)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"responses":{"200":{"description":"ok"}}}`, string(data))
+}
+
+func TestOperationMissingResponsesWithMultiError(t *testing.T) {
+	err := openapi3.NewOperation().Validate(t.Context(), openapi3.EnableMultiError())
+	var target *openapi3.OperationResponsesRequired
+	require.ErrorAs(t, err, &target)
 }

--- a/openapi3/response.go
+++ b/openapi3/response.go
@@ -14,6 +14,8 @@ type Responses struct {
 	Origin     *Origin        `json:"-" yaml:"-"`
 
 	m map[string]*ResponseRef
+
+	explicitlyNull bool
 }
 
 // NewResponses builds a responses object with response objects in insertion order.
@@ -24,6 +26,10 @@ func NewResponses(opts ...NewResponsesOption) *Responses {
 		opt(responses)
 	}
 	return responses
+}
+
+func (responses *Responses) isExplicitlyNull() bool {
+	return responses != nil && responses.explicitlyNull && responses.m == nil && len(responses.Extensions) == 0
 }
 
 // NewResponsesOption describes options to NewResponses func


### PR DESCRIPTION
As per the OpenAPI 3.1 specification, the Operation's responses can be optional. It is valid to leave it empty.

However, `null` and `{}` are *NOT* valid states, it must either be explicitly empty and OpenAPI 3.1 or later to be valid, any `null` or `{}` values we automatically result in an error no matter the version.

You can see this spec [here](https://spec.openapis.org/oas/v3.1.0#operation-object), note how compared to the [3.0 spec](https://spec.openapis.org/oas/v3.0.3#operation-object), the responses field is no longer designated as *REQUIRED*.