### PR TITLE
openapi3filter: reuse deepObject bracket regex

### DIFF
--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -38,6 +38,8 @@ const (
 	KindInvalidFormat
 )
 
+var deepObjectBracketRE = regexp.MustCompile(`\[(.*?)\]`)
+
 // ParseError describes errors which happens while parse operation's parameters, requestBody, or response.
 type ParseError struct {
 	Kind   ParseErrorKind
@@ -665,8 +667,7 @@ func (d *urlValuesDecoder) DecodeObject(param string, sm *openapi3.Serialization
 				if !regexp.MustCompile(fmt.Sprintf(`^%s\[`, regexp.QuoteMeta(param))).MatchString(key) {
 					continue
 				}
-
-				matches := regexp.MustCompile(`\[(.*?)\]`).FindAllStringSubmatch(key, -1)
+				matches := deepObjectBracketRE.FindAllStringSubmatch(key, -1)
 				switch l := len(matches); {
 				case l == 0:
 					// A query parameter's name does not match the required format, so skip it.


### PR DESCRIPTION
## Summary

Compile the constant `\[(.*?)\]` pattern once at package scope instead of rebuilding its regexp for every query-string key.

The other regexp used by this path (`^param\[`) may have separate optimization opportunities, but those have not yet been analyzed and are intentionally outside this PR.

## Benchmarks

Apple M4 Pro, Go 1.25.0, `darwin/arm64`; six runs per benchmark (test: [deepobject_bench_test.txt](https://github.com/user-attachments/files/30032920/deepobject_bench_test.txt))


```sh
go test ./openapi3filter/ -run '^$' -bench 'BenchmarkDeepObject' -benchmem -benchtime 1s -count 6
```

Compared with `benchstat`:

| Benchmark | ns/op (base → branch) | Time | B/op (base → branch) | allocs/op (base → branch) |
|---|---:|---:|---:|---:|
| Flat/1 key | 2,765 → 1,853 | -33.0% | 6,612 → 4,841 | 78 → 57 |
| Flat/8 keys | 18,610 → 12,850 | -31.0% | 45,960 → 32,640 | 589 → 421 |
| Flat/32 keys | 80,080 → 55,180 | -31.1% | 197,830 → 140,000 | 2,363 → 1,690 |
| Flat/128 keys | 326,800 → 220,100 | -32.7% | 795,900 → 563,300 | 9,387 → 6,697 |
| Nested/depth 4, 8 keys | 24,490 → 18,780 | -23.3% | 55,430 → 41,030 | 710 → 542 |
| Nested/depth 8, 32 keys | 121,830 → 98,710 | -19.0% | 249,100 → 191,400 | 3,101 → 2,429 |
| Mixed/8 matching, 120 noise | 179,900 → 164,600 | -8.5% | 473,900 → 458,900 | 5,991 → 5,823 |
| Mixed/8 matching, 504 noise | 670,200 → 661,300 | not significant | 1,831,000 → 1,817,000 | 23,278 → 23,110 |
| **Geomean** | | **-23.3%** | **-21.9%** | **-20.9%** |

For normal matching-key workloads, throughput improves by approximately **1.45–1.49×**, with roughly **28% fewer allocations**.
