### PR TITLE
openapi3gen: inline embedded struct with options-only JSON tag

### DIFF
--- a/openapi3gen/field_info.go
+++ b/openapi3gen/field_info.go
@@ -46,6 +46,11 @@ iteration:
 				fields = appendFields(fields, index, f.Type)
 				continue iteration
 			}
+			jsonName, _, _ := strings.Cut(jsonTag, ",")
+			if jsonName == "" {
+				fields = appendFields(fields, index, f.Type)
+				continue iteration
+			}
 		}
 
 		// Ignore certain types

--- a/openapi3gen/openapi3gen_test.go
+++ b/openapi3gen/openapi3gen_test.go
@@ -318,6 +318,33 @@ func TestEmbeddedPointerStructs(t *testing.T) {
 	require.Equal(t, true, ok)
 }
 
+func TestEmbeddedStructsWithNamelessJSONTag(t *testing.T) {
+	type NestedStruct struct {
+		Field1 string `json:"field1"`
+		Field2 string `json:"field2"`
+	}
+
+	type PointerContainerStruct struct {
+		*NestedStruct `json:",omitempty"`
+	}
+
+	type ValueContainerStruct struct {
+		NestedStruct `json:",omitempty"`
+	}
+
+	generator := openapi3gen.NewGenerator(openapi3gen.UseAllExportedFields())
+	for _, typ := range []reflect.Type{
+		reflect.TypeFor[*PointerContainerStruct](),
+		reflect.TypeFor[*ValueContainerStruct](),
+	} {
+		schemaRef, err := generator.GenerateSchemaRef(typ)
+		require.NoError(t, err)
+		require.Contains(t, schemaRef.Value.Properties, "field1")
+		require.Contains(t, schemaRef.Value.Properties, "field2")
+		require.NotContains(t, schemaRef.Value.Properties, "NestedStruct")
+	}
+}
+
 // See: https://github.com/getkin/kin-openapi/issues/500
 func TestEmbeddedPointerStructsWithSchemaCustomizer(t *testing.T) {
 	type EmbeddedStruct struct {


### PR DESCRIPTION
## Summary

`openapi3gen` emits a nested object property instead of inlining an embedded struct when the embedded field's JSON tag carries options but no name, e.g. `*NestedStruct \`json:",omitempty"\``. This inlines such fields, matching `encoding/json`, so the embedded struct's fields are promoted into the parent schema.

## Background

`encoding/json` flattens an anonymous struct field unless its JSON tag gives it an explicit name; `json:",omitempty"` has options but no name, so it is still inlined. `openapi3gen`'s `appendFields` only inlined anonymous fields when the tag was completely empty (`jsonTag == ""`), so a nameless-but-optioned tag fell through and became a nested object keyed by the Go field name. EnriqueL8 (#924) and a second commenter both hit this with the common `?include=a,b,c` query-parameter pattern, where the wrapper struct is embedded with `json:",omitempty"`.

The fix reads the tag's name segment with `strings.Cut(jsonTag, ",")` and, when the name is empty (and the tag is not `-`), recurses via `appendFields` exactly as the empty-tag path does. Explicitly-named anonymous fields still become nested objects, and `json:"-"` is still skipped. Added regression tests for both pointer and value embedded structs with an options-only tag.

Closes #924
