### PR TITLE
qol: Makefile for shorthand commands + preflight scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := help
+.DEFAULT_GOAL := prepare
 
 .PHONY: help generate format test prepare
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.DEFAULT_GOAL := help
+
+.PHONY: help generate format test prepare
+
+help:
+	@printf '%s\n' \
+		'Usage: make <target>' \
+		'' \
+		'  generate  Regenerate Go code, map helpers, and API documentation.' \
+		'  format    Apply the repository formatters and import cleanup.' \
+		'  test      Run the full Go package test suite.' \
+		'  prepare   Run generation, formatting, and tests in sequence.'
+
+generate:
+	go generate ./...
+	./maps.sh
+	./docs.sh
+
+format:
+	go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -test -diff -fix -omitzero=false ./...
+	go fmt ./...
+	go install github.com/incu6us/goimports-reviser/v3@latest
+	find . -type f -iname '*.go' ! -iname '*.pb.go' -exec goimports-reviser {} \;
+
+test:
+	go test ./...
+
+prepare:
+	$(MAKE) generate
+	$(MAKE) format
+	$(MAKE) test

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,7 @@ generate:
 	./docs.sh
 
 format:
-	go run golang.org/x/tools/go/analysis/passes/modernize/cmd/modernize@latest -test -diff -fix -omitzero=false ./...
 	go fmt ./...
-	go install github.com/incu6us/goimports-reviser/v3@latest
-	find . -type f -iname '*.go' ! -iname '*.pb.go' -exec goimports-reviser {} \;
 
 test:
 	go test ./...


### PR DESCRIPTION
Closes #1216 

Adds a root Makefile with common commands you will probably need for generation, formatting, testing, and preparing for PRs.

This would be good to always run `make prepare` before committing for a PR,  the CI really doesn't like it if you forget to generate or format.

Help message and some minor details were generated, never trying to format printed messages manually ever again. 😢 