### PR TITLE
openapi3: stable codes for validation errors

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -432,6 +432,8 @@ type CodedError interface {
     Renaming or removing a code is a breaking change and is recorded in the
     README changelog. The full set is available from ValidationErrorCodes.
 
+    Like net.Error, this interface exists as an assertion target for consumers;
+    the package itself constructs concrete error types and does not consume it.
     Reach the code of a wrapped error with errors.As:
 
         var coded openapi3.CodedError

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -258,6 +258,11 @@ func ValidateIdentifier(value string) error
     ValidateIdentifier returns an error if the given component name does not
     match IdentifierRegExp.
 
+func ValidationErrorCodes() []string
+    ValidationErrorCodes returns every code a validation error can carry,
+    sorted. TestValidationErrorCodes keeps it in sync with the errors the
+    validators emit.
+
 func WithValidationOptions(ctx context.Context, opts ...ValidationOption) context.Context
     WithValidationOptions allows adding validation options to a context object
     that can be used when validating any OpenAPI type.
@@ -278,6 +283,8 @@ type APIKeyInInvalidError struct {
     either omits `in:` or sets it to a value outside {query, header, cookie}.
     Carries the rejected value so callers can render or filter; empty string
     means the field was missing entirely.
+
+func (e *APIKeyInInvalidError) Code() string
 
 func (e *APIKeyInInvalidError) Error() string
 
@@ -410,6 +417,28 @@ func (m Callbacks) JSONLookup(token string) (any, error)
     JSONLookup implements
     https://pkg.go.dev/github.com/go-openapi/jsonpointer#JSONPointable
 
+type CodedError interface {
+	error
+	Code() string
+}
+    CodedError is implemented by every typed validation error. Code returns
+    a stable, kebab-case identifier for the validation rule that failed (e.g.
+    "operation-responses-required"), so consumers can suppress specific
+    findings, assign per-rule severities, emit machine-readable diagnostics
+    (e.g. the LSP Diagnostic.code field), or link to per-rule documentation
+    without depending on message text.
+
+    Codes are a contract: message wording may change freely, codes may not.
+    Renaming or removing a code is a breaking change and is recorded in the
+    README changelog. The full set is available from ValidationErrorCodes.
+
+    Reach the code of a wrapped error with errors.As:
+
+        var coded openapi3.CodedError
+        if errors.As(err, &coded) {
+        	fmt.Println(coded.Code())
+        }
+
 type CommentFieldFor31Plus struct{ ValidationError }
 
 func (e *CommentFieldFor31Plus) As(target any) bool
@@ -481,6 +510,8 @@ type ConflictingPathsError struct {
     ConflictingPathsError clusters "conflicting paths X and Y" failures.
     Fires when two path keys normalize to the same template (e.g. "/users/{a}"
     and "/users/{b}" both normalize to "/users/{}").
+
+func (e *ConflictingPathsError) Code() string
 
 func (e *ConflictingPathsError) Error() string
 
@@ -601,6 +632,8 @@ type DuplicateOperationIDError struct {
     failures. operationIds must be unique across all paths in a document.
     Endpoints are rendered as "<METHOD> <path>" (e.g. "POST /things").
 
+func (e *DuplicateOperationIDError) Code() string
+
 func (e *DuplicateOperationIDError) Error() string
 
 type DuplicateParameterError struct {
@@ -616,6 +649,8 @@ type DuplicateParameterError struct {
     failures. Fires when two parameters on an operation (or path item) share the
     same In + Name combination.
 
+func (e *DuplicateParameterError) Code() string
+
 func (e *DuplicateParameterError) Error() string
 
 type DuplicateRequiredFieldError struct {
@@ -629,6 +664,8 @@ type DuplicateRequiredFieldError struct {
     The elements of a schema's `required` array MUST be unique (JSON Schema
     2020-12 §6.5.3 for OpenAPI 3.1, draft-04 for OpenAPI 3.0).
 
+func (e *DuplicateRequiredFieldError) Code() string
+
 func (e *DuplicateRequiredFieldError) Error() string
 
 type DuplicateTagError struct {
@@ -640,6 +677,8 @@ type DuplicateTagError struct {
 }
     DuplicateTagError clusters "more than one tag has name X" failures. Each tag
     name in the document-root `tags` list MUST be unique (OpenAPI Object).
+
+func (e *DuplicateTagError) Code() string
 
 func (e *DuplicateTagError) Error() string
 
@@ -663,6 +702,8 @@ type EitherFieldRequiredError struct {
 }
     EitherFieldRequiredError clusters "at least one of these fields must be set"
     failures (example.value vs externalValue, link.operationId vs operationRef).
+
+func (e *EitherFieldRequiredError) Code() string
 
 func (e *EitherFieldRequiredError) Error() string
 
@@ -724,6 +765,8 @@ type ExactlyOneFieldError struct {
     ExactlyOneFieldError clusters "exactly one of these fields must be set"
     failures — e.g. a parameter or header where neither content nor schema is
     set, or both are.
+
+func (e *ExactlyOneFieldError) Code() string
 
 func (e *ExactlyOneFieldError) Error() string
 
@@ -893,6 +936,8 @@ type ExtraSiblingFieldsError struct {
     extras are `x-` extensions. Carries the offending field names so callers can
     render or filter.
 
+func (e *ExtraSiblingFieldsError) Code() string
+
 func (e *ExtraSiblingFieldsError) Error() string
 
 type FieldVersionMismatchError struct {
@@ -914,6 +959,8 @@ type FieldVersionMismatchError struct {
     (3.1+ keywords used in 3.0 documents). Carries the field name and minimum
     version, wraps the per-site leaf.
 
+func (e *FieldVersionMismatchError) Code() string
+
 func (e *FieldVersionMismatchError) Error() string
 
 func (e *FieldVersionMismatchError) Unwrap() error
@@ -931,6 +978,8 @@ type ForbiddenFieldError struct {
     ForbiddenFieldError clusters "field X must not be set in this context"
     failures (header.name and header.in inside a Headers map, OAuth flow URLs
     that don't apply to the chosen flow type).
+
+func (e *ForbiddenFieldError) Code() string
 
 func (e *ForbiddenFieldError) Error() string
 
@@ -1124,6 +1173,8 @@ type InvalidHTTPSchemeError struct {
     `bearer`, `basic`, `negotiate`, `digest`; this fires when an http scheme
     declares anything else.
 
+func (e *InvalidHTTPSchemeError) Code() string
+
 func (e *InvalidHTTPSchemeError) Error() string
 
 type InvalidParameterInError struct {
@@ -1138,6 +1189,8 @@ type InvalidParameterInError struct {
     or `cookie`; this fires when a parameter declares anything else (commonly
     `body`, a Swagger 2.0 leftover).
 
+func (e *InvalidParameterInError) Code() string
+
 func (e *InvalidParameterInError) Error() string
 
 type InvalidSecuritySchemeTypeError struct {
@@ -1151,6 +1204,8 @@ type InvalidSecuritySchemeTypeError struct {
     X" failures. The OpenAPI 3.x spec accepts only `apiKey`, `http`, `oauth2`,
     `openIdConnect`, and `mutualTLS` (3.1+); this fires when a security scheme
     declares anything else.
+
+func (e *InvalidSecuritySchemeTypeError) Code() string
 
 func (e *InvalidSecuritySchemeTypeError) Error() string
 
@@ -1173,6 +1228,8 @@ type InvalidSerializationMethodError struct {
     discriminates which surface is reporting: "media type" for encoding,
     the parameter location ("path", "query", etc.) for parameters and "header"
     for headers.
+
+func (e *InvalidSerializationMethodError) Code() string
 
 func (e *InvalidSerializationMethodError) Error() string
 
@@ -1487,6 +1544,8 @@ type MutuallyExclusiveFieldsError struct {
     one is allowed" failures (example.value vs externalValue, mediaType.example
     vs examples, license.url vs identifier, link.operationId vs operationRef).
     Carries both field names and wraps the per-site leaf.
+
+func (e *MutuallyExclusiveFieldsError) Code() string
 
 func (e *MutuallyExclusiveFieldsError) Error() string
 
@@ -1928,6 +1987,8 @@ type PathMustStartWithSlashError struct {
     PathMustStartWithSlashError clusters "path X does not start with a forward
     slash" failures. Path keys in the paths object must begin with `/`.
 
+func (e *PathMustStartWithSlashError) Code() string
+
 func (e *PathMustStartWithSlashError) Error() string
 
 type PathParameterRequiredError struct {
@@ -1941,6 +2002,8 @@ type PathParameterRequiredError struct {
     failures: per the OpenAPI spec, every parameter with `in: path` must be
     declared with `required: true`. Carries the parameter name so callers can
     render or filter by it.
+
+func (e *PathParameterRequiredError) Code() string
 
 func (e *PathParameterRequiredError) Error() string
 
@@ -1960,6 +2023,8 @@ type PathParametersError struct {
     than appear in the path template" failures. Carries the path template,
     method, and the list of missing parameter names so callers can render or
     filter without parsing the message.
+
+func (e *PathParametersError) Code() string
 
 func (e *PathParametersError) Error() string
 
@@ -2242,6 +2307,8 @@ type RequiredFieldError struct {
 
         var ivr *InfoVersionRequired
         if errors.As(err, &ivr) { /* knows it's exactly info.version */ }
+
+func (e *RequiredFieldError) Code() string
 
 func (e *RequiredFieldError) Error() string
 
@@ -2651,6 +2718,8 @@ type SchemaBothFormsExclusive struct {
     set to both its boolean and schema forms simultaneously" failures —
     additionalProperties, unevaluatedItems, unevaluatedProperties.
 
+func (e *SchemaBothFormsExclusive) Code() string
+
 func (e *SchemaBothFormsExclusive) Error() string
 
 func (e *SchemaBothFormsExclusive) Unwrap() error
@@ -2723,6 +2792,8 @@ type SchemaPatternRegexError struct {
     to Cause.Error()) so existing string-based consumers and golden fixtures are
     unaffected.
 
+func (e *SchemaPatternRegexError) Code() string
+
 func (e *SchemaPatternRegexError) Error() string
 
 func (e *SchemaPatternRegexError) Unwrap() error
@@ -2791,6 +2862,8 @@ type SchemaTypeError struct {
     SchemaTypeError clusters "unsupported 'type' value" failures on a Schema.
     Carries the bad type value so callers can surface it in user-facing output
     and filter findings by it.
+
+func (e *SchemaTypeError) Code() string
 
 func (e *SchemaTypeError) Error() string
 
@@ -2911,6 +2984,8 @@ type SchemaValueError struct {
     Cause is typed as error (not *SchemaError) because VisitJSON can return
     either a single SchemaError or a MultiError aggregating several. errors.As
     walks both shapes transparently.
+
+func (e *SchemaValueError) Code() string
 
 func (e *SchemaValueError) Error() string
 
@@ -3151,6 +3226,8 @@ type ServerURLTemplateError struct {
     braces and undeclared variables (template variables not matched by
     Server.Variables, or vice versa).
 
+func (e *ServerURLTemplateError) Code() string
+
 func (e *ServerURLTemplateError) Error() string
 
 func (e *ServerURLTemplateError) Unwrap() error
@@ -3213,6 +3290,8 @@ type SingleEntryContentError struct {
 }
     SingleEntryContentError clusters "the content map must contain at most one
     entry" failures (parameter.content, header.content).
+
+func (e *SingleEntryContentError) Code() string
 
 func (e *SingleEntryContentError) Error() string
 
@@ -3565,6 +3644,8 @@ type UnresolvedRefError struct {
     the offending ref string so callers can surface it in user-facing output and
     filter findings by it.
 
+func (e *UnresolvedRefError) Code() string
+
 func (e *UnresolvedRefError) Error() string
 
 type ValidationError struct {
@@ -3744,6 +3825,8 @@ type WebhookNilError struct {
 }
     WebhookNilError clusters "the value at webhook key X is nil" failures from
     T.Validate's webhook walk. Carries the offending key name.
+
+func (e *WebhookNilError) Code() string
 
 func (e *WebhookNilError) Error() string
 

--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -292,6 +292,8 @@ type APIKeySecuritySchemeNameRequired struct{ ValidationError }
 
 func (e *APIKeySecuritySchemeNameRequired) As(target any) bool
 
+func (e *APIKeySecuritySchemeNameRequired) Code() string
+
 type AdditionalProperties = BoolSchema
     AdditionalProperties is a type alias for BoolSchema, kept for backward
     compatibility.
@@ -299,6 +301,8 @@ type AdditionalProperties = BoolSchema
 type AnchorFieldFor31Plus struct{ ValidationError }
 
 func (e *AnchorFieldFor31Plus) As(target any) bool
+
+func (e *AnchorFieldFor31Plus) Code() string
 
 type BoolSchema struct {
 	Has    *bool
@@ -428,9 +432,11 @@ type CodedError interface {
     (e.g. the LSP Diagnostic.code field), or link to per-rule documentation
     without depending on message text.
 
-    Codes are a contract: message wording may change freely, codes may not.
-    Renaming or removing a code is a breaking change and is recorded in the
-    README changelog. The full set is available from ValidationErrorCodes.
+    Every code is declared as a literal on its error type; nothing is derived.
+    Codes are a contract: message wording and Go type names may change freely,
+    codes may not. Renaming or removing a code is a breaking change and
+    is recorded in the README changelog. The full set is available from
+    ValidationErrorCodes.
 
     Like net.Error, this interface exists as an assertion target for consumers;
     the package itself constructs concrete error types and does not consume it.
@@ -444,6 +450,8 @@ type CodedError interface {
 type CommentFieldFor31Plus struct{ ValidationError }
 
 func (e *CommentFieldFor31Plus) As(target any) bool
+
+func (e *CommentFieldFor31Plus) Code() string
 
 type ComponentRef interface {
 	RefString() string
@@ -521,6 +529,8 @@ type ConstFieldFor31Plus struct{ ValidationError }
 
 func (e *ConstFieldFor31Plus) As(target any) bool
 
+func (e *ConstFieldFor31Plus) Code() string
+
 type Contact struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -548,6 +558,8 @@ type ContainsFieldFor31Plus struct{ ValidationError }
 
 func (e *ContainsFieldFor31Plus) As(target any) bool
 
+func (e *ContainsFieldFor31Plus) Code() string
+
 type Content map[string]*MediaType
     Content is specified by OpenAPI/Swagger 3.0 standard.
 
@@ -574,25 +586,43 @@ type ContentEncodingFieldFor31Plus struct{ ValidationError }
 
 func (e *ContentEncodingFieldFor31Plus) As(target any) bool
 
+func (e *ContentEncodingFieldFor31Plus) Code() string
+
 type ContentMediaTypeFieldFor31Plus struct{ ValidationError }
 
 func (e *ContentMediaTypeFieldFor31Plus) As(target any) bool
+
+func (e *ContentMediaTypeFieldFor31Plus) Code() string
 
 type ContentSchemaFieldFor31Plus struct{ ValidationError }
 
 func (e *ContentSchemaFieldFor31Plus) As(target any) bool
 
+func (e *ContentSchemaFieldFor31Plus) Code() string
+
+type DefaultViolatesSchema struct{ SchemaValueError }
+
+func (e *DefaultViolatesSchema) As(target any) bool
+
+func (e *DefaultViolatesSchema) Code() string
+
 type DefsFieldFor31Plus struct{ ValidationError }
 
 func (e *DefsFieldFor31Plus) As(target any) bool
+
+func (e *DefsFieldFor31Plus) Code() string
 
 type DependentRequiredFieldFor31Plus struct{ ValidationError }
 
 func (e *DependentRequiredFieldFor31Plus) As(target any) bool
 
+func (e *DependentRequiredFieldFor31Plus) Code() string
+
 type DependentSchemasFieldFor31Plus struct{ ValidationError }
 
 func (e *DependentSchemasFieldFor31Plus) As(target any) bool
+
+func (e *DependentSchemasFieldFor31Plus) Code() string
 
 type Discriminator struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -688,9 +718,13 @@ type DynamicAnchorFieldFor31Plus struct{ ValidationError }
 
 func (e *DynamicAnchorFieldFor31Plus) As(target any) bool
 
+func (e *DynamicAnchorFieldFor31Plus) Code() string
+
 type DynamicRefFieldFor31Plus struct{ ValidationError }
 
 func (e *DynamicRefFieldFor31Plus) As(target any) bool
+
+func (e *DynamicRefFieldFor31Plus) Code() string
 
 type EitherFieldRequiredError struct {
 	// Fields is the set of field names, at least one of which must be
@@ -705,8 +739,6 @@ type EitherFieldRequiredError struct {
     EitherFieldRequiredError clusters "at least one of these fields must be set"
     failures (example.value vs externalValue, link.operationId vs operationRef).
 
-func (e *EitherFieldRequiredError) Code() string
-
 func (e *EitherFieldRequiredError) Error() string
 
 func (e *EitherFieldRequiredError) Unwrap() error
@@ -714,6 +746,8 @@ func (e *EitherFieldRequiredError) Unwrap() error
 type ElseFieldFor31Plus struct{ ValidationError }
 
 func (e *ElseFieldFor31Plus) As(target any) bool
+
+func (e *ElseFieldFor31Plus) Code() string
 
 type Encoding struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -767,8 +801,6 @@ type ExactlyOneFieldError struct {
     ExactlyOneFieldError clusters "exactly one of these fields must be set"
     failures — e.g. a parameter or header where neither content nor schema is
     set, or both are.
-
-func (e *ExactlyOneFieldError) Code() string
 
 func (e *ExactlyOneFieldError) Error() string
 
@@ -848,9 +880,22 @@ type ExampleValueExternalValueExclusive struct{ ValidationError }
 
 func (e *ExampleValueExternalValueExclusive) As(target any) bool
 
+func (e *ExampleValueExternalValueExclusive) Code() string
+
 type ExampleValueOrExternalValueRequired struct{ ValidationError }
 
 func (e *ExampleValueOrExternalValueRequired) As(target any) bool
+
+func (e *ExampleValueOrExternalValueRequired) Code() string
+
+type ExampleViolatesSchema struct{ SchemaValueError }
+    ExampleViolatesSchema and DefaultViolatesSchema mark which schema value kind
+    failed. They embed SchemaValueError, and their As exposes it, so errors.As
+    with a *SchemaValueError target keeps matching.
+
+func (e *ExampleViolatesSchema) As(target any) bool
+
+func (e *ExampleViolatesSchema) Code() string
 
 type Examples map[string]*ExampleRef // Examples represents components' named examples
 
@@ -861,6 +906,8 @@ func (m Examples) JSONLookup(token string) (any, error)
 type ExamplesFieldFor31Plus struct{ ValidationError }
 
 func (e *ExamplesFieldFor31Plus) As(target any) bool
+
+func (e *ExamplesFieldFor31Plus) Code() string
 
 type ExclusiveBound struct {
 	Bool  *bool    // For OpenAPI 3.0 style (modifier for min/max)
@@ -914,6 +961,8 @@ type ExternalDocsURLRequired struct{ ValidationError }
 
 func (e *ExternalDocsURLRequired) As(target any) bool
 
+func (e *ExternalDocsURLRequired) Code() string
+
 type ExternalDocsURLValidationError struct {
 	Cause error
 }
@@ -961,8 +1010,6 @@ type FieldVersionMismatchError struct {
     (3.1+ keywords used in 3.0 documents). Carries the field name and minimum
     version, wraps the per-site leaf.
 
-func (e *FieldVersionMismatchError) Code() string
-
 func (e *FieldVersionMismatchError) Error() string
 
 func (e *FieldVersionMismatchError) Unwrap() error
@@ -980,8 +1027,6 @@ type ForbiddenFieldError struct {
     ForbiddenFieldError clusters "field X must not be set in this context"
     failures (header.name and header.in inside a Headers map, OAuth flow URLs
     that don't apply to the chosen flow type).
-
-func (e *ForbiddenFieldError) Code() string
 
 func (e *ForbiddenFieldError) Error() string
 
@@ -1033,9 +1078,13 @@ type HeaderContentSchemaExactlyOne struct{ ValidationError }
 
 func (e *HeaderContentSchemaExactlyOne) As(target any) bool
 
+func (e *HeaderContentSchemaExactlyOne) Code() string
+
 type HeaderContentSingleEntry struct{ ValidationError }
 
 func (e *HeaderContentSingleEntry) As(target any) bool
+
+func (e *HeaderContentSingleEntry) Code() string
 
 type HeaderFieldValidationError struct {
 	// Field is "schema" or "content".
@@ -1053,9 +1102,13 @@ type HeaderInForbidden struct{ ValidationError }
 
 func (e *HeaderInForbidden) As(target any) bool
 
+func (e *HeaderInForbidden) Code() string
+
 type HeaderNameForbidden struct{ ValidationError }
 
 func (e *HeaderNameForbidden) As(target any) bool
+
+func (e *HeaderNameForbidden) Code() string
 
 type HeaderRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1111,9 +1164,13 @@ type IDFieldFor31Plus struct{ ValidationError }
 
 func (e *IDFieldFor31Plus) As(target any) bool
 
+func (e *IDFieldFor31Plus) Code() string
+
 type IfFieldFor31Plus struct{ ValidationError }
 
 func (e *IfFieldFor31Plus) As(target any) bool
+
+func (e *IfFieldFor31Plus) Code() string
 
 type Info struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -1148,17 +1205,25 @@ type InfoRequired struct{ ValidationError }
 
 func (e *InfoRequired) As(target any) bool
 
+func (e *InfoRequired) Code() string
+
 type InfoSummaryFieldFor31Plus struct{ ValidationError }
 
 func (e *InfoSummaryFieldFor31Plus) As(target any) bool
+
+func (e *InfoSummaryFieldFor31Plus) Code() string
 
 type InfoTitleRequired struct{ ValidationError }
 
 func (e *InfoTitleRequired) As(target any) bool
 
+func (e *InfoTitleRequired) Code() string
+
 type InfoVersionRequired struct{ ValidationError }
 
 func (e *InfoVersionRequired) As(target any) bool
+
+func (e *InfoVersionRequired) Code() string
 
 type IntegerFormatValidator = FormatValidator[int64]
     IntegerFormatValidator is a type alias for FormatValidator[int64]
@@ -1235,13 +1300,23 @@ func (e *InvalidSerializationMethodError) Code() string
 
 func (e *InvalidSerializationMethodError) Error() string
 
+type ItemSchemaFieldFor32Plus struct{ ValidationError }
+
+func (e *ItemSchemaFieldFor32Plus) As(target any) bool
+
+func (e *ItemSchemaFieldFor32Plus) Code() string
+
 type JSONSchemaDialectAbsoluteURIRequired struct{ ValidationError }
 
 func (e *JSONSchemaDialectAbsoluteURIRequired) As(target any) bool
 
+func (e *JSONSchemaDialectAbsoluteURIRequired) Code() string
+
 type JSONSchemaDialectFieldFor31Plus struct{ ValidationError }
 
 func (e *JSONSchemaDialectFieldFor31Plus) As(target any) bool
+
+func (e *JSONSchemaDialectFieldFor31Plus) Code() string
 
 type License struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -1275,13 +1350,19 @@ type LicenseIdentifierFieldFor31Plus struct{ ValidationError }
 
 func (e *LicenseIdentifierFieldFor31Plus) As(target any) bool
 
+func (e *LicenseIdentifierFieldFor31Plus) Code() string
+
 type LicenseNameRequired struct{ ValidationError }
 
 func (e *LicenseNameRequired) As(target any) bool
 
+func (e *LicenseNameRequired) Code() string
+
 type LicenseURLIdentifierExclusive struct{ ValidationError }
 
 func (e *LicenseURLIdentifierExclusive) As(target any) bool
+
+func (e *LicenseURLIdentifierExclusive) Code() string
 
 type Link struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -1313,9 +1394,13 @@ type LinkOperationIDOrRefRequired struct{ ValidationError }
 
 func (e *LinkOperationIDOrRefRequired) As(target any) bool
 
+func (e *LinkOperationIDOrRefRequired) Code() string
+
 type LinkOperationIDRefExclusive struct{ ValidationError }
 
 func (e *LinkOperationIDRefExclusive) As(target any) bool
+
+func (e *LinkOperationIDRefExclusive) Code() string
 
 type LinkRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -1456,6 +1541,8 @@ type MaxContainsFieldFor31Plus struct{ ValidationError }
 
 func (e *MaxContainsFieldFor31Plus) As(target any) bool
 
+func (e *MaxContainsFieldFor31Plus) Code() string
+
 type MediaType struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -1500,6 +1587,8 @@ type MediaTypeExampleExamplesExclusive struct{ ValidationError }
 
 func (e *MediaTypeExampleExamplesExclusive) As(target any) bool
 
+func (e *MediaTypeExampleExamplesExclusive) Code() string
+
 type MediaTypeExampleValidationError struct {
 	// ExampleName is the example map key.
 	ExampleName string
@@ -1515,6 +1604,8 @@ func (e *MediaTypeExampleValidationError) Unwrap() error
 type MinContainsFieldFor31Plus struct{ ValidationError }
 
 func (e *MinContainsFieldFor31Plus) As(target any) bool
+
+func (e *MinContainsFieldFor31Plus) Code() string
 
 type MultiError []error
     MultiError is a collection of errors, intended for when multiple issues need
@@ -1546,8 +1637,6 @@ type MutuallyExclusiveFieldsError struct {
     one is allowed" failures (example.value vs externalValue, mediaType.example
     vs examples, license.url vs identifier, link.operationId vs operationRef).
     Carries both field names and wraps the per-site leaf.
-
-func (e *MutuallyExclusiveFieldsError) Code() string
 
 func (e *MutuallyExclusiveFieldsError) Error() string
 
@@ -1606,9 +1695,13 @@ type OAuthFlowAuthorizationURLForbidden struct{ ValidationError }
 
 func (e *OAuthFlowAuthorizationURLForbidden) As(target any) bool
 
+func (e *OAuthFlowAuthorizationURLForbidden) Code() string
+
 type OAuthFlowAuthorizationURLRequired struct{ ValidationError }
 
 func (e *OAuthFlowAuthorizationURLRequired) As(target any) bool
+
+func (e *OAuthFlowAuthorizationURLRequired) Code() string
 
 type OAuthFlowFieldValidationError struct {
 	// Field is the offending field name ("refreshUrl" is the only
@@ -1627,13 +1720,19 @@ type OAuthFlowScopesRequired struct{ ValidationError }
 
 func (e *OAuthFlowScopesRequired) As(target any) bool
 
+func (e *OAuthFlowScopesRequired) Code() string
+
 type OAuthFlowTokenURLForbidden struct{ ValidationError }
 
 func (e *OAuthFlowTokenURLForbidden) As(target any) bool
 
+func (e *OAuthFlowTokenURLForbidden) Code() string
+
 type OAuthFlowTokenURLRequired struct{ ValidationError }
 
 func (e *OAuthFlowTokenURLRequired) As(target any) bool
+
+func (e *OAuthFlowTokenURLRequired) Code() string
 
 type OAuthFlowValidationError struct {
 	// FlowKind is one of "implicit", "password", "clientCredentials",
@@ -1677,9 +1776,13 @@ type OpenAPIVersionRequired struct{ ValidationError }
 
 func (e *OpenAPIVersionRequired) As(target any) bool
 
+func (e *OpenAPIVersionRequired) Code() string
+
 type OpenIDConnectURLRequired struct{ ValidationError }
 
 func (e *OpenIDConnectURLRequired) As(target any) bool
+
+func (e *OpenIDConnectURLRequired) Code() string
 
 type Operation struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -1749,6 +1852,8 @@ func (operation *Operation) Validate(ctx context.Context, opts ...ValidationOpti
 type OperationResponsesRequired struct{ ValidationError }
 
 func (e *OperationResponsesRequired) As(target any) bool
+
+func (e *OperationResponsesRequired) Code() string
 
 type OperationValidationError struct {
 	Method string
@@ -1836,13 +1941,19 @@ type ParameterContentSchemaExactlyOne struct{ ValidationError }
 
 func (e *ParameterContentSchemaExactlyOne) As(target any) bool
 
+func (e *ParameterContentSchemaExactlyOne) Code() string
+
 type ParameterContentSingleEntry struct{ ValidationError }
 
 func (e *ParameterContentSingleEntry) As(target any) bool
 
+func (e *ParameterContentSingleEntry) Code() string
+
 type ParameterExampleAndExamplesExclusive struct{ ValidationError }
 
 func (e *ParameterExampleAndExamplesExclusive) As(target any) bool
+
+func (e *ParameterExampleAndExamplesExclusive) Code() string
 
 type ParameterExampleValidationError struct {
 	// ExampleName is the example map key.
@@ -1873,6 +1984,8 @@ func (e *ParameterFieldValidationError) Unwrap() error
 type ParameterNameRequired struct{ ValidationError }
 
 func (e *ParameterNameRequired) As(target any) bool
+
+func (e *ParameterNameRequired) Code() string
 
 type ParameterRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -2120,17 +2233,25 @@ type PathsRequired struct{ ValidationError }
 
 func (e *PathsRequired) As(target any) bool
 
+func (e *PathsRequired) Code() string
+
 type PatternPropertiesFieldFor31Plus struct{ ValidationError }
 
 func (e *PatternPropertiesFieldFor31Plus) As(target any) bool
+
+func (e *PatternPropertiesFieldFor31Plus) Code() string
 
 type PrefixItemsFieldFor31Plus struct{ ValidationError }
 
 func (e *PrefixItemsFieldFor31Plus) As(target any) bool
 
+func (e *PrefixItemsFieldFor31Plus) Code() string
+
 type PropertyNamesFieldFor31Plus struct{ ValidationError }
 
 func (e *PropertyNamesFieldFor31Plus) As(target any) bool
+
+func (e *PropertyNamesFieldFor31Plus) Code() string
 
 type ReadFromURIFunc func(loader *Loader, url *url.URL) ([]byte, error)
     ReadFromURIFunc defines a function which reads the contents of a resource
@@ -2243,6 +2364,8 @@ type RequestBodyContentRequired struct{ ValidationError }
 
 func (e *RequestBodyContentRequired) As(target any) bool
 
+func (e *RequestBodyContentRequired) Code() string
+
 type RequestBodyRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
 	// are allowed by the openapi spec.
@@ -2310,8 +2433,6 @@ type RequiredFieldError struct {
         var ivr *InfoVersionRequired
         if errors.As(err, &ivr) { /* knows it's exactly info.version */ }
 
-func (e *RequiredFieldError) Code() string
-
 func (e *RequiredFieldError) Error() string
 
 func (e *RequiredFieldError) Unwrap() error
@@ -2359,6 +2480,8 @@ func (m ResponseBodies) JSONLookup(token string) (any, error)
 type ResponseDescriptionRequired struct{ ValidationError }
 
 func (e *ResponseDescriptionRequired) As(target any) bool
+
+func (e *ResponseDescriptionRequired) Code() string
 
 type ResponseRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -2468,6 +2591,8 @@ func (responses *Responses) Value(key string) *ResponseRef
 type ResponsesNonEmptyRequired struct{ ValidationError }
 
 func (e *ResponsesNonEmptyRequired) As(target any) bool
+
+func (e *ResponsesNonEmptyRequired) Code() string
 
 type Schema struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
@@ -2706,6 +2831,8 @@ type SchemaAdditionalPropertiesBothForms struct{ ValidationError }
 
 func (e *SchemaAdditionalPropertiesBothForms) As(target any) bool
 
+func (e *SchemaAdditionalPropertiesBothForms) Code() string
+
 type SchemaBothFormsExclusive struct {
 	// Field is the name of the union-typed schema property
 	// (e.g. "additionalProperties", "unevaluatedItems").
@@ -2719,8 +2846,6 @@ type SchemaBothFormsExclusive struct {
     SchemaBothFormsExclusive clusters "this union-typed schema field is
     set to both its boolean and schema forms simultaneously" failures —
     additionalProperties, unevaluatedItems, unevaluatedProperties.
-
-func (e *SchemaBothFormsExclusive) Code() string
 
 func (e *SchemaBothFormsExclusive) Error() string
 
@@ -2770,9 +2895,13 @@ type SchemaFieldFor31Plus struct{ ValidationError }
 
 func (e *SchemaFieldFor31Plus) As(target any) bool
 
+func (e *SchemaFieldFor31Plus) Code() string
+
 type SchemaItemsRequired struct{ ValidationError }
 
 func (e *SchemaItemsRequired) As(target any) bool
+
+func (e *SchemaItemsRequired) Code() string
 
 type SchemaPatternRegexError struct {
 	// Pattern is the schema's `pattern:` value that failed to compile.
@@ -2803,6 +2932,8 @@ func (e *SchemaPatternRegexError) Unwrap() error
 type SchemaReadOnlyWriteOnlyExclusive struct{ ValidationError }
 
 func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool
+
+func (e *SchemaReadOnlyWriteOnlyExclusive) Code() string
 
 type SchemaRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -2873,9 +3004,13 @@ type SchemaUnevaluatedItemsBothForms struct{ ValidationError }
 
 func (e *SchemaUnevaluatedItemsBothForms) As(target any) bool
 
+func (e *SchemaUnevaluatedItemsBothForms) Code() string
+
 type SchemaUnevaluatedPropertiesBothForms struct{ ValidationError }
 
 func (e *SchemaUnevaluatedPropertiesBothForms) As(target any) bool
+
+func (e *SchemaUnevaluatedPropertiesBothForms) Code() string
 
 type SchemaValidationOption func(*schemaValidationSettings)
     SchemaValidationOption describes options a user has when validating request
@@ -2987,8 +3122,6 @@ type SchemaValueError struct {
     either a single SchemaError or a MultiError aggregating several. errors.As
     walks both shapes transparently.
 
-func (e *SchemaValueError) Code() string
-
 func (e *SchemaValueError) Error() string
 
 func (e *SchemaValueError) Unwrap() error
@@ -3092,6 +3225,8 @@ type SecuritySchemeBearerFormatForbidden struct{ ValidationError }
 
 func (e *SecuritySchemeBearerFormatForbidden) As(target any) bool
 
+func (e *SecuritySchemeBearerFormatForbidden) Code() string
+
 type SecuritySchemeFlowValidationError struct {
 	Cause error
 }
@@ -3106,17 +3241,25 @@ type SecuritySchemeFlowsForbidden struct{ ValidationError }
 
 func (e *SecuritySchemeFlowsForbidden) As(target any) bool
 
+func (e *SecuritySchemeFlowsForbidden) Code() string
+
 type SecuritySchemeFlowsRequired struct{ ValidationError }
 
 func (e *SecuritySchemeFlowsRequired) As(target any) bool
+
+func (e *SecuritySchemeFlowsRequired) Code() string
 
 type SecuritySchemeInForbidden struct{ ValidationError }
 
 func (e *SecuritySchemeInForbidden) As(target any) bool
 
+func (e *SecuritySchemeInForbidden) Code() string
+
 type SecuritySchemeNameForbidden struct{ ValidationError }
 
 func (e *SecuritySchemeNameForbidden) As(target any) bool
+
+func (e *SecuritySchemeNameForbidden) Code() string
 
 type SecuritySchemeRef struct {
 	// Extensions only captures fields starting with 'x-' as no other fields
@@ -3215,6 +3358,8 @@ type ServerURLRequired struct{ ValidationError }
 
 func (e *ServerURLRequired) As(target any) bool
 
+func (e *ServerURLRequired) Code() string
+
 type ServerURLTemplateError struct {
 	// URL is the server URL whose template failed validation.
 	URL string
@@ -3264,6 +3409,8 @@ type ServerVariableDefaultRequired struct{ ValidationError }
 
 func (e *ServerVariableDefaultRequired) As(target any) bool
 
+func (e *ServerVariableDefaultRequired) Code() string
+
 type ServerVariables map[string]*ServerVariable
     ServerVariable is specified by OpenAPI/Swagger standard version 3. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#server-variable-object
@@ -3292,8 +3439,6 @@ type SingleEntryContentError struct {
 }
     SingleEntryContentError clusters "the content map must contain at most one
     entry" failures (parameter.content, header.content).
-
-func (e *SingleEntryContentError) Code() string
 
 func (e *SingleEntryContentError) Error() string
 
@@ -3503,6 +3648,8 @@ type ThenFieldFor31Plus struct{ ValidationError }
 
 func (e *ThenFieldFor31Plus) As(target any) bool
 
+func (e *ThenFieldFor31Plus) Code() string
+
 type Types []string
     Types represents the type(s) of a schema.
 
@@ -3629,9 +3776,13 @@ type UnevaluatedItemsFieldFor31Plus struct{ ValidationError }
 
 func (e *UnevaluatedItemsFieldFor31Plus) As(target any) bool
 
+func (e *UnevaluatedItemsFieldFor31Plus) Code() string
+
 type UnevaluatedPropertiesFieldFor31Plus struct{ ValidationError }
 
 func (e *UnevaluatedPropertiesFieldFor31Plus) As(target any) bool
+
+func (e *UnevaluatedPropertiesFieldFor31Plus) Code() string
 
 type UnresolvedRefError struct {
 	// Ref is the unresolved $ref value (e.g. "#/components/schemas/X"
@@ -3849,6 +4000,8 @@ func (e *WebhookValidationError) Unwrap() error
 type WebhooksFieldFor31Plus struct{ ValidationError }
 
 func (e *WebhooksFieldFor31Plus) As(target any) bool
+
+func (e *WebhooksFieldFor31Plus) Code() string
 
 type XML struct {
 	Extensions map[string]any `json:"-" yaml:"-"`

--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ The `Origin` struct contains three parts:
 
 Origin data is populated by an internal post-processing step after YAML decoding — it is not part of the OpenAPI spec itself. For this reason, Origin fields are excluded from serialization. If you marshal a loaded document back to JSON/YAML, origin data will not appear in the output.
 
+## Identifying validation errors by code
+
+Each validation error carries a stable, kebab-case code (e.g. `operation-responses-required`), independent of the message text, so tools can suppress specific findings, assign per-rule severities, or emit machine-readable diagnostics. The full catalog is available from `openapi3.ValidationErrorCodes()`.
+
+```go
+err := doc.Validate(ctx, openapi3.EnableMultiError())
+for _, e := range err.(openapi3.MultiError) {
+	var coded openapi3.CodedError
+	if errors.As(e, &coded) {
+		fmt.Println(coded.Code(), e) // e.g. "operation-responses-required value of responses must be an object"
+	}
+}
+```
+
 ## Getting OpenAPI operation that matches request
 ```go
 loader := openapi3.NewLoader()

--- a/openapi3/validation_code.go
+++ b/openapi3/validation_code.go
@@ -17,6 +17,8 @@ import (
 // Renaming or removing a code is a breaking change and is recorded in the
 // README changelog. The full set is available from ValidationErrorCodes.
 //
+// Like net.Error, this interface exists as an assertion target for consumers;
+// the package itself constructs concrete error types and does not consume it.
 // Reach the code of a wrapped error with errors.As:
 //
 //	var coded openapi3.CodedError

--- a/openapi3/validation_code.go
+++ b/openapi3/validation_code.go
@@ -1,10 +1,6 @@
 package openapi3
 
-import (
-	"slices"
-	"strings"
-	"unicode"
-)
+import "slices"
 
 // CodedError is implemented by every typed validation error. Code returns a
 // stable, kebab-case identifier for the validation rule that failed (e.g.
@@ -13,9 +9,11 @@ import (
 // (e.g. the LSP Diagnostic.code field), or link to per-rule documentation
 // without depending on message text.
 //
-// Codes are a contract: message wording may change freely, codes may not.
-// Renaming or removing a code is a breaking change and is recorded in the
-// README changelog. The full set is available from ValidationErrorCodes.
+// Every code is declared as a literal on its error type; nothing is derived.
+// Codes are a contract: message wording and Go type names may change freely,
+// codes may not. Renaming or removing a code is a breaking change and is
+// recorded in the README changelog. The full set is available from
+// ValidationErrorCodes.
 //
 // Like net.Error, this interface exists as an assertion target for consumers;
 // the package itself constructs concrete error types and does not consume it.
@@ -30,91 +28,132 @@ type CodedError interface {
 	Code() string
 }
 
-func (e *RequiredFieldError) Code() string {
-	return codeToken(e.Field) + "-required"
+func (e *AnchorFieldFor31Plus) Code() string             { return "anchor-field-for-3-1-plus" }
+func (e *APIKeyInInvalidError) Code() string             { return "security-scheme-apikey-in-invalid" }
+func (e *APIKeySecuritySchemeNameRequired) Code() string { return "security-scheme-name-required" }
+func (e *CommentFieldFor31Plus) Code() string            { return "comment-field-for-3-1-plus" }
+func (e *ConflictingPathsError) Code() string            { return "conflicting-paths" }
+func (e *ConstFieldFor31Plus) Code() string              { return "const-field-for-3-1-plus" }
+func (e *ContainsFieldFor31Plus) Code() string           { return "contains-field-for-3-1-plus" }
+func (e *ContentEncodingFieldFor31Plus) Code() string    { return "content-encoding-field-for-3-1-plus" }
+func (e *ContentMediaTypeFieldFor31Plus) Code() string {
+	return "content-media-type-field-for-3-1-plus"
 }
-
-func (e *FieldVersionMismatchError) Code() string {
-	return codeToken(e.Field) + "-field-for-" + strings.ReplaceAll(e.MinVersion, ".", "-") + "-plus"
+func (e *ContentSchemaFieldFor31Plus) Code() string { return "content-schema-field-for-3-1-plus" }
+func (e *DefaultViolatesSchema) Code() string       { return "default-violates-schema" }
+func (e *DefsFieldFor31Plus) Code() string          { return "defs-field-for-3-1-plus" }
+func (e *DependentRequiredFieldFor31Plus) Code() string {
+	return "dependent-required-field-for-3-1-plus"
 }
-
-func (e *SchemaValueError) Code() string {
-	return codeToken(e.ValueKind) + "-violates-schema"
+func (e *DependentSchemasFieldFor31Plus) Code() string { return "dependent-schemas-field-for-3-1-plus" }
+func (e *DuplicateOperationIDError) Code() string      { return "duplicate-operation-id" }
+func (e *DuplicateParameterError) Code() string        { return "duplicate-parameter" }
+func (e *DuplicateRequiredFieldError) Code() string    { return "duplicate-required-field" }
+func (e *DuplicateTagError) Code() string              { return "duplicate-tag" }
+func (e *DynamicAnchorFieldFor31Plus) Code() string    { return "dynamic-anchor-field-for-3-1-plus" }
+func (e *DynamicRefFieldFor31Plus) Code() string       { return "dynamic-ref-field-for-3-1-plus" }
+func (e *ElseFieldFor31Plus) Code() string             { return "else-field-for-3-1-plus" }
+func (e *ExamplesFieldFor31Plus) Code() string         { return "examples-field-for-3-1-plus" }
+func (e *ExampleValueExternalValueExclusive) Code() string {
+	return "value-external-value-mutually-exclusive"
 }
-
-func (e *MutuallyExclusiveFieldsError) Code() string {
-	return codeToken(e.Field1) + "-" + codeToken(e.Field2) + "-mutually-exclusive"
+func (e *ExampleValueOrExternalValueRequired) Code() string {
+	return "value-or-external-value-required"
 }
-
-func (e *ForbiddenFieldError) Code() string {
-	return codeToken(e.Field) + "-forbidden"
+func (e *ExampleViolatesSchema) Code() string                { return "example-violates-schema" }
+func (e *ExternalDocsURLRequired) Code() string              { return "external-docs-url-required" }
+func (e *ExtraSiblingFieldsError) Code() string              { return "extra-sibling-fields" }
+func (e *HeaderContentSchemaExactlyOne) Code() string        { return "content-or-schema-exactly-one" }
+func (e *HeaderContentSingleEntry) Code() string             { return "header-content-single-entry" }
+func (e *HeaderInForbidden) Code() string                    { return "in-forbidden" }
+func (e *HeaderNameForbidden) Code() string                  { return "name-forbidden" }
+func (e *IDFieldFor31Plus) Code() string                     { return "id-field-for-3-1-plus" }
+func (e *IfFieldFor31Plus) Code() string                     { return "if-field-for-3-1-plus" }
+func (e *InfoRequired) Code() string                         { return "info-required" }
+func (e *InfoSummaryFieldFor31Plus) Code() string            { return "summary-field-for-3-1-plus" }
+func (e *InfoTitleRequired) Code() string                    { return "info-title-required" }
+func (e *InfoVersionRequired) Code() string                  { return "info-version-required" }
+func (e *InvalidHTTPSchemeError) Code() string               { return "security-scheme-http-scheme-invalid" }
+func (e *InvalidParameterInError) Code() string              { return "parameter-in-invalid" }
+func (e *InvalidSecuritySchemeTypeError) Code() string       { return "security-scheme-type-invalid" }
+func (e *InvalidSerializationMethodError) Code() string      { return "serialization-method-invalid" }
+func (e *ItemSchemaFieldFor32Plus) Code() string             { return "item-schema-field-for-3-2-plus" }
+func (e *JSONSchemaDialectAbsoluteURIRequired) Code() string { return "json-schema-dialect-required" }
+func (e *JSONSchemaDialectFieldFor31Plus) Code() string {
+	return "jsonschemadialect-field-for-3-1-plus"
 }
-
-func (e *EitherFieldRequiredError) Code() string {
-	return joinCodeTokens(e.Fields) + "-required"
+func (e *LicenseIdentifierFieldFor31Plus) Code() string { return "identifier-field-for-3-1-plus" }
+func (e *LicenseNameRequired) Code() string             { return "license-name-required" }
+func (e *LicenseURLIdentifierExclusive) Code() string   { return "url-identifier-mutually-exclusive" }
+func (e *LinkOperationIDOrRefRequired) Code() string    { return "operation-id-or-operation-ref-required" }
+func (e *LinkOperationIDRefExclusive) Code() string {
+	return "operation-id-operation-ref-mutually-exclusive"
 }
-
-func (e *ExactlyOneFieldError) Code() string {
-	return joinCodeTokens(e.Fields) + "-exactly-one"
+func (e *MaxContainsFieldFor31Plus) Code() string { return "max-contains-field-for-3-1-plus" }
+func (e *MediaTypeExampleExamplesExclusive) Code() string {
+	return "example-examples-mutually-exclusive"
 }
-
-func (e *SchemaBothFormsExclusive) Code() string {
-	return codeToken(e.Field) + "-both-forms-exclusive"
+func (e *MinContainsFieldFor31Plus) Code() string          { return "min-contains-field-for-3-1-plus" }
+func (e *OAuthFlowAuthorizationURLForbidden) Code() string { return "authorization-url-forbidden" }
+func (e *OAuthFlowAuthorizationURLRequired) Code() string {
+	return "oauth-flow-authorization-url-required"
 }
-
-func (e *SingleEntryContentError) Code() string {
-	return codeToken(e.Subject) + "-content-single-entry"
+func (e *OAuthFlowScopesRequired) Code() string          { return "oauth-flow-scopes-required" }
+func (e *OAuthFlowTokenURLForbidden) Code() string       { return "token-url-forbidden" }
+func (e *OAuthFlowTokenURLRequired) Code() string        { return "oauth-flow-token-url-required" }
+func (e *OpenAPIVersionRequired) Code() string           { return "openapi-required" }
+func (e *OpenIDConnectURLRequired) Code() string         { return "openid-connect-url-required" }
+func (e *OperationResponsesRequired) Code() string       { return "operation-responses-required" }
+func (e *ParameterContentSchemaExactlyOne) Code() string { return "content-or-schema-exactly-one" }
+func (e *ParameterContentSingleEntry) Code() string      { return "parameter-content-single-entry" }
+func (e *ParameterExampleAndExamplesExclusive) Code() string {
+	return "example-examples-mutually-exclusive"
 }
-
-func (e *DuplicateRequiredFieldError) Code() string { return "duplicate-required-field" }
-func (e *DuplicateTagError) Code() string           { return "duplicate-tag" }
-func (e *PathParametersError) Code() string         { return "path-parameters-mismatch" }
-func (e *ServerURLTemplateError) Code() string      { return "server-url-template-invalid" }
-func (e *WebhookNilError) Code() string             { return "webhook-nil" }
-func (e *PathParameterRequiredError) Code() string  { return "path-parameter-required" }
-func (e *DuplicateOperationIDError) Code() string   { return "duplicate-operation-id" }
-func (e *ExtraSiblingFieldsError) Code() string     { return "extra-sibling-fields" }
-func (e *SchemaTypeError) Code() string             { return "schema-type-unsupported" }
-func (e *InvalidParameterInError) Code() string     { return "parameter-in-invalid" }
-func (e *SchemaPatternRegexError) Code() string     { return "schema-pattern-regex-invalid" }
-func (e *InvalidSecuritySchemeTypeError) Code() string {
-	return "security-scheme-type-invalid"
-}
-func (e *InvalidHTTPSchemeError) Code() string      { return "security-scheme-http-scheme-invalid" }
-func (e *UnresolvedRefError) Code() string          { return "unresolved-ref" }
-func (e *APIKeyInInvalidError) Code() string        { return "security-scheme-apikey-in-invalid" }
+func (e *ParameterNameRequired) Code() string       { return "parameter-name-required" }
 func (e *PathMustStartWithSlashError) Code() string { return "path-must-start-with-slash" }
-func (e *ConflictingPathsError) Code() string       { return "conflicting-paths" }
-func (e *DuplicateParameterError) Code() string     { return "duplicate-parameter" }
-func (e *InvalidSerializationMethodError) Code() string {
-	return "serialization-method-invalid"
+func (e *PathParameterRequiredError) Code() string  { return "path-parameter-required" }
+func (e *PathParametersError) Code() string         { return "path-parameters-mismatch" }
+func (e *PathsRequired) Code() string               { return "paths-required" }
+func (e *PatternPropertiesFieldFor31Plus) Code() string {
+	return "pattern-properties-field-for-3-1-plus"
 }
-
-// codeToken renders a field path as a code segment: "$" is stripped, "." joins
-// with "-", known acronyms stay single words ("oAuthFlow" -> "oauth-flow"),
-// and camelCase splits on "-" ("externalDocs.url" -> "external-docs-url").
-func codeToken(field string) string {
-	field = strings.TrimPrefix(field, "$")
-	field = strings.ReplaceAll(field, ".", "-")
-	field = strings.ReplaceAll(field, "oAuth", "oauth")
-	field = strings.ReplaceAll(field, "openId", "openid")
-	var b strings.Builder
-	for i, r := range field {
-		if i > 0 && unicode.IsUpper(r) {
-			b.WriteByte('-')
-		}
-		b.WriteRune(unicode.ToLower(r))
-	}
-	return b.String()
+func (e *PrefixItemsFieldFor31Plus) Code() string   { return "prefix-items-field-for-3-1-plus" }
+func (e *PropertyNamesFieldFor31Plus) Code() string { return "property-names-field-for-3-1-plus" }
+func (e *RequestBodyContentRequired) Code() string  { return "request-body-content-required" }
+func (e *ResponseDescriptionRequired) Code() string { return "response-description-required" }
+func (e *ResponsesNonEmptyRequired) Code() string   { return "responses-required" }
+func (e *SchemaAdditionalPropertiesBothForms) Code() string {
+	return "additional-properties-both-forms-exclusive"
 }
-
-func joinCodeTokens(fields []string) string {
-	tokens := make([]string, len(fields))
-	for i, f := range fields {
-		tokens[i] = codeToken(f)
-	}
-	return strings.Join(tokens, "-or-")
+func (e *SchemaFieldFor31Plus) Code() string    { return "schema-field-for-3-1-plus" }
+func (e *SchemaItemsRequired) Code() string     { return "schema-items-required" }
+func (e *SchemaPatternRegexError) Code() string { return "schema-pattern-regex-invalid" }
+func (e *SchemaReadOnlyWriteOnlyExclusive) Code() string {
+	return "read-only-write-only-mutually-exclusive"
 }
+func (e *SchemaTypeError) Code() string { return "schema-type-unsupported" }
+func (e *SchemaUnevaluatedItemsBothForms) Code() string {
+	return "unevaluated-items-both-forms-exclusive"
+}
+func (e *SchemaUnevaluatedPropertiesBothForms) Code() string {
+	return "unevaluated-properties-both-forms-exclusive"
+}
+func (e *SecuritySchemeBearerFormatForbidden) Code() string { return "bearer-format-forbidden" }
+func (e *SecuritySchemeFlowsForbidden) Code() string        { return "flows-forbidden" }
+func (e *SecuritySchemeFlowsRequired) Code() string         { return "flows-required" }
+func (e *SecuritySchemeInForbidden) Code() string           { return "in-forbidden" }
+func (e *SecuritySchemeNameForbidden) Code() string         { return "name-forbidden" }
+func (e *ServerURLRequired) Code() string                   { return "server-url-required" }
+func (e *ServerURLTemplateError) Code() string              { return "server-url-template-invalid" }
+func (e *ServerVariableDefaultRequired) Code() string       { return "default-required" }
+func (e *ThenFieldFor31Plus) Code() string                  { return "then-field-for-3-1-plus" }
+func (e *UnevaluatedItemsFieldFor31Plus) Code() string      { return "unevaluated-items-field-for-3-1-plus" }
+func (e *UnevaluatedPropertiesFieldFor31Plus) Code() string {
+	return "unevaluated-properties-field-for-3-1-plus"
+}
+func (e *UnresolvedRefError) Code() string     { return "unresolved-ref" }
+func (e *WebhookNilError) Code() string        { return "webhook-nil" }
+func (e *WebhooksFieldFor31Plus) Code() string { return "webhooks-field-for-3-1-plus" }
 
 // ValidationErrorCodes returns every code a validation error can carry,
 // sorted. TestValidationErrorCodes keeps it in sync with the errors the

--- a/openapi3/validation_code.go
+++ b/openapi3/validation_code.go
@@ -1,0 +1,217 @@
+package openapi3
+
+import (
+	"slices"
+	"strings"
+	"unicode"
+)
+
+// CodedError is implemented by every typed validation error. Code returns a
+// stable, kebab-case identifier for the validation rule that failed (e.g.
+// "operation-responses-required"), so consumers can suppress specific
+// findings, assign per-rule severities, emit machine-readable diagnostics
+// (e.g. the LSP Diagnostic.code field), or link to per-rule documentation
+// without depending on message text.
+//
+// Codes are a contract: message wording may change freely, codes may not.
+// Renaming or removing a code is a breaking change and is recorded in the
+// README changelog. The full set is available from ValidationErrorCodes.
+//
+// Reach the code of a wrapped error with errors.As:
+//
+//	var coded openapi3.CodedError
+//	if errors.As(err, &coded) {
+//		fmt.Println(coded.Code())
+//	}
+type CodedError interface {
+	error
+	Code() string
+}
+
+func (e *RequiredFieldError) Code() string {
+	return codeToken(e.Field) + "-required"
+}
+
+func (e *FieldVersionMismatchError) Code() string {
+	return codeToken(e.Field) + "-field-for-" + strings.ReplaceAll(e.MinVersion, ".", "-") + "-plus"
+}
+
+func (e *SchemaValueError) Code() string {
+	return codeToken(e.ValueKind) + "-violates-schema"
+}
+
+func (e *MutuallyExclusiveFieldsError) Code() string {
+	return codeToken(e.Field1) + "-" + codeToken(e.Field2) + "-mutually-exclusive"
+}
+
+func (e *ForbiddenFieldError) Code() string {
+	return codeToken(e.Field) + "-forbidden"
+}
+
+func (e *EitherFieldRequiredError) Code() string {
+	return joinCodeTokens(e.Fields) + "-required"
+}
+
+func (e *ExactlyOneFieldError) Code() string {
+	return joinCodeTokens(e.Fields) + "-exactly-one"
+}
+
+func (e *SchemaBothFormsExclusive) Code() string {
+	return codeToken(e.Field) + "-both-forms-exclusive"
+}
+
+func (e *SingleEntryContentError) Code() string {
+	return codeToken(e.Subject) + "-content-single-entry"
+}
+
+func (e *DuplicateRequiredFieldError) Code() string { return "duplicate-required-field" }
+func (e *DuplicateTagError) Code() string           { return "duplicate-tag" }
+func (e *PathParametersError) Code() string         { return "path-parameters-mismatch" }
+func (e *ServerURLTemplateError) Code() string      { return "server-url-template-invalid" }
+func (e *WebhookNilError) Code() string             { return "webhook-nil" }
+func (e *PathParameterRequiredError) Code() string  { return "path-parameter-required" }
+func (e *DuplicateOperationIDError) Code() string   { return "duplicate-operation-id" }
+func (e *ExtraSiblingFieldsError) Code() string     { return "extra-sibling-fields" }
+func (e *SchemaTypeError) Code() string             { return "schema-type-unsupported" }
+func (e *InvalidParameterInError) Code() string     { return "parameter-in-invalid" }
+func (e *SchemaPatternRegexError) Code() string     { return "schema-pattern-regex-invalid" }
+func (e *InvalidSecuritySchemeTypeError) Code() string {
+	return "security-scheme-type-invalid"
+}
+func (e *InvalidHTTPSchemeError) Code() string      { return "security-scheme-http-scheme-invalid" }
+func (e *UnresolvedRefError) Code() string          { return "unresolved-ref" }
+func (e *APIKeyInInvalidError) Code() string        { return "security-scheme-apikey-in-invalid" }
+func (e *PathMustStartWithSlashError) Code() string { return "path-must-start-with-slash" }
+func (e *ConflictingPathsError) Code() string       { return "conflicting-paths" }
+func (e *DuplicateParameterError) Code() string     { return "duplicate-parameter" }
+func (e *InvalidSerializationMethodError) Code() string {
+	return "serialization-method-invalid"
+}
+
+// codeToken renders a field path as a code segment: "$" is stripped, "." joins
+// with "-", known acronyms stay single words ("oAuthFlow" -> "oauth-flow"),
+// and camelCase splits on "-" ("externalDocs.url" -> "external-docs-url").
+func codeToken(field string) string {
+	field = strings.TrimPrefix(field, "$")
+	field = strings.ReplaceAll(field, ".", "-")
+	field = strings.ReplaceAll(field, "oAuth", "oauth")
+	field = strings.ReplaceAll(field, "openId", "openid")
+	var b strings.Builder
+	for i, r := range field {
+		if i > 0 && unicode.IsUpper(r) {
+			b.WriteByte('-')
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+func joinCodeTokens(fields []string) string {
+	tokens := make([]string, len(fields))
+	for i, f := range fields {
+		tokens[i] = codeToken(f)
+	}
+	return strings.Join(tokens, "-or-")
+}
+
+// ValidationErrorCodes returns every code a validation error can carry,
+// sorted. TestValidationErrorCodes keeps it in sync with the errors the
+// validators emit.
+func ValidationErrorCodes() []string {
+	return slices.Clone(validationErrorCodes)
+}
+
+var validationErrorCodes = []string{
+	"additional-properties-both-forms-exclusive",
+	"anchor-field-for-3-1-plus",
+	"authorization-url-forbidden",
+	"bearer-format-forbidden",
+	"comment-field-for-3-1-plus",
+	"conflicting-paths",
+	"const-field-for-3-1-plus",
+	"contains-field-for-3-1-plus",
+	"content-encoding-field-for-3-1-plus",
+	"content-media-type-field-for-3-1-plus",
+	"content-or-schema-exactly-one",
+	"content-schema-field-for-3-1-plus",
+	"default-required",
+	"default-violates-schema",
+	"defs-field-for-3-1-plus",
+	"dependent-required-field-for-3-1-plus",
+	"dependent-schemas-field-for-3-1-plus",
+	"duplicate-operation-id",
+	"duplicate-parameter",
+	"duplicate-required-field",
+	"duplicate-tag",
+	"dynamic-anchor-field-for-3-1-plus",
+	"dynamic-ref-field-for-3-1-plus",
+	"else-field-for-3-1-plus",
+	"example-examples-mutually-exclusive",
+	"example-violates-schema",
+	"examples-field-for-3-1-plus",
+	"external-docs-url-required",
+	"extra-sibling-fields",
+	"flows-forbidden",
+	"flows-required",
+	"header-content-single-entry",
+	"id-field-for-3-1-plus",
+	"identifier-field-for-3-1-plus",
+	"if-field-for-3-1-plus",
+	"in-forbidden",
+	"info-required",
+	"info-title-required",
+	"info-version-required",
+	"item-schema-field-for-3-2-plus",
+	"json-schema-dialect-required",
+	"jsonschemadialect-field-for-3-1-plus",
+	"license-name-required",
+	"max-contains-field-for-3-1-plus",
+	"min-contains-field-for-3-1-plus",
+	"name-forbidden",
+	"oauth-flow-authorization-url-required",
+	"oauth-flow-scopes-required",
+	"oauth-flow-token-url-required",
+	"openapi-required",
+	"openid-connect-url-required",
+	"operation-id-operation-ref-mutually-exclusive",
+	"operation-id-or-operation-ref-required",
+	"operation-responses-required",
+	"parameter-content-single-entry",
+	"parameter-in-invalid",
+	"parameter-name-required",
+	"path-must-start-with-slash",
+	"path-parameter-required",
+	"path-parameters-mismatch",
+	"paths-required",
+	"pattern-properties-field-for-3-1-plus",
+	"prefix-items-field-for-3-1-plus",
+	"property-names-field-for-3-1-plus",
+	"read-only-write-only-mutually-exclusive",
+	"request-body-content-required",
+	"response-description-required",
+	"responses-required",
+	"schema-field-for-3-1-plus",
+	"schema-items-required",
+	"schema-pattern-regex-invalid",
+	"schema-type-unsupported",
+	"security-scheme-apikey-in-invalid",
+	"security-scheme-http-scheme-invalid",
+	"security-scheme-name-required",
+	"security-scheme-type-invalid",
+	"serialization-method-invalid",
+	"server-url-required",
+	"server-url-template-invalid",
+	"summary-field-for-3-1-plus",
+	"then-field-for-3-1-plus",
+	"token-url-forbidden",
+	"unevaluated-items-both-forms-exclusive",
+	"unevaluated-items-field-for-3-1-plus",
+	"unevaluated-properties-both-forms-exclusive",
+	"unevaluated-properties-field-for-3-1-plus",
+	"unresolved-ref",
+	"url-identifier-mutually-exclusive",
+	"value-external-value-mutually-exclusive",
+	"value-or-external-value-required",
+	"webhook-nil",
+	"webhooks-field-for-3-1-plus",
+}

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -10,90 +10,115 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// codedErrorInventory holds one instance of every validation error the
-// openapi3 validators emit, with the strings the emit sites use. When a
-// validation is added, renamed, or removed, update both this inventory and
-// ValidationErrorCodes -- TestValidationErrorCodes fails until the two agree,
-// which keeps the exported catalog honest.
+// codedErrorInventory holds one instance of every typed validation error.
+// Codes are literals on the types, so zero values suffice. When a validation
+// is added, renamed, or removed, update this inventory and
+// ValidationErrorCodes together; TestValidationErrorCodes fails until the two
+// agree, which keeps the exported catalog honest.
 func codedErrorInventory() []openapi3.CodedError {
-	var errs []openapi3.CodedError
-
-	for _, f := range []string{
-		"default", "externalDocs.url", "flows", "info", "info.title", "info.version",
-		"jsonSchemaDialect", "license.name", "oAuthFlow.authorizationUrl", "oAuthFlow.scopes",
-		"oAuthFlow.tokenUrl", "openapi", "openIdConnectUrl", "operation.responses",
-		"parameter.name", "paths", "requestBody.content", "response.description",
-		"responses", "schema.items", "securityScheme.name", "server.url",
-	} {
-		errs = append(errs, &openapi3.RequiredFieldError{Field: f})
-	}
-
-	// fields allowed from OAS 3.1 (see Schema.Validate and the per-object
-	// validators) and from OAS 3.2 (itemSchema)
-	for _, f := range []string{
-		"summary", "identifier", "webhooks", "jsonschemadialect",
-		"$anchor", "$comment", "$defs", "$dynamicAnchor", "$dynamicRef", "$id", "$schema",
-		"const", "contains", "contentEncoding", "contentMediaType", "contentSchema",
-		"dependentRequired", "dependentSchemas", "else", "examples", "if",
-		"maxContains", "minContains", "patternProperties", "prefixItems",
-		"propertyNames", "then", "unevaluatedItems", "unevaluatedProperties",
-	} {
-		errs = append(errs, &openapi3.FieldVersionMismatchError{Field: f, MinVersion: "3.1"})
-	}
-	errs = append(errs, &openapi3.FieldVersionMismatchError{Field: "itemSchema", MinVersion: "3.2"})
-
-	for _, k := range []string{"example", "default"} {
-		errs = append(errs, &openapi3.SchemaValueError{ValueKind: k})
-	}
-
-	for _, p := range [][2]string{
-		{"value", "externalValue"}, {"example", "examples"}, {"url", "identifier"},
-		{"operationId", "operationRef"}, {"readOnly", "writeOnly"},
-	} {
-		errs = append(errs, &openapi3.MutuallyExclusiveFieldsError{Field1: p[0], Field2: p[1]})
-	}
-
-	for _, f := range []string{"authorizationUrl", "bearerFormat", "flows", "in", "name", "tokenUrl"} {
-		errs = append(errs, &openapi3.ForbiddenFieldError{Field: f})
-	}
-
-	for _, f := range []string{"additionalProperties", "unevaluatedItems", "unevaluatedProperties"} {
-		errs = append(errs, &openapi3.SchemaBothFormsExclusive{Field: f})
-	}
-
-	for _, s := range []string{"header", "parameter"} {
-		errs = append(errs, &openapi3.SingleEntryContentError{Subject: s})
-	}
-
-	return append(errs,
-		&openapi3.EitherFieldRequiredError{Fields: []string{"value", "externalValue"}},
-		&openapi3.EitherFieldRequiredError{Fields: []string{"operationId", "operationRef"}},
-		&openapi3.ExactlyOneFieldError{Fields: []string{"content", "schema"}},
+	return []openapi3.CodedError{
+		&openapi3.AnchorFieldFor31Plus{},
+		&openapi3.APIKeyInInvalidError{},
+		&openapi3.APIKeySecuritySchemeNameRequired{},
+		&openapi3.CommentFieldFor31Plus{},
+		&openapi3.ConflictingPathsError{},
+		&openapi3.ConstFieldFor31Plus{},
+		&openapi3.ContainsFieldFor31Plus{},
+		&openapi3.ContentEncodingFieldFor31Plus{},
+		&openapi3.ContentMediaTypeFieldFor31Plus{},
+		&openapi3.ContentSchemaFieldFor31Plus{},
+		&openapi3.DefaultViolatesSchema{},
+		&openapi3.DefsFieldFor31Plus{},
+		&openapi3.DependentRequiredFieldFor31Plus{},
+		&openapi3.DependentSchemasFieldFor31Plus{},
+		&openapi3.DuplicateOperationIDError{},
+		&openapi3.DuplicateParameterError{},
 		&openapi3.DuplicateRequiredFieldError{},
 		&openapi3.DuplicateTagError{},
-		&openapi3.PathParametersError{},
-		&openapi3.ServerURLTemplateError{},
-		&openapi3.WebhookNilError{},
-		&openapi3.PathParameterRequiredError{},
-		&openapi3.DuplicateOperationIDError{},
+		&openapi3.DynamicAnchorFieldFor31Plus{},
+		&openapi3.DynamicRefFieldFor31Plus{},
+		&openapi3.ElseFieldFor31Plus{},
+		&openapi3.ExamplesFieldFor31Plus{},
+		&openapi3.ExampleValueExternalValueExclusive{},
+		&openapi3.ExampleValueOrExternalValueRequired{},
+		&openapi3.ExampleViolatesSchema{},
+		&openapi3.ExternalDocsURLRequired{},
 		&openapi3.ExtraSiblingFieldsError{},
-		&openapi3.SchemaTypeError{},
-		&openapi3.InvalidParameterInError{},
-		&openapi3.SchemaPatternRegexError{},
-		&openapi3.InvalidSecuritySchemeTypeError{},
+		&openapi3.HeaderContentSchemaExactlyOne{},
+		&openapi3.HeaderContentSingleEntry{},
+		&openapi3.HeaderInForbidden{},
+		&openapi3.HeaderNameForbidden{},
+		&openapi3.IDFieldFor31Plus{},
+		&openapi3.IfFieldFor31Plus{},
+		&openapi3.InfoRequired{},
+		&openapi3.InfoSummaryFieldFor31Plus{},
+		&openapi3.InfoTitleRequired{},
+		&openapi3.InfoVersionRequired{},
 		&openapi3.InvalidHTTPSchemeError{},
-		&openapi3.UnresolvedRefError{},
-		&openapi3.APIKeyInInvalidError{},
-		&openapi3.PathMustStartWithSlashError{},
-		&openapi3.ConflictingPathsError{},
-		&openapi3.DuplicateParameterError{},
+		&openapi3.InvalidParameterInError{},
+		&openapi3.InvalidSecuritySchemeTypeError{},
 		&openapi3.InvalidSerializationMethodError{},
-	)
+		&openapi3.ItemSchemaFieldFor32Plus{},
+		&openapi3.JSONSchemaDialectAbsoluteURIRequired{},
+		&openapi3.JSONSchemaDialectFieldFor31Plus{},
+		&openapi3.LicenseIdentifierFieldFor31Plus{},
+		&openapi3.LicenseNameRequired{},
+		&openapi3.LicenseURLIdentifierExclusive{},
+		&openapi3.LinkOperationIDOrRefRequired{},
+		&openapi3.LinkOperationIDRefExclusive{},
+		&openapi3.MaxContainsFieldFor31Plus{},
+		&openapi3.MediaTypeExampleExamplesExclusive{},
+		&openapi3.MinContainsFieldFor31Plus{},
+		&openapi3.OAuthFlowAuthorizationURLForbidden{},
+		&openapi3.OAuthFlowAuthorizationURLRequired{},
+		&openapi3.OAuthFlowScopesRequired{},
+		&openapi3.OAuthFlowTokenURLForbidden{},
+		&openapi3.OAuthFlowTokenURLRequired{},
+		&openapi3.OpenAPIVersionRequired{},
+		&openapi3.OpenIDConnectURLRequired{},
+		&openapi3.OperationResponsesRequired{},
+		&openapi3.ParameterContentSchemaExactlyOne{},
+		&openapi3.ParameterContentSingleEntry{},
+		&openapi3.ParameterExampleAndExamplesExclusive{},
+		&openapi3.ParameterNameRequired{},
+		&openapi3.PathMustStartWithSlashError{},
+		&openapi3.PathParameterRequiredError{},
+		&openapi3.PathParametersError{},
+		&openapi3.PathsRequired{},
+		&openapi3.PatternPropertiesFieldFor31Plus{},
+		&openapi3.PrefixItemsFieldFor31Plus{},
+		&openapi3.PropertyNamesFieldFor31Plus{},
+		&openapi3.RequestBodyContentRequired{},
+		&openapi3.ResponseDescriptionRequired{},
+		&openapi3.ResponsesNonEmptyRequired{},
+		&openapi3.SchemaAdditionalPropertiesBothForms{},
+		&openapi3.SchemaFieldFor31Plus{},
+		&openapi3.SchemaItemsRequired{},
+		&openapi3.SchemaPatternRegexError{},
+		&openapi3.SchemaReadOnlyWriteOnlyExclusive{},
+		&openapi3.SchemaTypeError{},
+		&openapi3.SchemaUnevaluatedItemsBothForms{},
+		&openapi3.SchemaUnevaluatedPropertiesBothForms{},
+		&openapi3.SecuritySchemeBearerFormatForbidden{},
+		&openapi3.SecuritySchemeFlowsForbidden{},
+		&openapi3.SecuritySchemeFlowsRequired{},
+		&openapi3.SecuritySchemeInForbidden{},
+		&openapi3.SecuritySchemeNameForbidden{},
+		&openapi3.ServerURLRequired{},
+		&openapi3.ServerURLTemplateError{},
+		&openapi3.ServerVariableDefaultRequired{},
+		&openapi3.ThenFieldFor31Plus{},
+		&openapi3.UnevaluatedItemsFieldFor31Plus{},
+		&openapi3.UnevaluatedPropertiesFieldFor31Plus{},
+		&openapi3.UnresolvedRefError{},
+		&openapi3.WebhookNilError{},
+		&openapi3.WebhooksFieldFor31Plus{},
+	}
 }
 
-// TestValidationErrorCodes pins the code contract: every inventory error
-// yields a code from the exported catalog, every catalog entry is yielded by
-// some inventory error, and the catalog is sorted, unique, kebab-case.
+// TestValidationErrorCodes pins the code contract: every typed error yields a
+// code from the exported catalog, every catalog entry is yielded by some
+// type, and the catalog is sorted, unique, kebab-case.
 func TestValidationErrorCodes(t *testing.T) {
 	catalog := openapi3.ValidationErrorCodes()
 	require.True(t, slices.IsSorted(catalog), "catalog must be sorted")

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -116,31 +116,97 @@ func TestValidationErrorCodes(t *testing.T) {
 		"catalog and inventory diverge: update ValidationErrorCodes and codedErrorInventory together")
 }
 
-// TestValidationErrorCodes_EndToEnd exercises the code surface through a real
-// document validation.
+// TestValidationErrorCodes_EndToEnd proves codes are reachable with errors.As
+// through every wrapper shape Validate produces: the inventory test covers
+// which codes exist; this covers that a consumer can get to them. One row per
+// unwrap path, not per code.
 func TestValidationErrorCodes_EndToEnd(t *testing.T) {
-	const spec = `
+	for _, tc := range []struct {
+		name    string // the wrapper chain under test
+		spec    string
+		expects string
+	}{
+		{
+			name: "doc root, unwrapped",
+			spec: `
+openapi: ""
+info: { title: t, version: "1" }
+paths: {}
+`,
+			expects: "openapi-required",
+		},
+		{
+			name: "path and operation wrappers",
+			spec: `
 openapi: 3.0.0
 info: { title: t, version: "1" }
 paths:
   /a:
     get:
       summary: no responses
-`
-	loader := openapi3.NewLoader()
-	doc, err := loader.LoadFromData([]byte(spec))
-	require.NoError(t, err)
-	verr := doc.Validate(t.Context(), openapi3.EnableMultiError())
-	require.Error(t, verr)
+`,
+			expects: "operation-responses-required",
+		},
+		{
+			name: "section wrapper inside an operation",
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      externalDocs: { description: d }
+      responses:
+        "200": { description: ok }
+`,
+			expects: "external-docs-url-required",
+		},
+		{
+			name: "component wrapper",
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  securitySchemes:
+    s: { type: bogus }
+`,
+			expects: "security-scheme-type-invalid",
+		},
+		{
+			name: "schema nested in a component",
+			spec: `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths: {}
+components:
+  schemas:
+    S: { type: string, const: x }
+`,
+			expects: "const-field-for-3-1-plus",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			loader := openapi3.NewLoader()
+			doc, err := loader.LoadFromData([]byte(tc.spec))
+			require.NoError(t, err)
 
-	var codes []string
-	for _, e := range verr.(openapi3.MultiError) {
-		var coded openapi3.CodedError
-		require.ErrorAs(t, e, &coded, "every validation error carries a code")
-		codes = append(codes, coded.Code())
-	}
-	require.Contains(t, codes, "operation-responses-required")
-	for _, c := range codes {
-		require.Contains(t, openapi3.ValidationErrorCodes(), c, "emitted codes come from the catalog")
+			verr := doc.Validate(t.Context(), openapi3.EnableMultiError())
+			require.Error(t, verr)
+			var multi openapi3.MultiError
+			require.ErrorAs(t, verr, &multi)
+			require.NotEmpty(t, multi)
+
+			var codes []string
+			for _, e := range multi {
+				var coded openapi3.CodedError
+				require.ErrorAs(t, e, &coded, "a code must be reachable through the %s chain (error: %v)", tc.name, e)
+				codes = append(codes, coded.Code())
+			}
+			require.Contains(t, codes, tc.expects)
+			for _, c := range codes {
+				require.Contains(t, openapi3.ValidationErrorCodes(), c, "emitted codes come from the catalog")
+			}
+		})
 	}
 }

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -1,0 +1,144 @@
+package openapi3_test
+
+import (
+	"regexp"
+	"slices"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/require"
+)
+
+// codedErrorInventory holds one instance of every validation error the
+// openapi3 validators emit, with the strings the emit sites use. When a
+// validation is added, renamed, or removed, update both this inventory and
+// ValidationErrorCodes -- TestValidationErrorCodes fails until the two agree,
+// which keeps the exported catalog honest.
+func codedErrorInventory() []openapi3.CodedError {
+	var errs []openapi3.CodedError
+
+	for _, f := range []string{
+		"default", "externalDocs.url", "flows", "info", "info.title", "info.version",
+		"jsonSchemaDialect", "license.name", "oAuthFlow.authorizationUrl", "oAuthFlow.scopes",
+		"oAuthFlow.tokenUrl", "openapi", "openIdConnectUrl", "operation.responses",
+		"parameter.name", "paths", "requestBody.content", "response.description",
+		"responses", "schema.items", "securityScheme.name", "server.url",
+	} {
+		errs = append(errs, &openapi3.RequiredFieldError{Field: f})
+	}
+
+	// fields allowed from OAS 3.1 (see Schema.Validate and the per-object
+	// validators) and from OAS 3.2 (itemSchema)
+	for _, f := range []string{
+		"summary", "identifier", "webhooks", "jsonschemadialect",
+		"$anchor", "$comment", "$defs", "$dynamicAnchor", "$dynamicRef", "$id", "$schema",
+		"const", "contains", "contentEncoding", "contentMediaType", "contentSchema",
+		"dependentRequired", "dependentSchemas", "else", "examples", "if",
+		"maxContains", "minContains", "patternProperties", "prefixItems",
+		"propertyNames", "then", "unevaluatedItems", "unevaluatedProperties",
+	} {
+		errs = append(errs, &openapi3.FieldVersionMismatchError{Field: f, MinVersion: "3.1"})
+	}
+	errs = append(errs, &openapi3.FieldVersionMismatchError{Field: "itemSchema", MinVersion: "3.2"})
+
+	for _, k := range []string{"example", "default"} {
+		errs = append(errs, &openapi3.SchemaValueError{ValueKind: k})
+	}
+
+	for _, p := range [][2]string{
+		{"value", "externalValue"}, {"example", "examples"}, {"url", "identifier"},
+		{"operationId", "operationRef"}, {"readOnly", "writeOnly"},
+	} {
+		errs = append(errs, &openapi3.MutuallyExclusiveFieldsError{Field1: p[0], Field2: p[1]})
+	}
+
+	for _, f := range []string{"authorizationUrl", "bearerFormat", "flows", "in", "name", "tokenUrl"} {
+		errs = append(errs, &openapi3.ForbiddenFieldError{Field: f})
+	}
+
+	for _, f := range []string{"additionalProperties", "unevaluatedItems", "unevaluatedProperties"} {
+		errs = append(errs, &openapi3.SchemaBothFormsExclusive{Field: f})
+	}
+
+	for _, s := range []string{"header", "parameter"} {
+		errs = append(errs, &openapi3.SingleEntryContentError{Subject: s})
+	}
+
+	return append(errs,
+		&openapi3.EitherFieldRequiredError{Fields: []string{"value", "externalValue"}},
+		&openapi3.EitherFieldRequiredError{Fields: []string{"operationId", "operationRef"}},
+		&openapi3.ExactlyOneFieldError{Fields: []string{"content", "schema"}},
+		&openapi3.DuplicateRequiredFieldError{},
+		&openapi3.DuplicateTagError{},
+		&openapi3.PathParametersError{},
+		&openapi3.ServerURLTemplateError{},
+		&openapi3.WebhookNilError{},
+		&openapi3.PathParameterRequiredError{},
+		&openapi3.DuplicateOperationIDError{},
+		&openapi3.ExtraSiblingFieldsError{},
+		&openapi3.SchemaTypeError{},
+		&openapi3.InvalidParameterInError{},
+		&openapi3.SchemaPatternRegexError{},
+		&openapi3.InvalidSecuritySchemeTypeError{},
+		&openapi3.InvalidHTTPSchemeError{},
+		&openapi3.UnresolvedRefError{},
+		&openapi3.APIKeyInInvalidError{},
+		&openapi3.PathMustStartWithSlashError{},
+		&openapi3.ConflictingPathsError{},
+		&openapi3.DuplicateParameterError{},
+		&openapi3.InvalidSerializationMethodError{},
+	)
+}
+
+// TestValidationErrorCodes pins the code contract: every inventory error
+// yields a code from the exported catalog, every catalog entry is yielded by
+// some inventory error, and the catalog is sorted, unique, kebab-case.
+func TestValidationErrorCodes(t *testing.T) {
+	catalog := openapi3.ValidationErrorCodes()
+	require.True(t, slices.IsSorted(catalog), "catalog must be sorted")
+	require.Equal(t, len(slices.Compact(slices.Clone(catalog))), len(catalog), "catalog must be unique")
+	kebab := regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+	for _, c := range catalog {
+		require.Truef(t, kebab.MatchString(c), "code %q is not kebab-case", c)
+	}
+
+	emitted := map[string]struct{}{}
+	for _, e := range codedErrorInventory() {
+		emitted[e.Code()] = struct{}{}
+	}
+	emittedSorted := make([]string, 0, len(emitted))
+	for c := range emitted {
+		emittedSorted = append(emittedSorted, c)
+	}
+	slices.Sort(emittedSorted)
+	require.Equal(t, catalog, emittedSorted,
+		"catalog and inventory diverge: update ValidationErrorCodes and codedErrorInventory together")
+}
+
+// TestValidationErrorCodes_EndToEnd exercises the code surface through a real
+// document validation.
+func TestValidationErrorCodes_EndToEnd(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /a:
+    get:
+      summary: no responses
+`
+	doc, err := openapi3.NewLoader().LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	verr := doc.Validate(t.Context(), openapi3.EnableMultiError())
+	require.Error(t, verr)
+
+	var codes []string
+	for _, e := range verr.(openapi3.MultiError) {
+		var coded openapi3.CodedError
+		require.ErrorAs(t, e, &coded, "every validation error carries a code")
+		codes = append(codes, coded.Code())
+	}
+	require.Contains(t, codes, "operation-responses-required")
+	for _, c := range codes {
+		require.Contains(t, openapi3.ValidationErrorCodes(), c, "emitted codes come from the catalog")
+	}
+}

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -5,8 +5,9 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
 )
 
 // codedErrorInventory holds one instance of every validation error the

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -127,7 +127,8 @@ paths:
     get:
       summary: no responses
 `
-	doc, err := openapi3.NewLoader().LoadFromData([]byte(spec))
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
 	require.NoError(t, err)
 	verr := doc.Validate(t.Context(), openapi3.EnableMultiError())
 	require.Error(t, verr)

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -1376,12 +1376,43 @@ func newAPIKeySecuritySchemeNameRequired(origin *Origin) error {
 		&APIKeySecuritySchemeNameRequired{ValidationError{Message: msg}}, origin)
 }
 
+// ExampleViolatesSchema and DefaultViolatesSchema mark which schema value kind
+// failed. They embed SchemaValueError, and their As exposes it, so errors.As
+// with a *SchemaValueError target keeps matching.
+type ExampleViolatesSchema struct{ SchemaValueError }
+
+func (e *ExampleViolatesSchema) As(target any) bool {
+	return asSchemaValueError(target, &e.SchemaValueError)
+}
+
+type DefaultViolatesSchema struct{ SchemaValueError }
+
+func (e *DefaultViolatesSchema) As(target any) bool {
+	return asSchemaValueError(target, &e.SchemaValueError)
+}
+
+func asSchemaValueError(target any, sve *SchemaValueError) bool {
+	t, ok := target.(**SchemaValueError)
+	if !ok {
+		return false
+	}
+	*t = sve
+	return true
+}
+
 // newSchemaValueError wraps the result of schema.VisitJSON in a
 // *SchemaValueError cluster, identifying which schema sub-field
 // (example, default, ...) carried the offending value. cause is
 // either a *SchemaError or a MultiError of them.
 func newSchemaValueError(valueKind string, cause error, origin *Origin) error {
-	return &SchemaValueError{ValueKind: valueKind, Cause: cause, Origin: origin}
+	sve := SchemaValueError{ValueKind: valueKind, Cause: cause, Origin: origin}
+	switch valueKind {
+	case "example":
+		return &ExampleViolatesSchema{sve}
+	case "default":
+		return &DefaultViolatesSchema{sve}
+	}
+	return &sve
 }
 
 // exampleValueOrigin returns an Origin pinned to the example's `value:`
@@ -1494,9 +1525,25 @@ func errFieldFor31Plus(field string, origin *Origin) error {
 	return newFieldVersionMismatch(field, "3.1", leaf, origin)
 }
 
+type ItemSchemaFieldFor32Plus struct{ ValidationError }
+
+func (e *ItemSchemaFieldFor32Plus) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+var fieldFor32PlusLeaves = map[string]func(msg string) error{
+	"itemSchema": func(m string) error { return &ItemSchemaFieldFor32Plus{ValidationError{Message: m}} },
+}
+
 func errFieldFor32Plus(field string, origin *Origin) error {
 	msg := "field " + field + " is for OpenAPI >=3.2"
-	return newFieldVersionMismatch(field, "3.2", &ValidationError{Message: msg}, origin)
+	var leaf error
+	if ctor, ok := fieldFor32PlusLeaves[field]; ok {
+		leaf = ctor(msg)
+	} else {
+		leaf = &ValidationError{Message: msg}
+	}
+	return newFieldVersionMismatch(field, "3.2", leaf, origin)
 }
 
 func newPathParameterRequired(param string, origin *Origin) error {


### PR DESCRIPTION
Validation errors have typed identities (#1018 through #1170) but no portable one: a consumer that wants to suppress a specific finding, set per-rule severity, emit machine-readable diagnostics, or link to per-rule documentation can only key off message text, which makes every wording improvement silently breaking (related asks: #390, #194).

This adds a stable, kebab-case `Code()` to every typed validation error, plus a `ValidationErrorCodes()` catalog: the rule-identifier pattern of ESLint, Spectral, and staticcheck. Codes become the contract; messages and Go type names become freely improvable.

### Design (after review)
- **Every code is a literal declared on its error type; nothing is derived.** 96 typed errors, one line each. This also completes per-site types for the three sites that lacked them: `itemSchema` (via a `fieldFor32PlusLeaves` map mirroring the 3.1 one) and the two `SchemaValueError` kinds (`ExampleViolatesSchema`, `DefaultViolatesSchema`, embedding `SchemaValueError` with an `As` bridge so `errors.As` with a `*SchemaValueError` target keeps matching).
- **Why declared codes and not `reflect.TypeOf(err).Name()`**: renaming a Go type is a normal refactor and Go users get a compile error; but these identifiers also live in config files (ignore lists, severity settings) and logs, where there is no compiler, so a type rename would break them silently. Declared codes keep the two contracts independent: types can be renamed freely, codes stay stable, and the catalog test guards them.
- `CodedError` interface for uniform access via `errors.As` (an assertion target for consumers, like `net.Error`).
- `ValidationErrorCodes()` returns the sorted catalog (92 codes; a few types share a code where the same rule fires at two sites, e.g. `in-forbidden`). `TestValidationErrorCodes` pins it bidirectionally against an inventory of every typed error, using zero values since codes are constants. An end-to-end test exercises the surface through real document validation, one case per wrapper shape.

No behavior change; full `openapi3` suite green.