### PR TITLE
openapi3filter: skip schema checks for empty allowEmptyValue strings

### DIFF
--- a/openapi3filter/issue1134_test.go
+++ b/openapi3filter/issue1134_test.go
@@ -1,0 +1,107 @@
+package openapi3filter_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+// Empty string query params used to become nil in parsePrimitive, which skipped
+// schema checks. After #1096 they stay "", so format:date was applied even when
+// allowEmptyValue is true. See #1134.
+func TestIssue1134(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info:
+  title: issue 1134
+  version: 0.0.1
+paths:
+  /people:
+    get:
+      parameters:
+        - name: dateOfBirth
+          in: query
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+            format: date
+        - name: updatedAt
+          in: query
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+            format: date-time
+        - name: strictDate
+          in: query
+          required: false
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: ok
+`[1:]
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(loader.Context))
+
+	router, err := gorillamux.NewRouter(doc)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name       string
+		url        string
+		shouldFail bool
+	}{
+		{
+			name: "empty date with allowEmptyValue",
+			url:  "/people?dateOfBirth=",
+		},
+		{
+			name: "empty date-time with allowEmptyValue",
+			url:  "/people?updatedAt=",
+		},
+		{
+			name: "valid date still accepted",
+			url:  "/people?dateOfBirth=1970-01-01",
+		},
+		{
+			name:       "invalid non-empty date still rejected",
+			url:        "/people?dateOfBirth=not-a-date",
+			shouldFail: true,
+		},
+		{
+			name:       "empty date without allowEmptyValue still rejected",
+			url:        "/people?strictDate=",
+			shouldFail: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tc.url, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(req)
+			require.NoError(t, err)
+
+			err = openapi3filter.ValidateRequest(loader.Context, &openapi3filter.RequestValidationInput{
+				Request:    req,
+				PathParams: pathParams,
+				Route:      route,
+			})
+			if tc.shouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/openapi3filter/validate_request.go
+++ b/openapi3filter/validate_request.go
@@ -227,6 +227,11 @@ func ValidateParameter(ctx context.Context, input *RequestValidationInput, param
 		}
 		return nil
 	}
+	// #1096 keeps empty strings as ""; with allowEmptyValue skip schema checks
+	// (format, pattern, ...) like we used to when the value was nil.
+	if s, ok := value.(string); ok && s == "" && parameter.AllowEmptyValue {
+		return nil
+	}
 	if schema == nil {
 		// A parameter's schema is not defined so skip validation of a parameter's value.
 		return nil


### PR DESCRIPTION
Fixes #1134.

#1096 stopped turning empty string params into nil, so format validation still fires on values like `dateOfBirth=` even when allowEmptyValue is true. Skip schema checks in that case.

Regression in openapi3filter/issue1134_test.go.
