### PR TITLE
openapi31: support 3.1+ reference metadata overrides

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -365,6 +365,9 @@ type CallbackRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Callback
@@ -757,6 +760,9 @@ type ExampleRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Example
@@ -1005,6 +1011,9 @@ type HeaderRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Header
@@ -1254,6 +1263,9 @@ type LinkRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Link
@@ -1806,6 +1818,9 @@ type ParameterRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Parameter
@@ -2072,12 +2087,15 @@ func URIMapCache(reader ReadFromURIFunc) ReadFromURIFunc
     documents.
 
 type Ref struct {
-	Ref        string         `json:"$ref" yaml:"$ref"`
-	Extensions map[string]any `json:"-" yaml:"-"`
-	Origin     *Origin        `json:"-" yaml:"-"`
+	Ref         string         `json:"$ref" yaml:"$ref"`
+	Summary     *string        `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string        `json:"description,omitempty" yaml:"description,omitempty"`
+	Extensions  map[string]any `json:"-" yaml:"-"`
+	Origin      *Origin        `json:"-" yaml:"-"`
 }
-    Ref is specified by OpenAPI/Swagger 3.0 standard. See
-    https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#reference-object
+    Ref represents the common fields of an OpenAPI Reference Object.
+    Summary and Description are supported by OpenAPI 3.1 and later. See
+    https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.2.md#reference-object
 
 func (x Ref) MarshalJSON() ([]byte, error)
     MarshalJSON returns the JSON encoding of Ref.
@@ -2163,6 +2181,9 @@ type RequestBodyRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *RequestBody
@@ -2275,6 +2296,9 @@ type ResponseRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Response
@@ -3022,6 +3046,9 @@ type SecuritySchemeRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *SecurityScheme

--- a/openapi3/issue513_test.go
+++ b/openapi3/issue513_test.go
@@ -185,7 +185,7 @@ components:
 	}
 }
 
-func TestIssue513KOMixesRefAlongWithOtherFieldsDisallowed(t *testing.T) {
+func TestIssue513ReferenceDescriptionIsVersionAware(t *testing.T) {
 	spec := `
 openapi: "3.0.3"
 info:
@@ -199,7 +199,7 @@ paths:
       summary: Delete something
       responses:
         200:
-          description: A sibling field that the spec says is ignored
+          description: Reference description
           $ref: '#/components/responses/SomeResponseBody'
 components:
   responses:
@@ -226,7 +226,16 @@ components:
 			doc, err := sl.LoadFromData([]byte(strings.ReplaceAll(spec, "3.0.3", majmin)))
 			require.NoError(t, err)
 			err = doc.Validate(sl.Context)
-			require.ErrorContains(t, err, `extra sibling fields: [description]`)
+			if majmin == "3.0" {
+				require.ErrorContains(t, err, `extra sibling fields: [description]`)
+				return
+			}
+			require.NoError(t, err)
+
+			response := doc.Paths.Value("/v1/operation").Delete.Responses.Status(200)
+			require.NotNil(t, response.Value)
+			require.NotNil(t, response.Value.Description)
+			require.Equal(t, "Reference description", *response.Value.Description)
 		})
 	}
 }

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -647,7 +647,19 @@ var (
 	errMUSTSecurityScheme = errors.New("invalid securityScheme: value MUST be an object")
 )
 
+func applyHeaderRefMetadata(value *Header, component *HeaderRef, isOpenAPI31OrLater bool) *Header {
+	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
+		return value
+	}
+
+	result := *value
+	result.Description = *component.Description
+	return &result
+}
+
 func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if component.isEmpty() {
 		return errMUSTHeader
 	}
@@ -657,7 +669,7 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*Header)
+			component.Value = applyHeaderRefMetadata(value.(*Header), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -687,6 +699,7 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applyHeaderRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -706,7 +719,20 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 	return nil
 }
 
+// applyParameterRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Parameter.
+func applyParameterRefMetadata(value *Parameter, component *ParameterRef, isOpenAPI31OrLater bool) *Parameter {
+	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
+		return value
+	}
+
+	result := *value
+	result.Description = *component.Description
+	return &result
+}
+
 func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if component.isEmpty() {
 		return errMUSTParameter
 	}
