### PR TITLE
openapi3filter: prefer non-empty value for repeated scalar query params

### DIFF
--- a/openapi3filter/issue1230_test.go
+++ b/openapi3filter/issue1230_test.go
@@ -1,0 +1,89 @@
+package openapi3filter_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/openapi3filter"
+	"github.com/getkin/kin-openapi/routers/gorillamux"
+)
+
+// Repeated scalar query params: an empty first value must not hide a later
+// invalid value from schema validation. See #1230.
+func TestIssue1230(t *testing.T) {
+	spec := `
+openapi: 3.0.3
+info:
+  title: issue 1230
+  version: 0.0.1
+paths:
+  /people:
+    get:
+      parameters:
+        - name: dateOfBirth
+          in: query
+          required: false
+          allowEmptyValue: true
+          schema:
+            type: string
+            format: date
+      responses:
+        '200':
+          description: ok
+`[1:]
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(loader.Context))
+
+	router, err := gorillamux.NewRouter(doc)
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name       string
+		url        string
+		shouldFail bool
+	}{
+		{
+			name: "single empty still allowed",
+			url:  "/people?dateOfBirth=",
+		},
+		{
+			name:       "empty first then invalid is rejected",
+			url:        "/people?dateOfBirth=&dateOfBirth=not-a-date",
+			shouldFail: true,
+		},
+		{
+			name:       "invalid first then empty is rejected",
+			url:        "/people?dateOfBirth=not-a-date&dateOfBirth=",
+			shouldFail: true,
+		},
+		{
+			name: "empty first then valid is accepted",
+			url:  "/people?dateOfBirth=&dateOfBirth=1970-01-01",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tc.url, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(req)
+			require.NoError(t, err)
+
+			err = openapi3filter.ValidateRequest(loader.Context, &openapi3filter.RequestValidationInput{
+				Request:    req,
+				PathParams: pathParams,
+				Route:      route,
+			})
+			if tc.shouldFail {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -514,10 +514,24 @@ func (d *urlValuesDecoder) DecodePrimitive(param string, sm *openapi3.Serializat
 		return nil, ok, nil
 	}
 
-	if schema.Value.Type == nil && schema.Value.Pattern != "" {
-		return values[0], ok, nil
+	// For scalar params, Go's url.Values may hold repeated keys. Prefer the first
+	// non-empty occurrence so an empty leading value cannot hide a later one
+	// from schema validation (see #1230). A single empty value is still returned
+	// so allowEmptyValue behavior is preserved.
+	raw := values[0]
+	if raw == "" && len(values) > 1 {
+		for _, v := range values[1:] {
+			if v != "" {
+				raw = v
+				break
+			}
+		}
 	}
-	val, err := parsePrimitive(values[0], schema)
+
+	if schema.Value.Type == nil && schema.Value.Pattern != "" {
+		return raw, ok, nil
+	}
+	val, err := parsePrimitive(raw, schema)
 	return val, ok, err
 }
 

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -514,10 +514,9 @@ func (d *urlValuesDecoder) DecodePrimitive(param string, sm *openapi3.Serializat
 		return nil, ok, nil
 	}
 
-	// For scalar params, Go's url.Values may hold repeated keys. Prefer the first
-	// non-empty occurrence so an empty leading value cannot hide a later one
-	// from schema validation (see #1230). A single empty value is still returned
-	// so allowEmptyValue behavior is preserved.
+	// Repeated query keys: prefer the first non-empty value so an empty
+	// leading occurrence cannot hide a later value from schema validation
+	// (#1230). A lone empty string is still returned unchanged.
 	raw := values[0]
 	if raw == "" && len(values) > 1 {
 		for _, v := range values[1:] {


### PR DESCRIPTION
## What

When a scalar query parameter is repeated and the first value is empty, decode the first non-empty occurrence instead of always taking `values[0]`.

## Why

With `allowEmptyValue: true`, an empty first value short-circuits schema validation. That made order-dependent results:

- `?dateOfBirth=&dateOfBirth=not-a-date` was accepted
- `?dateOfBirth=not-a-date&dateOfBirth=` was rejected

A single empty value still works as before (#1228 / #1134).

Fixes #1230.

## Test

- `TestIssue1230`
- existing `TestIssue1134`