### PR TITLE
openapi3filter: skip Split allocation for single-value array query params

### DIFF
--- a/openapi3filter/decode_array_test.go
+++ b/openapi3filter/decode_array_test.go
@@ -1,0 +1,205 @@
+package openapi3filter
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Tests for (*urlValuesDecoder).DecodeArray across form/space/pipe styles
+// and explode settings, including single-value and delimited multi-value inputs.
+
+func decodeArrayStringSchema() *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{
+		Type:  &openapi3.Types{"array"},
+		Items: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+	}}
+}
+
+func decodeArrayIntSchema() *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{
+		Type:  &openapi3.Types{"array"},
+		Items: &openapi3.SchemaRef{Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}}},
+	}}
+}
+
+func TestDecodeArray_FormNoExplode(t *testing.T) {
+	sm := &openapi3.SerializationMethod{Style: "form", Explode: false}
+	schema := decodeArrayStringSchema()
+
+	t.Run("single value no delimiter", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo"}, got)
+	})
+
+	t.Run("multi value comma delimited", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo,bar,baz"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo", "bar", "baz"}, got)
+	})
+
+	t.Run("trailing delimiter", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo,"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo", ""}, got)
+	})
+
+	t.Run("leading delimiter", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {",foo"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"", "foo"}, got)
+	})
+
+	t.Run("empty middle segment", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"a,,b"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"a", "", "b"}, got)
+	})
+
+	t.Run("empty string only", func(t *testing.T) {
+		// parseArray treats a single empty string as "no value".
+		dec := &urlValuesDecoder{values: url.Values{"param": {""}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Nil(t, got)
+	})
+
+	t.Run("missing param", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.False(t, found)
+		require.Nil(t, got)
+	})
+
+	t.Run("pipe chars are not delimiters in form style", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo|bar"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo|bar"}, got)
+	})
+}
+
+func TestDecodeArray_SpaceAndPipeNoExplode(t *testing.T) {
+	schema := decodeArrayStringSchema()
+
+	t.Run("spaceDelimited single", func(t *testing.T) {
+		sm := &openapi3.SerializationMethod{Style: "spaceDelimited", Explode: false}
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo"}, got)
+	})
+
+	t.Run("spaceDelimited multi", func(t *testing.T) {
+		sm := &openapi3.SerializationMethod{Style: "spaceDelimited", Explode: false}
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo bar baz"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo", "bar", "baz"}, got)
+	})
+
+	t.Run("pipeDelimited single", func(t *testing.T) {
+		sm := &openapi3.SerializationMethod{Style: "pipeDelimited", Explode: false}
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo"}, got)
+	})
+
+	t.Run("pipeDelimited multi", func(t *testing.T) {
+		sm := &openapi3.SerializationMethod{Style: "pipeDelimited", Explode: false}
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo|bar|baz"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo", "bar", "baz"}, got)
+	})
+}
+
+func TestDecodeArray_FormExplode(t *testing.T) {
+	sm := &openapi3.SerializationMethod{Style: "form", Explode: true}
+	schema := decodeArrayStringSchema()
+
+	t.Run("single repeated key", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo"}, got)
+	})
+
+	t.Run("multiple repeated keys", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo", "bar", "baz"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo", "bar", "baz"}, got)
+	})
+
+	t.Run("commas are part of the value when explode", func(t *testing.T) {
+		// explode skips Split; commas must not become item separators.
+		dec := &urlValuesDecoder{values: url.Values{"param": {"foo,bar"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{"foo,bar"}, got)
+	})
+}
+
+func TestDecodeArray_IntegerItems(t *testing.T) {
+	sm := &openapi3.SerializationMethod{Style: "form", Explode: false}
+	schema := decodeArrayIntSchema()
+
+	t.Run("single", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"42"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{int64(42)}, got)
+	})
+
+	t.Run("multi", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"1,2,3"}}}
+		got, found, err := dec.DecodeArray("param", sm, schema)
+		require.NoError(t, err)
+		require.True(t, found)
+		require.Equal(t, []any{int64(1), int64(2), int64(3)}, got)
+	})
+
+	t.Run("invalid item", func(t *testing.T) {
+		dec := &urlValuesDecoder{values: url.Values{"param": {"1,x"}}}
+		_, found, err := dec.DecodeArray("param", sm, schema)
+		require.True(t, found)
+		require.Error(t, err)
+		var pe *ParseError
+		require.ErrorAs(t, err, &pe)
+		require.Equal(t, []any{1}, pe.Path())
+	})
+}
+
+func TestDecodeArray_DeepObjectRejected(t *testing.T) {
+	sm := &openapi3.SerializationMethod{Style: "deepObject", Explode: true}
+	dec := &urlValuesDecoder{values: url.Values{"param": {"x"}}}
+	_, _, err := dec.DecodeArray("param", sm, decodeArrayStringSchema())
+	require.Error(t, err)
+}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -539,7 +539,13 @@ func (d *urlValuesDecoder) DecodeArray(param string, sm *openapi3.SerializationM
 		case "pipeDelimited":
 			delim = "|"
 		}
-		values = strings.Split(values[0], delim)
+		// strings.Split always allocates a new slice, even when the delimiter
+		// is absent (single-element arrays — the common case). Reuse values[:1].
+		if strings.Contains(values[0], delim) {
+			values = strings.Split(values[0], delim)
+		} else {
+			values = values[:1]
+		}
 	}
 	val, err := d.parseArray(values, schema)
 	return val, ok, err


### PR DESCRIPTION
## Summary

Non-explode `DecodeArray` always called `strings.Split`, which allocates even when the value has no delimiter (common single-element case). Skip `Split` when the delimiter is absent and reuse `values[:1]`.

## Benchmarks

Apple M4 Pro, Go 1.25.0, `darwin/arm64`; six runs (benchmark [deepobject_bench_test.txt](https://github.com/user-attachments/files/30033518/deepobject_bench_test.txt)):

```sh
go test ./openapi3filter/ -run '^$' -bench 'BenchmarkDecodeArray' -benchmem -benchtime 1s -count 6
```

**Single-value, non-explode** (skip-`Split` path):

| Benchmark | ns/op | Time | ops/s | B/op | allocs/op |
|---|---:|---:|---:|---:|---:|
| Form / 1 item | 46.72 → 35.86 | −23% (**1.30×**) | 21.4M → 27.9M | 48 → 32 | 3 → 2 |
| Space / 1 item | 49.45 → 36.93 | −25% (**1.34×**) | 20.2M → 27.1M | 48 → 32 | 3 → 2 |
| Pipe / 1 item | 49.29 → 37.73 | −23% (**1.31×**) | 20.3M → 26.5M | 48 → 32 | 3 → 2 |
| Form int / 1 item | 45.66 → 35.05 | −23% (**1.30×**) | 21.9M → 28.5M | 32 → 16 | 2 → 1 |

**Multi-value / explode controls:** B/op and allocs/op unchanged (still `Split` or no-`Split` explode path). Timing ~flat within noise.

**Suite geomean:** −5.0% ns/op, −13.7% B/op, −13.7% allocs/op.