@@ -716,7 +742,7 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*Parameter)
+			component.Value = applyParameterRefMetadata(value.(*Parameter), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -746,6 +772,7 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applyParameterRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -773,7 +800,20 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 	return nil
 }
 
+// applyRequestBodyRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced RequestBody.
+func applyRequestBodyRefMetadata(value *RequestBody, component *RequestBodyRef, isOpenAPI31OrLater bool) *RequestBody {
+	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
+		return value
+	}
+
+	result := *value
+	result.Description = *component.Description
+	return &result
+}
+
 func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if component.isEmpty() {
 		return errMUSTRequestBody
 	}
@@ -783,7 +823,7 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*RequestBody)
+			component.Value = applyRequestBodyRefMetadata(value.(*RequestBody), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -813,6 +853,7 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applyRequestBodyRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -827,7 +868,21 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 	return nil
 }
 
+// applyResponseRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Response.
+func applyResponseRefMetadata(value *Response, component *ResponseRef, isOpenAPI31OrLater bool) *Response {
+	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
+		return value
+	}
+
+	result := *value
+	description := *component.Description
+	result.Description = &description
+	return &result
+}
+
 func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if component.isEmpty() {
 		return errMUSTResponse
 	}
@@ -837,7 +892,7 @@ func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documen
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*Response)
+			component.Value = applyResponseRefMetadata(value.(*Response), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -867,6 +922,7 @@ func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documen
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applyResponseRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -1098,7 +1154,20 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 	return nil
 }
 
+// applySecuritySchemeRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced SecurityScheme.
+func applySecuritySchemeRefMetadata(value *SecurityScheme, component *SecuritySchemeRef, isOpenAPI31OrLater bool) *SecurityScheme {
+	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
+		return value
+	}
+
+	result := *value
+	result.Description = *component.Description
+	return &result
+}
+
 func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecuritySchemeRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if component.isEmpty() {
 		return errMUSTSecurityScheme
 	}
@@ -1108,7 +1177,7 @@ func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecurityScheme
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*SecurityScheme)
+			component.Value = applySecuritySchemeRefMetadata(value.(*SecurityScheme), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -1138,17 +1207,36 @@ func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecurityScheme
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applySecuritySchemeRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	return nil
 }
 
+// applyExampleRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Example.
+func applyExampleRefMetadata(value *Example, component *ExampleRef, isOpenAPI31OrLater bool) *Example {
+	if !isOpenAPI31OrLater || value == nil || (component.Summary == nil && component.Description == nil) {
+		return value
+	}
+
+	result := *value
+	if component.Summary != nil {
+		result.Summary = *component.Summary
+	}
+	if component.Description != nil {
+		result.Description = *component.Description
+	}
+	return &result
+}
+
 func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if ref := component.Ref; ref != "" {
 		if component.Value != nil {
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*Example)
+			component.Value = applyExampleRefMetadata(value.(*Example), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -1178,6 +1266,7 @@ func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentP
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applyExampleRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	return nil
 }
@@ -1238,7 +1327,20 @@ func (loader *Loader) resolveCallbackRef(doc *T, component *CallbackRef, documen
 	return nil
 }
 
+// applyLinkRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Link.
+func applyLinkRefMetadata(value *Link, component *LinkRef, isOpenAPI31OrLater bool) *Link {
+	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
+		return value
+	}
+
+	result := *value
+	result.Description = *component.Description
+	return &result
+}
+
 func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *url.URL) (err error) {
+	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
+
 	if component.isEmpty() {
 		return errMUSTLink
 	}
@@ -1248,7 +1350,7 @@ func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *u
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = value.(*Link)
+			component.Value = applyLinkRefMetadata(value.(*Link), component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -1278,6 +1380,7 @@ func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *u
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
+		component.Value = applyLinkRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	return nil
 }

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -647,14 +647,12 @@ var (
 	errMUSTSecurityScheme = errors.New("invalid securityScheme: value MUST be an object")
 )
 
-func applyHeaderRefMetadata(value *Header, component *HeaderRef, isOpenAPI31OrLater bool) *Header {
+func applyHeaderRefMetadata(value *Header, component *HeaderRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
-		return value
+		return
 	}
 
-	result := *value
-	result.Description = *component.Description
-	return &result
+	value.Description = *component.Description
 }
 
 func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPath *url.URL) (err error) {
@@ -669,7 +667,8 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applyHeaderRefMetadata(value.(*Header), component, isOpenAPI31OrLater)
+			component.Value = value.(*Header)
+			applyHeaderRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -699,7 +698,7 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applyHeaderRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applyHeaderRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -719,15 +718,12 @@ func (loader *Loader) resolveHeaderRef(doc *T, component *HeaderRef, documentPat
 	return nil
 }
 
-// applyParameterRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Parameter.
-func applyParameterRefMetadata(value *Parameter, component *ParameterRef, isOpenAPI31OrLater bool) *Parameter {
+func applyParameterRefMetadata(value *Parameter, component *ParameterRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
-		return value
+		return
 	}
 
-	result := *value
-	result.Description = *component.Description
-	return &result
+	value.Description = *component.Description
 }
 
 func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, documentPath *url.URL) (err error) {
@@ -742,7 +738,8 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applyParameterRefMetadata(value.(*Parameter), component, isOpenAPI31OrLater)
+			component.Value = value.(*Parameter)
+			applyParameterRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -772,7 +769,7 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applyParameterRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applyParameterRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -800,15 +797,12 @@ func (loader *Loader) resolveParameterRef(doc *T, component *ParameterRef, docum
 	return nil
 }
 
-// applyRequestBodyRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced RequestBody.
-func applyRequestBodyRefMetadata(value *RequestBody, component *RequestBodyRef, isOpenAPI31OrLater bool) *RequestBody {
+func applyRequestBodyRefMetadata(value *RequestBody, component *RequestBodyRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
-		return value
+		return
 	}
 
-	result := *value
-	result.Description = *component.Description
-	return &result
+	value.Description = *component.Description
 }
 
 func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, documentPath *url.URL) (err error) {
@@ -823,7 +817,8 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applyRequestBodyRefMetadata(value.(*RequestBody), component, isOpenAPI31OrLater)
+			component.Value = value.(*RequestBody)
+			applyRequestBodyRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -853,7 +848,7 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applyRequestBodyRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applyRequestBodyRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -868,16 +863,12 @@ func (loader *Loader) resolveRequestBodyRef(doc *T, component *RequestBodyRef, d
 	return nil
 }
 
-// applyResponseRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Response.
-func applyResponseRefMetadata(value *Response, component *ResponseRef, isOpenAPI31OrLater bool) *Response {
+func applyResponseRefMetadata(value *Response, component *ResponseRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
-		return value
+		return
 	}
 
-	result := *value
-	description := *component.Description
-	result.Description = &description
-	return &result
+	value.Description = component.Description
 }
 
 func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documentPath *url.URL) (err error) {
@@ -892,7 +883,8 @@ func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documen
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applyResponseRefMetadata(value.(*Response), component, isOpenAPI31OrLater)
+			component.Value = value.(*Response)
+			applyResponseRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -922,7 +914,7 @@ func (loader *Loader) resolveResponseRef(doc *T, component *ResponseRef, documen
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applyResponseRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applyResponseRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	value := component.Value
 	if value == nil {
@@ -1154,15 +1146,12 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 	return nil
 }
 
-// applySecuritySchemeRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced SecurityScheme.
-func applySecuritySchemeRefMetadata(value *SecurityScheme, component *SecuritySchemeRef, isOpenAPI31OrLater bool) *SecurityScheme {
+func applySecuritySchemeRefMetadata(value *SecurityScheme, component *SecuritySchemeRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
-		return value
+		return
 	}
 
-	result := *value
-	result.Description = *component.Description
-	return &result
+	value.Description = *component.Description
 }
 
 func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecuritySchemeRef, documentPath *url.URL) (err error) {
@@ -1177,7 +1166,8 @@ func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecurityScheme
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applySecuritySchemeRefMetadata(value.(*SecurityScheme), component, isOpenAPI31OrLater)
+			component.Value = value.(*SecurityScheme)
+			applySecuritySchemeRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -1207,25 +1197,22 @@ func (loader *Loader) resolveSecuritySchemeRef(doc *T, component *SecurityScheme
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applySecuritySchemeRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applySecuritySchemeRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	return nil
 }
 
-// applyExampleRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Example.
-func applyExampleRefMetadata(value *Example, component *ExampleRef, isOpenAPI31OrLater bool) *Example {
+func applyExampleRefMetadata(value *Example, component *ExampleRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || (component.Summary == nil && component.Description == nil) {
-		return value
+		return
 	}
 
-	result := *value
 	if component.Summary != nil {
-		result.Summary = *component.Summary
+		value.Summary = *component.Summary
 	}
 	if component.Description != nil {
-		result.Description = *component.Description
+		value.Description = *component.Description
 	}
-	return &result
 }
 
 func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentPath *url.URL) (err error) {
@@ -1236,7 +1223,8 @@ func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentP
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applyExampleRefMetadata(value.(*Example), component, isOpenAPI31OrLater)
+			component.Value = value.(*Example)
+			applyExampleRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -1266,7 +1254,7 @@ func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentP
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applyExampleRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applyExampleRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	return nil
 }
@@ -1327,15 +1315,12 @@ func (loader *Loader) resolveCallbackRef(doc *T, component *CallbackRef, documen
 	return nil
 }
 
-// applyLinkRefMetadata applies OpenAPI 3.1 overrides without mutating the referenced Link.
-func applyLinkRefMetadata(value *Link, component *LinkRef, isOpenAPI31OrLater bool) *Link {
+func applyLinkRefMetadata(value *Link, component *LinkRef, isOpenAPI31OrLater bool) {
 	if !isOpenAPI31OrLater || value == nil || component.Description == nil {
-		return value
+		return
 	}
 
-	result := *value
-	result.Description = *component.Description
-	return &result
+	value.Description = *component.Description
 }
 
 func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *url.URL) (err error) {
@@ -1350,7 +1335,8 @@ func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *u
 			return nil
 		}
 		if !loader.shouldVisitRef(ref, func(value any) {
-			component.Value = applyLinkRefMetadata(value.(*Link), component, isOpenAPI31OrLater)
+			component.Value = value.(*Link)
+			applyLinkRefMetadata(component.Value, component, isOpenAPI31OrLater)
 			refPath, _ := loader.resolveRefPath(ref, documentPath)
 			component.setRefPath(refPath)
 		}) {
@@ -1380,7 +1366,7 @@ func (loader *Loader) resolveLinkRef(doc *T, component *LinkRef, documentPath *u
 			component.setRefPath(resolved.RefPath())
 		}
 		defer loader.unvisitRef(ref, component.Value)
-		component.Value = applyLinkRefMetadata(component.Value, component, isOpenAPI31OrLater)
+		applyLinkRefMetadata(component.Value, component, isOpenAPI31OrLater)
 	}
 	return nil
 }

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -276,15 +276,23 @@ components:
 				})
 			}
 
