### PR TITLE
openapi3: preserve origin for a $ref to a schema under an arbitrary top-level key

### DIFF
--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -516,11 +516,45 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		if err := codec(cursor, resolved); err != nil {
 			return nil, nil, fmt.Errorf("bad data in %q (expecting %s)", ref, readableType(resolved))
 		}
+		// The value came from a generic map in T.Extensions (a $ref to an
+		// arbitrary top-level key), so the json round-trip above stripped its
+		// origins. Re-attach them from the file, best-effort.
+		loader.attachOriginToResolved(resolved, componentPath, fragment)
 		return componentDoc, componentPath, nil
 
 	default:
 		return nil, nil, fmt.Errorf("bad data in %q (expecting %s)", ref, readableType(resolved))
 	}
+}
+
+// attachOriginToResolved re-attaches source origins to a component resolved
+// through the generic-map path: a $ref to a schema under an arbitrary top-level
+// key lands in T.Extensions, and the json round-trip in resolveComponent strips
+// its origin. It re-derives the component file's origin tree, walks to the ref
+// fragment, and applies that subtree, so the object carries the same origins a
+// typed resolution would, with the original file's line numbers. Best-effort:
+// any failure leaves the object without origins, exactly as before.
+func (loader *Loader) attachOriginToResolved(resolved any, componentPath *url.URL, fragment string) {
+	if !loader.IncludeOrigin || componentPath == nil {
+		return
+	}
+	data, err := loader.readURL(componentPath)
+	if err != nil {
+		return
+	}
+	tree := originTree(data, componentPath)
+	if tree == nil {
+		return
+	}
+	for _, part := range strings.Split(strings.Trim(fragment, "/"), "/") {
+		if part == "" {
+			continue
+		}
+		if tree = tree.Fields[unescapeRefString(part)]; tree == nil {
+			return
+		}
+	}
+	applyOrigins(resolved, tree)
 }
 
 func readableType(x any) string {

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -546,7 +546,7 @@ func (loader *Loader) attachOriginToResolved(resolved any, componentPath *url.UR
 	if tree == nil {
 		return
 	}
-	for _, part := range strings.Split(strings.Trim(fragment, "/"), "/") {
+	for part := range strings.SplitSeq(strings.Trim(fragment, "/"), "/") {
 		if part == "" {
 			continue
 		}

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -64,11 +64,12 @@ type Loader struct {
 
 	visitedDocuments map[string]*T
 
-	// originTrees retains each visited document's origin tree (keyed like
-	// visitedDocuments) when IncludeOrigin is set, so resolveComponent can
-	// re-attach origins to components that lose them in the generic-map path
-	// without re-reading or re-parsing the file.
-	originTrees map[string]*originTree
+	// originTrees retains each loaded document's origin tree, keyed by the
+	// document itself so insert and lookup cannot disagree, populated when
+	// IncludeOrigin is set. resolveComponent uses it to re-attach origins to
+	// components that lose them in the generic-map path, without re-reading
+	// or re-parsing the file.
+	originTrees map[*T]*originTree
 
 	visitedRefs map[string]struct{}
 	visitedPath []string
@@ -146,6 +147,18 @@ func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, el
 	return resolvedPath, nil
 }
 
+// rememberOriginTree retains doc's origin tree for attachOriginToResolved.
+// tree is nil when IncludeOrigin is off or the data took the json path.
+func (loader *Loader) rememberOriginTree(doc *T, tree *originTree) {
+	if tree == nil {
+		return
+	}
+	if loader.originTrees == nil {
+		loader.originTrees = make(map[*T]*originTree)
+	}
+	loader.originTrees[doc] = tree
+}
+
 func (loader *Loader) readURL(location *url.URL) ([]byte, error) {
 	if f := loader.ReadFromURIFunc; f != nil {
 		return f(loader, location)
@@ -175,9 +188,11 @@ func (loader *Loader) LoadFromIoReader(reader io.Reader) (*T, error) {
 func (loader *Loader) LoadFromData(data []byte) (*T, error) {
 	loader.resetVisitedPathItemRefs()
 	doc := &T{}
-	if _, err := unmarshal(data, doc, loader.IncludeOrigin, nil); err != nil {
+	tree, err := unmarshal(data, doc, loader.IncludeOrigin, nil)
+	if err != nil {
 		return nil, err
 	}
+	loader.rememberOriginTree(doc, tree)
 	if err := loader.ResolveRefsIn(doc, nil); err != nil {
 		return nil, err
 	}
@@ -208,12 +223,7 @@ func (loader *Loader) loadFromDataWithPathInternal(data []byte, location *url.UR
 	if err != nil {
 		return nil, err
 	}
-	if tree != nil {
-		if loader.originTrees == nil {
-			loader.originTrees = make(map[string]*originTree)
-		}
-		loader.originTrees[uri] = tree
-	}
+	loader.rememberOriginTree(doc, tree)
 
 	doc.url = copyURI(location)
 
@@ -532,7 +542,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		// The value came from a generic map in T.Extensions (a $ref to an
 		// arbitrary top-level key), so the json round-trip above stripped its
 		// origins. Re-attach them from the file, best-effort.
-		loader.attachOriginToResolved(resolved, componentPath, fragment)
+		loader.attachOriginToResolved(resolved, componentDoc, fragment)
 		return componentDoc, componentPath, nil
 
 	default:
@@ -544,15 +554,15 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 // through the generic-map path: a $ref to a schema under an arbitrary top-level
 // key lands in T.Extensions, and the json round-trip in resolveComponent strips
 // its origin. It walks the document's retained origin tree (see originTrees,
-// populated when the file was first unmarshaled: no re-read, no re-parse) down
-// to the ref fragment and applies that subtree, so the object carries the same
-// origins a typed resolution would, with the original file's line numbers.
+// populated when the document was first unmarshaled: no re-read, no re-parse)
+// down to the ref fragment and applies that subtree, so the object carries the
+// same origins a typed resolution would, with the original file's line numbers.
 // Best-effort: a missing tree or fragment leaves the object without origins.
-func (loader *Loader) attachOriginToResolved(resolved any, componentPath *url.URL, fragment string) {
-	if !loader.IncludeOrigin || componentPath == nil {
+func (loader *Loader) attachOriginToResolved(resolved any, componentDoc *T, fragment string) {
+	if !loader.IncludeOrigin {
 		return
 	}
-	tree := loader.originTrees[componentPath.String()]
+	tree := loader.originTrees[componentDoc]
 	if tree == nil {
 		return
 	}

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -64,6 +64,12 @@ type Loader struct {
 
 	visitedDocuments map[string]*T
 
+	// originTrees retains each visited document's origin tree (keyed like
+	// visitedDocuments) when IncludeOrigin is set, so resolveComponent can
+	// re-attach origins to components that lose them in the generic-map path
+	// without re-reading or re-parsing the file.
+	originTrees map[string]*originTree
+
 	visitedRefs map[string]struct{}
 	visitedPath []string
 	backtrack   map[string][]func(value any)
@@ -133,7 +139,7 @@ func (loader *Loader) loadSingleElementFromURI(ref string, rootPath *url.URL, el
 	if err != nil {
 		return nil, err
 	}
-	if err := unmarshal(data, element, loader.IncludeOrigin, resolvedPath); err != nil {
+	if _, err := unmarshal(data, element, loader.IncludeOrigin, resolvedPath); err != nil {
 		return nil, err
 	}
 
@@ -169,7 +175,7 @@ func (loader *Loader) LoadFromIoReader(reader io.Reader) (*T, error) {
 func (loader *Loader) LoadFromData(data []byte) (*T, error) {
 	loader.resetVisitedPathItemRefs()
 	doc := &T{}
-	if err := unmarshal(data, doc, loader.IncludeOrigin, nil); err != nil {
+	if _, err := unmarshal(data, doc, loader.IncludeOrigin, nil); err != nil {
 		return nil, err
 	}
 	if err := loader.ResolveRefsIn(doc, nil); err != nil {
@@ -198,8 +204,15 @@ func (loader *Loader) loadFromDataWithPathInternal(data []byte, location *url.UR
 	doc := &T{}
 	loader.visitedDocuments[uri] = doc
 
-	if err := unmarshal(data, doc, loader.IncludeOrigin, location); err != nil {
+	tree, err := unmarshal(data, doc, loader.IncludeOrigin, location)
+	if err != nil {
 		return nil, err
+	}
+	if tree != nil {
+		if loader.originTrees == nil {
+			loader.originTrees = make(map[string]*originTree)
+		}
+		loader.originTrees[uri] = tree
 	}
 
 	doc.url = copyURI(location)
@@ -468,7 +481,7 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 		if err2 != nil {
 			return nil, nil, err
 		}
-		if err2 = unmarshal(data, &cursor, loader.IncludeOrigin, path); err2 != nil {
+		if _, err2 = unmarshal(data, &cursor, loader.IncludeOrigin, path); err2 != nil {
 			return nil, nil, err
 		}
 		if cursor, err2 = drill(cursor); err2 != nil || cursor == nil {
@@ -530,19 +543,16 @@ func (loader *Loader) resolveComponent(doc *T, ref string, path *url.URL, resolv
 // attachOriginToResolved re-attaches source origins to a component resolved
 // through the generic-map path: a $ref to a schema under an arbitrary top-level
 // key lands in T.Extensions, and the json round-trip in resolveComponent strips
-// its origin. It re-derives the component file's origin tree, walks to the ref
-// fragment, and applies that subtree, so the object carries the same origins a
-// typed resolution would, with the original file's line numbers. Best-effort:
-// any failure leaves the object without origins, exactly as before.
+// its origin. It walks the document's retained origin tree (see originTrees,
+// populated when the file was first unmarshaled: no re-read, no re-parse) down
+// to the ref fragment and applies that subtree, so the object carries the same
+// origins a typed resolution would, with the original file's line numbers.
+// Best-effort: a missing tree or fragment leaves the object without origins.
 func (loader *Loader) attachOriginToResolved(resolved any, componentPath *url.URL, fragment string) {
 	if !loader.IncludeOrigin || componentPath == nil {
 		return
 	}
-	data, err := loader.readURL(componentPath)
-	if err != nil {
-		return
-	}
-	tree := originTree(data, componentPath)
+	tree := loader.originTrees[componentPath.String()]
 	if tree == nil {
 		return
 	}

--- a/openapi3/marsh.go
+++ b/openapi3/marsh.go
@@ -43,24 +43,3 @@ func unmarshal(data []byte, v any, includeOrigin bool, location *url.URL) error 
 	// If both unmarshaling attempts fail, return a new error that includes both errors
 	return fmt.Errorf("failed to unmarshal data: json error: %v, yaml error: %v", jsonErr, yamlErr)
 }
-
-// originTree parses data solely for its origin tree, used to re-attach source
-// origins to a component resolved through the generic-map path: a $ref to a
-// schema under an arbitrary top-level key lands in T.Extensions and loses its
-// origin in the json round-trip (see resolveComponent). Returns nil when parsing
-// fails; callers degrade to no origin.
-func originTree(data []byte, location *url.URL) *yaml.OriginTree {
-	var file string
-	if location != nil {
-		file = location.String()
-	}
-	var v any
-	tree, err := yaml.Unmarshal(data, &v, yaml.DecodeOpts{
-		Origin:            yaml.OriginOpt{Enabled: true, File: file},
-		DisableTimestamps: true,
-	})
-	if err != nil {
-		return nil
-	}
-	return tree
-}

--- a/openapi3/marsh.go
+++ b/openapi3/marsh.go
@@ -43,3 +43,24 @@ func unmarshal(data []byte, v any, includeOrigin bool, location *url.URL) error 
 	// If both unmarshaling attempts fail, return a new error that includes both errors
 	return fmt.Errorf("failed to unmarshal data: json error: %v, yaml error: %v", jsonErr, yamlErr)
 }
+
+// originTree parses data solely for its origin tree, used to re-attach source
+// origins to a component resolved through the generic-map path: a $ref to a
+// schema under an arbitrary top-level key lands in T.Extensions and loses its
+// origin in the json round-trip (see resolveComponent). Returns nil when parsing
+// fails; callers degrade to no origin.
+func originTree(data []byte, location *url.URL) *yaml.OriginTree {
+	var file string
+	if location != nil {
+		file = location.String()
+	}
+	var v any
+	tree, err := yaml.Unmarshal(data, &v, yaml.DecodeOpts{
+		Origin:            yaml.OriginOpt{Enabled: true, File: file},
+		DisableTimestamps: true,
+	})
+	if err != nil {
+		return nil
+	}
+	return tree
+}

--- a/openapi3/marsh.go
+++ b/openapi3/marsh.go
@@ -17,12 +17,15 @@ func unmarshalError(jsonUnmarshalErr error) error {
 	return jsonUnmarshalErr
 }
 
-func unmarshal(data []byte, v any, includeOrigin bool, location *url.URL) error {
+// unmarshal decodes data into v. It returns the document origin tree when
+// includeOrigin is set and the data took the yaml path (json input carries no
+// origins), so the caller can retain it (see Loader.originTrees).
+func unmarshal(data []byte, v any, includeOrigin bool, location *url.URL) (*originTree, error) {
 	var jsonErr, yamlErr error
 
 	// See https://github.com/getkin/kin-openapi/issues/680
 	if jsonErr = json.Unmarshal(data, v); jsonErr == nil {
-		return nil
+		return nil, nil
 	}
 
 	// UnmarshalStrict(data, v) TODO: investigate how ymlv3 handles duplicate map keys
@@ -35,11 +38,11 @@ func unmarshal(data []byte, v any, includeOrigin bool, location *url.URL) error 
 		DisableTimestamps: true,
 	}); err == nil {
 		applyOrigins(v, tree)
-		return nil
+		return tree, nil
 	} else {
 		yamlErr = err
 	}
 
 	// If both unmarshaling attempts fail, return a new error that includes both errors
-	return fmt.Errorf("failed to unmarshal data: json error: %v, yaml error: %v", jsonErr, yamlErr)
+	return nil, fmt.Errorf("failed to unmarshal data: json error: %v, yaml error: %v", jsonErr, yamlErr)
 }

--- a/openapi3/origin.go
+++ b/openapi3/origin.go
@@ -1,6 +1,7 @@
 package openapi3
 
 import (
+	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -323,4 +324,25 @@ func jsonTagName(f reflect.StructField) string {
 	}
 	name, _, _ := strings.Cut(tag, ",")
 	return name
+}
+
+// originTree parses data solely for its origin tree, used to re-attach source
+// origins to a component resolved through the generic-map path: a $ref to a
+// schema under an arbitrary top-level key lands in T.Extensions and loses its
+// origin in the json round-trip (see resolveComponent). Returns nil when parsing
+// fails; callers degrade to no origin.
+func originTree(data []byte, location *url.URL) *yaml.OriginTree {
+	var file string
+	if location != nil {
+		file = location.String()
+	}
+	var v any
+	tree, err := yaml.Unmarshal(data, &v, yaml.DecodeOpts{
+		Origin:            yaml.OriginOpt{Enabled: true, File: file},
+		DisableTimestamps: true,
+	})
+	if err != nil {
+		return nil
+	}
+	return tree
 }

--- a/openapi3/origin.go
+++ b/openapi3/origin.go
@@ -1,7 +1,6 @@
 package openapi3
 
 import (
-	"net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -326,23 +325,6 @@ func jsonTagName(f reflect.StructField) string {
 	return name
 }
 
-// originTree parses data solely for its origin tree, used to re-attach source
-// origins to a component resolved through the generic-map path: a $ref to a
-// schema under an arbitrary top-level key lands in T.Extensions and loses its
-// origin in the json round-trip (see resolveComponent). Returns nil when parsing
-// fails; callers degrade to no origin.
-func originTree(data []byte, location *url.URL) *yaml.OriginTree {
-	var file string
-	if location != nil {
-		file = location.String()
-	}
-	var v any
-	tree, err := yaml.Unmarshal(data, &v, yaml.DecodeOpts{
-		Origin:            yaml.OriginOpt{Enabled: true, File: file},
-		DisableTimestamps: true,
-	})
-	if err != nil {
-		return nil
-	}
-	return tree
-}
+// originTree aliases the decoder-side origin tree, so the loader and marsh can
+// carry it without referencing the yaml package directly.
+type originTree = yaml.OriginTree

--- a/openapi3/origin_external_ref_test.go
+++ b/openapi3/origin_external_ref_test.go
@@ -28,7 +28,21 @@ func TestOrigin_ExternalRefToArbitraryTopLevelKey(t *testing.T) {
 	require.NotNil(t, user.Origin.Key, "the origin has a key location")
 	require.Equal(t, "arbitrary_key_schemas.yaml", filepath.Base(user.Origin.Key.File),
 		"origin points at the file the schema lives in, not the referencing document")
-	require.NotZero(t, user.Origin.Key.Line, "the origin has a source line")
+	require.Equal(t, Location{
+		File:    user.Origin.Key.File,
+		Line:    1,
+		Column:  1,
+		Name:    "User",
+		EndLine: 7, EndColumn: 19,
+	}, *user.Origin.Key, "the key origin spans the whole User block in arbitrary_key_schemas.yaml")
+	require.Equal(t, 2, user.Origin.Fields["type"].Line, "field origins are attached too")
+
+	// the subtree gets origins as well, with the same file
+	id := user.Properties["id"].Value
+	require.NotNil(t, id.Origin)
+	require.Equal(t, user.Origin.Key.File, id.Origin.Key.File)
+	require.Equal(t, 4, id.Origin.Key.Line, "the id property's own line")
+	require.Equal(t, 5, id.Origin.Fields["type"].Line)
 }
 
 // Re-attaching origins reuses the origin tree retained at load time: resolving
@@ -83,5 +97,10 @@ User:
 
 	user := doc.Paths.Value("/users").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
 	require.NotNil(t, user.Origin, "a same-document arbitrary-key $ref carries an origin")
-	require.NotZero(t, user.Origin.Key.Line)
+	require.NotNil(t, user.Origin.Key)
+	require.Equal(t, "User", user.Origin.Key.Name)
+	require.Equal(t, 14, user.Origin.Key.Line, "the User: line in the document above")
+	require.Equal(t, 17, user.Origin.Key.EndLine, "the block's last line")
+	require.Equal(t, 15, user.Origin.Fields["type"].Line)
+	require.Empty(t, user.Origin.Key.File, "a document loaded from data has no file")
 }

--- a/openapi3/origin_external_ref_test.go
+++ b/openapi3/origin_external_ref_test.go
@@ -1,6 +1,7 @@
 package openapi3
 
 import (
+	"net/url"
 	"path/filepath"
 	"testing"
 
@@ -28,4 +29,27 @@ func TestOrigin_ExternalRefToArbitraryTopLevelKey(t *testing.T) {
 	require.Equal(t, "arbitrary_key_schemas.yaml", filepath.Base(user.Origin.Key.File),
 		"origin points at the file the schema lives in, not the referencing document")
 	require.NotZero(t, user.Origin.Key.Line, "the origin has a source line")
+}
+
+// Re-attaching origins reuses the origin tree retained at load time: resolving
+// the arbitrary-key $ref must not read any file a second time.
+func TestOrigin_ExternalRefToArbitraryTopLevelKey_NoRereads(t *testing.T) {
+	reads := map[string]int{}
+	loader := NewLoader()
+	loader.IncludeOrigin = true
+	loader.ReadFromURIFunc = func(l *Loader, location *url.URL) ([]byte, error) {
+		reads[location.String()]++
+		return DefaultReadFromURI(l, location)
+	}
+
+	doc, err := loader.LoadFromFile("testdata/origin/arbitrary_key.yaml")
+	require.NoError(t, err)
+
+	user := doc.Paths.Value("/users").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	require.NotNil(t, user.Origin, "origins are attached")
+
+	require.Len(t, reads, 2, "the root and the $ref'd file")
+	for location, n := range reads {
+		require.Equalf(t, 1, n, "%s must be read exactly once", location)
+	}
 }

--- a/openapi3/origin_external_ref_test.go
+++ b/openapi3/origin_external_ref_test.go
@@ -53,3 +53,35 @@ func TestOrigin_ExternalRefToArbitraryTopLevelKey_NoRereads(t *testing.T) {
 		require.Equalf(t, 1, n, "%s must be read exactly once", location)
 	}
 }
+
+// Keying the retained trees by document also serves documents loaded from
+// memory (no location): a $ref to an arbitrary top-level key in the same
+// document gets its origin attached too.
+func TestOrigin_InternalRefToArbitraryTopLevelKey_FromData(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info: { title: t, version: "1" }
+paths:
+  /users:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/User'
+User:
+  type: object
+  properties:
+    id: { type: string }
+`
+	loader := NewLoader()
+	loader.IncludeOrigin = true
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	user := doc.Paths.Value("/users").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	require.NotNil(t, user.Origin, "a same-document arbitrary-key $ref carries an origin")
+	require.NotZero(t, user.Origin.Key.Line)
+}

--- a/openapi3/origin_external_ref_test.go
+++ b/openapi3/origin_external_ref_test.go
@@ -1,0 +1,31 @@
+package openapi3
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// A $ref to a schema stored under an arbitrary top-level key in another file
+// (e.g. "./schemas.yaml#/User", the Swagger-2-era "definitions bag") must carry
+// the origin of the file it lives in, like a $ref into /components/schemas does.
+// The key is not a typed field of T, so the loader reaches it through T.Extensions
+// (a generic map); the origin must survive that path.
+func TestOrigin_ExternalRefToArbitraryTopLevelKey(t *testing.T) {
+	loader := NewLoader()
+	loader.IncludeOrigin = true
+	loader.IsExternalRefsAllowed = true
+
+	doc, err := loader.LoadFromFile("testdata/origin/arbitrary_key.yaml")
+	require.NoError(t, err)
+
+	user := doc.Paths.Value("/users").Get.Responses.Value("200").Value.Content["application/json"].Schema.Value
+	require.NotNil(t, user, "the User schema resolves")
+
+	require.NotNil(t, user.Origin, "a schema $ref'd under an arbitrary top-level key must carry an origin")
+	require.NotNil(t, user.Origin.Key, "the origin has a key location")
+	require.Equal(t, "arbitrary_key_schemas.yaml", filepath.Base(user.Origin.Key.File),
+		"origin points at the file the schema lives in, not the referencing document")
+	require.NotZero(t, user.Origin.Key.Line, "the origin has a source line")
+}

--- a/openapi3/testdata/origin/arbitrary_key.yaml
+++ b/openapi3/testdata/origin/arbitrary_key.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.0
+info:
+  title: Arbitrary top-level key ref
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "./arbitrary_key_schemas.yaml#/User"

--- a/openapi3/testdata/origin/arbitrary_key_schemas.yaml
+++ b/openapi3/testdata/origin/arbitrary_key_schemas.yaml
@@ -1,0 +1,7 @@
+User:
+  type: object
+  properties:
+    id:
+      type: string
+    name:
+      type: string


### PR DESCRIPTION
A `$ref` to a schema stored under an arbitrary top-level key in another file (e.g. `./schemas.yaml#/User`, the Swagger-2-era "definitions bag") resolves through `T.Extensions`, a generic map that carries no origin, and the json round-trip that decodes it into the typed component drops origin entirely. With `IncludeOrigin` enabled the resolved schema then has a nil `Origin`, unlike the `/components/schemas` path.

Fix: retain each document.s origin tree when it is unmarshaled (keyed by the document, only under `IncludeOrigin`), and on that generic-map path (and only there) walk the retained tree down the ref fragment and apply the subtree, so the resolved object carries the same origins a typed resolution would, with the original file.s line numbers. No file is read or parsed twice. Best-effort: a missing tree or fragment leaves the object without origins, exactly as before. The common typed path is untouched.

### Why it matters
A consumer that uses origins for source locations (error anchors, editor links, source slicing) gets the wrong location for any element behind this ref shape: the origin chain falls back to the referencing document, pointing at the `$ref` site in the root file instead of the schema's own file and line. Whole-file refs (`./user.yaml`) and components-structured refs already carry correct origins; this closes the remaining shape.

The same applies to a same-document ref to an arbitrary top-level key (`$ref: .#/User.`): it drills through the identical Extensions path, so it is covered too, including documents loaded from memory.

Repro test + fixtures included (`TestOrigin_ExternalRefToArbitraryTopLevelKey`); full `openapi3` suite green.
