### PR TITLE
docs: move the StringMap changelog entry to v0.143.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ for _, path := range doc.Paths.InMatchingOrder() {
 
 ## CHANGELOG: Sub-v1 breaking API changes
 
-### v0.142.0
+### v0.143.0
 * Removed the `openapi3.StringMap[V]` type (an internal helper for origin-aware map unmarshalling, obsolete since origin tracking moved to a separate `OriginTree` pass). `openapi3.Discriminator.Mapping` field type changed from `StringMap[MappingRef]` to `map[string]MappingRef`, and `openapi3.OAuthFlow.Scopes` from `StringMap[string]` to `map[string]string`.
 
 ### v0.137.0


### PR DESCRIPTION
#1219 added its breaking-change entry under `### v0.142.0`, but v0.142.0 was tagged shortly before that PR merged, so the StringMap removal is not in it — it ships in the next release. Move the entry to `### v0.143.0` so the changelog matches the tags.

(If the next release gets a different number, this heading should follow it.)