-			// Applying metadata to aliases must not modify the shared components.
-			require.Equal(t, "component summary", doc.Components.Examples["Base"].Value.Summary)
-			require.Equal(t, "component description", doc.Components.Examples["Base"].Value.Description)
-			require.Equal(t, "component description", doc.Components.Headers["Base"].Value.Description)
-			require.Equal(t, "component description", doc.Components.Parameters["Base"].Value.Description)
-			require.Equal(t, "component description", doc.Components.RequestBodies["Base"].Value.Description)
-			require.Equal(t, "component description", *doc.Components.Responses["Base"].Value.Description)
-			require.Equal(t, "component description", doc.Components.Links["Base"].Value.Description)
-			require.Equal(t, "component description", doc.Components.SecuritySchemes["Base"].Value.Description)
+			// Aliases retain the referenced value and apply metadata to it in place.
+			require.Same(t, doc.Components.Examples["Base"].Value, doc.Components.Examples["Alias"].Value)
+			require.Same(t, doc.Components.Headers["Base"].Value, doc.Components.Headers["Alias"].Value)
+			require.Same(t, doc.Components.Parameters["Base"].Value, doc.Components.Parameters["Alias"].Value)
+			require.Same(t, doc.Components.RequestBodies["Base"].Value, doc.Components.RequestBodies["Alias"].Value)
+			require.Same(t, doc.Components.Responses["Base"].Value, doc.Components.Responses["Alias"].Value)
+			require.Same(t, doc.Components.Links["Base"].Value, doc.Components.Responses["Base"].Value.Links["Alias"].Value)
+			require.Same(t, doc.Components.SecuritySchemes["Base"].Value, doc.Components.SecuritySchemes["Alias"].Value)
+
+			require.Equal(t, test.wantSummary, doc.Components.Examples["Base"].Value.Summary)
+			require.Equal(t, test.wantDescription, doc.Components.Examples["Base"].Value.Description)
+			require.Equal(t, test.wantDescription, doc.Components.Headers["Base"].Value.Description)
+			require.Equal(t, test.wantDescription, doc.Components.Parameters["Base"].Value.Description)
+			require.Equal(t, test.wantDescription, doc.Components.RequestBodies["Base"].Value.Description)
+			require.Equal(t, test.wantDescription, *doc.Components.Responses["Base"].Value.Description)
+			require.Equal(t, test.wantDescription, doc.Components.Links["Base"].Value.Description)
+			require.Equal(t, test.wantDescription, doc.Components.SecuritySchemes["Base"].Value.Description)
 		})
 	}
 }

--- a/openapi3/loader_test.go
+++ b/openapi3/loader_test.go
@@ -174,6 +174,121 @@ paths:
 	require.Equal(t, example.Value.Value.(map[string]any)["error"].(bool), false)
 }
 
+func TestReferenceObjectMetadataIsVersionAware(t *testing.T) {
+	const spec = `
+openapi: VERSION
+info: {title: Test, version: "1"}
+paths: {}
+components:
+  examples:
+    Base:
+      summary: component summary
+      description: component description
+      value: example
+    Alias:
+      $ref: "#/components/examples/Base"
+      summary: reference summary
+      description: reference description
+  headers:
+    Base:
+      description: component description
+    Alias:
+      $ref: "#/components/headers/Base"
+      description: reference description
+  parameters:
+    Base:
+      name: id
+      in: query
+      description: component description
+    Alias:
+      $ref: "#/components/parameters/Base"
+      description: reference description
+  requestBodies:
+    Base:
+      description: component description
+      content: {}
+    Alias:
+      $ref: "#/components/requestBodies/Base"
+      description: reference description
+  responses:
+    Base:
+      description: component description
+      links:
+        Alias:
+          $ref: "#/components/links/Base"
+          description: reference description
+    Alias:
+      $ref: "#/components/responses/Base"
+      description: reference description
+  links:
+    Base:
+      operationId: test
+      description: component description
+  securitySchemes:
+    Base:
+      type: apiKey
+      name: X-API-Key
+      in: header
+      description: component description
+    Alias:
+      $ref: "#/components/securitySchemes/Base"
+      description: reference description
+`
+
+	for _, test := range []struct {
+		name            string
+		version         string
+		wantSummary     string
+		wantDescription string
+	}{
+		{
+			name:            "OpenAPI 3.0 does not apply reference metadata",
+			version:         "3.0.3",
+			wantSummary:     "component summary",
+			wantDescription: "component description",
+		},
+		{
+			name:            "OpenAPI 3.1 applies reference metadata",
+			version:         "3.1.0",
+			wantSummary:     "reference summary",
+			wantDescription: "reference description",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			loader := NewLoader()
+			doc, err := loader.LoadFromData([]byte(strings.Replace(spec, "VERSION", test.version, 1)))
+			require.NoError(t, err)
+
+			require.Equal(t, test.wantSummary, doc.Components.Examples["Alias"].Value.Summary)
+			descriptions := map[string]string{
+				"example":         doc.Components.Examples["Alias"].Value.Description,
+				"header":          doc.Components.Headers["Alias"].Value.Description,
+				"parameter":       doc.Components.Parameters["Alias"].Value.Description,
+				"request body":    doc.Components.RequestBodies["Alias"].Value.Description,
+				"response":        *doc.Components.Responses["Alias"].Value.Description,
+				"link":            doc.Components.Responses["Base"].Value.Links["Alias"].Value.Description,
+				"security scheme": doc.Components.SecuritySchemes["Alias"].Value.Description,
+			}
+			for name, description := range descriptions {
+				t.Run(name, func(t *testing.T) {
+					require.Equal(t, test.wantDescription, description)
+				})
+			}
+
+			// Applying metadata to aliases must not modify the shared components.
+			require.Equal(t, "component summary", doc.Components.Examples["Base"].Value.Summary)
+			require.Equal(t, "component description", doc.Components.Examples["Base"].Value.Description)
+			require.Equal(t, "component description", doc.Components.Headers["Base"].Value.Description)
+			require.Equal(t, "component description", doc.Components.Parameters["Base"].Value.Description)
+			require.Equal(t, "component description", doc.Components.RequestBodies["Base"].Value.Description)
+			require.Equal(t, "component description", *doc.Components.Responses["Base"].Value.Description)
+			require.Equal(t, "component description", doc.Components.Links["Base"].Value.Description)
+			require.Equal(t, "component description", doc.Components.SecuritySchemes["Base"].Value.Description)
+		})
+	}
+}
+
 func TestLoadErrorOnRefMisuse(t *testing.T) {
 	spec := []byte(`
 openapi: '3.0.0'

--- a/openapi3/ref.go
+++ b/openapi3/ref.go
@@ -8,12 +8,15 @@ import (
 
 //go:generate go run refsgenerator.go
 
-// Ref is specified by OpenAPI/Swagger 3.0 standard.
-// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#reference-object
+// Ref represents the common fields of an OpenAPI Reference Object.
+// Summary and Description are supported by OpenAPI 3.1 and later.
+// See https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.2.md#reference-object
 type Ref struct {
-	Ref        string         `json:"$ref" yaml:"$ref"`
-	Extensions map[string]any `json:"-" yaml:"-"`
-	Origin     *Origin        `json:"-" yaml:"-"`
+	Ref         string         `json:"$ref" yaml:"$ref"`
+	Summary     *string        `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string        `json:"description,omitempty" yaml:"description,omitempty"`
+	Extensions  map[string]any `json:"-" yaml:"-"`
+	Origin      *Origin        `json:"-" yaml:"-"`
 }
 
 // MarshalYAML returns the YAML encoding of Ref.
@@ -22,6 +25,12 @@ func (x Ref) MarshalYAML() (any, error) {
 	maps.Copy(m, x.Extensions)
 	if x := x.Ref; x != "" {
 		m["$ref"] = x
+	}
+	if x.Summary != nil {
+		m["summary"] = *x.Summary
+	}
+	if x.Description != nil {
+		m["description"] = *x.Description
 	}
 	return m, nil
 }

--- a/openapi3/refs.go
+++ b/openapi3/refs.go
@@ -17,6 +17,9 @@ type CallbackRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Callback
@@ -51,7 +54,12 @@ func (x *CallbackRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of CallbackRef.
 func (x CallbackRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -74,6 +82,10 @@ func (x *CallbackRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -99,6 +111,14 @@ func (x *CallbackRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -159,6 +179,9 @@ type ExampleRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Example
@@ -193,7 +216,12 @@ func (x *ExampleRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of ExampleRef.
 func (x ExampleRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -216,6 +244,10 @@ func (x *ExampleRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -241,6 +273,14 @@ func (x *ExampleRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -301,6 +341,9 @@ type HeaderRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Header
@@ -335,7 +378,12 @@ func (x *HeaderRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of HeaderRef.
 func (x HeaderRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -358,6 +406,10 @@ func (x *HeaderRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -383,6 +435,14 @@ func (x *HeaderRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -443,6 +503,9 @@ type LinkRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Link
@@ -477,7 +540,12 @@ func (x *LinkRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of LinkRef.
 func (x LinkRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -500,6 +568,10 @@ func (x *LinkRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -525,6 +597,14 @@ func (x *LinkRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -585,6 +665,9 @@ type ParameterRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Parameter
@@ -619,7 +702,12 @@ func (x *ParameterRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of ParameterRef.
 func (x ParameterRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -642,6 +730,10 @@ func (x *ParameterRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -667,6 +759,14 @@ func (x *ParameterRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -727,6 +827,9 @@ type RequestBodyRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *RequestBody
@@ -761,7 +864,12 @@ func (x *RequestBodyRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of RequestBodyRef.
 func (x RequestBodyRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -784,6 +892,10 @@ func (x *RequestBodyRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -809,6 +921,14 @@ func (x *RequestBodyRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -869,6 +989,9 @@ type ResponseRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *Response
@@ -903,7 +1026,12 @@ func (x *ResponseRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of ResponseRef.
 func (x ResponseRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -926,6 +1054,10 @@ func (x *ResponseRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -951,6 +1083,14 @@ func (x *ResponseRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
@@ -1048,7 +1188,10 @@ func (x *SchemaRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of SchemaRef.
 func (x SchemaRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:        ref,
+			Extensions: x.Extensions,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -1174,6 +1317,9 @@ type SecuritySchemeRef struct {
 	// are allowed by the openapi spec.
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 
 	Ref   string
 	Value *SecurityScheme
@@ -1208,7 +1354,12 @@ func (x *SecuritySchemeRef) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of SecuritySchemeRef.
 func (x SecuritySchemeRef) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref:         ref,
+			Extensions:  x.Extensions,
+			Summary:     x.Summary,
+			Description: x.Description,
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -1231,6 +1382,10 @@ func (x *SecuritySchemeRef) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 			for k := range extra {
@@ -1256,6 +1411,14 @@ func (x *SecuritySchemeRef) validateExtras(ctx context.Context) error {
 	allowed := validationOpts.extraSiblingFieldsAllowed
 	if allowed == nil {
 		allowed = make(map[string]struct{})
+	}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
 	}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {

--- a/openapi3/refs.tmpl
+++ b/openapi3/refs.tmpl
@@ -18,6 +18,12 @@ type {{ $type.Name }}Ref struct {
 	Extensions map[string]any
 	Origin     *Origin `json:"-" yaml:"-"`
 
+	{{- if ne $type.Name "Schema" }}
+	// Reference Object summary and description are supported in OpenAPI 3.1+.
+	Summary     *string `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	{{- end }}
+
 	Ref   string
 	Value *{{ $type.Name }}
 	extra []string
@@ -56,7 +62,14 @@ func (x *{{ $type.Name }}Ref) setRefPath(u *url.URL) {
 // MarshalYAML returns the YAML encoding of {{ $type.Name }}Ref.
 func (x {{ $type.Name }}Ref) MarshalYAML() (any, error) {
 	if ref := x.Ref; ref != "" {
-		return &Ref{Ref: ref, Extensions: x.Extensions}, nil
+		return &Ref{
+			Ref: ref,
+			Extensions: x.Extensions,
+			{{- if ne $type.Name "Schema" }}
+			Summary:     x.Summary,
+			Description: x.Description,
+			{{- end }}
+		}, nil
 	}
 	return x.Value.MarshalYAML()
 }
@@ -79,6 +92,12 @@ func (x *{{ $type.Name }}Ref) UnmarshalJSON(data []byte) error {
 		delete(extra, "$ref")
 		x.Ref = refOnly.Ref
 		x.Origin = refOnly.Origin
+		{{- if ne $type.Name "Schema" }}
+		x.Summary = refOnly.Summary
+		x.Description = refOnly.Description
+		delete(extra, "summary")
+		delete(extra, "description")
+		{{- end }}
 		if len(extra) != 0 {
 			x.extra = componentNames(extra)
 {{- if eq $type.Name "Schema" }}
@@ -123,6 +142,16 @@ func (x *{{ $type.Name }}Ref) validateExtras(ctx context.Context) error {
 	if allowed == nil {
 		allowed = make(map[string]struct{})
 	}
+	{{- if ne $type.Name "Schema" }}
+	if !validationOpts.isOpenAPI31OrLater {
+		if _, ok := allowed["description"]; x.Description != nil && !ok {
+			extras = append(extras, "description")
+		}
+		if _, ok := allowed["summary"]; x.Summary != nil && !ok {
+			extras = append(extras, "summary")
+		}
+	}
+	{{- end }}
 	for _, ex := range x.extra {
 		if _, ok := allowed[ex]; !ok {
 			if _, ok := x.Extensions[ex]; !ok {

--- a/openapi3/refsgenerator.go
+++ b/openapi3/refsgenerator.go
@@ -4,7 +4,9 @@
 package main
 
 import (
+	"bytes"
 	_ "embed"
+	"go/format"
 	"os"
 	"text/template"
 )
@@ -21,17 +23,6 @@ func main() {
 }
 
 func generateTemplate(filename string, tmpl string) {
-	file, err := os.Create(filename + ".go")
-	if err != nil {
-		panic(err)
-	}
-
-	defer func() {
-		if err := file.Close(); err != nil {
-			panic(err)
-		}
-	}()
-
 	packageTemplate := template.Must(template.New("openapi3-" + filename).Parse(tmpl))
 
 	type componentType struct {
@@ -39,7 +30,8 @@ func generateTemplate(filename string, tmpl string) {
 		CollectionName string
 	}
 
-	if err := packageTemplate.Execute(file, struct {
+	var output bytes.Buffer
+	if err := packageTemplate.Execute(&output, struct {
 		Package string
 		Types   []componentType
 	}{
@@ -56,6 +48,14 @@ func generateTemplate(filename string, tmpl string) {
 			{Name: "SecurityScheme", CollectionName: "securitySchemes"},
 		},
 	}); err != nil {
+		panic(err)
+	}
+
+	formatted, err := format.Source(output.Bytes())
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(filename+".go", formatted, 0o644); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Adds OpenAPI 3.1 Reference Object `summary` and `description` override support. This is described in the [reference object spec](https://spec.openapis.org/oas/v3.1.2.html#reference-object).

Changed ref.go and refs.tmpl to support new summary and description fields excluding Schema type.

These overrides do **NOT** apply in OpenAPI 3.0, and therefore are ignored. Furthermore, only the following Reference Object types support overrides:

- Example (summary and description)
- Header (description only)
- Parameter (description only)
- RequestBody (description only)
- Response (description only)
- Link (description only)
- SecurityScheme (description only)

These do not apply to CallbackRef or SchemaRef, as these fields are not allowed.

Some minor details to pay attention to:
- If you don't capture IsOpenAPI31OrLater() at the start, it may be evaluated "after" resolution context changes.
- Metadata resolution/overriding is done in both mutually exclusive paths
   - Normal reference resolution
   - shouldVisitRef is false resulting in a backtracking callback
   
**Note**: Updated the Issue #513 regression test because it previously treated description beside $ref as invalid in every version. `summary` and `description` are now recognized Reference Object fields and they override supported metadata in OAS 3.1 and are **STILL ERRORS**  in OAS 3.0.

#### Testing
Added regression testing in `loader_test.go`.

You can try it out!
```bash
go test ./openapi3 -run '^TestReferenceObjectMetadataIsVersionAware$' -count=1
```

#### Unrelated
CI was not having a fun time with the formatting after template generation. Instead, I changed `refsgenerator.go` to feed the generated content into a formatter and then write to a file to preserve formatting. This is a purely cosmetic problem.
