### PR TITLE
openapi3: stop InternalizeRefs panicking on unresolved discriminator mappings

### DIFF
--- a/openapi3/internalize_refs.go
+++ b/openapi3/internalize_refs.go
@@ -351,6 +351,13 @@ func (doc *T) derefSchema(s *Schema, refNameResolver RefNameResolver, parentIsEx
 		for _, k := range componentNames(s.Discriminator.Mapping) {
 			mapRef := s.Discriminator.Mapping[k]
 			s2 := (*SchemaRef)(&mapRef)
+			// The mapping value may be a plain schema name rather than a
+			// reference, and a reference the loader could not follow was left
+			// as written. Neither has a resolved path, so neither can be named
+			// by the resolver: leave them exactly as they are.
+			if s2.RefPath() == nil {
+				continue
+			}
 			isExternal := doc.addSchemaToSpec(s2, refNameResolver, parentIsExternal)
 			doc.derefSchema(s2.Value, refNameResolver, isExternal || parentIsExternal)
 			s.Discriminator.Mapping[k] = MappingRef(*s2)

--- a/openapi3/internalize_refs_test.go
+++ b/openapi3/internalize_refs_test.go
@@ -27,6 +27,9 @@ func TestInternalizeRefs(t *testing.T) {
 		{"testdata/issue959/openapi.yml"},
 		{"testdata/interalizationNameCollision/api.yml"},
 		{"testdata/discriminator.yml"},
+		{"testdata/discriminatorLocalMapping.yml"},
+		{"testdata/issue1205/openapi.yml"},
+		{"testdata/issue1205/mutual.yml"},
 	}
 
 	for _, test := range tests {

--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -1116,19 +1116,25 @@ func (loader *Loader) resolveSchemaRef(doc *T, component *SchemaRef, documentPat
 	}
 	// Discriminator mapping refs are a special case since they are not full
 	// ref objects but are plain strings that reference schema objects.
-	// Only resolve refs that look like external references (contain a path).
-	// Plain schema names like "Dog" or internal refs like "#/components/schemas/Dog"
-	// don't need to be resolved by the loader.
+	// Plain schema names like "Dog" are not references and are left alone.
 	if value.Discriminator != nil {
+		inExternalDoc := documentPath != nil && documentPath.Path != "" && documentPath.Path != loader.rootLocation
 		for _, k := range componentNames(value.Discriminator.Mapping) {
 			v := value.Discriminator.Mapping[k]
-			// Only resolve if it looks like an external ref (contains path separator)
-			if strings.Contains(v.Ref, "/") && !strings.HasPrefix(v.Ref, "#") {
-				if err := loader.resolveSchemaRef(doc, (*SchemaRef)(&v), documentPath, visited); err != nil {
-					return err
-				}
-				value.Discriminator.Mapping[k] = v
+			if !strings.Contains(v.Ref, "/") {
+				continue
 			}
+			// A document-local mapping needs resolving only when it lives in
+			// another document, because InternalizeRefs then has to rewrite it
+			// against that document. One in the root document is already
+			// written against the document it will end up in.
+			if strings.HasPrefix(v.Ref, "#") && !inExternalDoc {
+				continue
+			}
+			if err := loader.resolveSchemaRef(doc, (*SchemaRef)(&v), documentPath, visited); err != nil {
+				return err
+			}
+			value.Discriminator.Mapping[k] = v
 		}
 	}
 

--- a/openapi3/testdata/discriminatorLocalMapping.yml
+++ b/openapi3/testdata/discriminatorLocalMapping.yml
@@ -1,0 +1,26 @@
+openapi: 3.1.0
+info:
+  title: local discriminator mappings
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Dog:
+      type: object
+      properties:
+        petType:
+          type: string
+    Cat:
+      type: object
+      properties:
+        petType:
+          type: string
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Cat'
+      discriminator:
+        propertyName: petType
+        mapping:
+          dog: Dog
+          cat: '#/components/schemas/Cat'

--- a/openapi3/testdata/discriminatorLocalMapping.yml.internalized.yml
+++ b/openapi3/testdata/discriminatorLocalMapping.yml.internalized.yml
@@ -1,0 +1,45 @@
+{
+    "components": {
+        "schemas": {
+            "Cat": {
+                "properties": {
+                    "petType": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "Dog": {
+                "properties": {
+                    "petType": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "Pet": {
+                "discriminator": {
+                    "mapping": {
+                        "cat": "#/components/schemas/Cat",
+                        "dog": "Dog"
+                    },
+                    "propertyName": "petType"
+                },
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/Dog"
+                    },
+                    {
+                        "$ref": "#/components/schemas/Cat"
+                    }
+                ]
+            }
+        }
+    },
+    "info": {
+        "title": "local discriminator mappings",
+        "version": "1.0.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {}
+}

--- a/openapi3/testdata/issue1205/ext.yml
+++ b/openapi3/testdata/issue1205/ext.yml
@@ -1,0 +1,24 @@
+openapi: 3.1.0
+info:
+  title: recursive discriminated union
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Comp:
+      oneOf:
+        - $ref: '#/components/schemas/Container'
+      discriminator:
+        propertyName: type
+        mapping:
+          container: '#/components/schemas/Container'
+    Container:
+      type: object
+      required: [type]
+      properties:
+        type:
+          type: string
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/Comp'

--- a/openapi3/testdata/issue1205/mutual-a.yml
+++ b/openapi3/testdata/issue1205/mutual-a.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: mutually recursive union a
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    AUnion:
+      oneOf:
+        - $ref: '#/components/schemas/ALeaf'
+      discriminator:
+        propertyName: kind
+        mapping:
+          aleaf: '#/components/schemas/ALeaf'
+          across: './mutual-b.yml#/components/schemas/BUnion'
+    ALeaf:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string
+        over:
+          $ref: './mutual-b.yml#/components/schemas/BUnion'
+        self:
+          $ref: '#/components/schemas/AUnion'

--- a/openapi3/testdata/issue1205/mutual-b.yml
+++ b/openapi3/testdata/issue1205/mutual-b.yml
@@ -1,0 +1,25 @@
+openapi: 3.1.0
+info:
+  title: mutually recursive union b
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    BUnion:
+      oneOf:
+        - $ref: '#/components/schemas/BLeaf'
+      discriminator:
+        propertyName: kind
+        mapping:
+          bleaf: '#/components/schemas/BLeaf'
+          across: './mutual-a.yml#/components/schemas/AUnion'
+    BLeaf:
+      type: object
+      required: [kind]
+      properties:
+        kind:
+          type: string
+        back:
+          $ref: './mutual-a.yml#/components/schemas/AUnion'
+        self:
+          $ref: '#/components/schemas/BUnion'

--- a/openapi3/testdata/issue1205/mutual.yml
+++ b/openapi3/testdata/issue1205/mutual.yml
@@ -1,0 +1,14 @@
+openapi: 3.1.0
+info:
+  title: mutually recursive unions across documents
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Root:
+      type: object
+      properties:
+        a:
+          $ref: './mutual-a.yml#/components/schemas/AUnion'
+        b:
+          $ref: './mutual-b.yml#/components/schemas/BUnion'

--- a/openapi3/testdata/issue1205/mutual.yml.internalized.yml
+++ b/openapi3/testdata/issue1205/mutual.yml.internalized.yml
@@ -1,0 +1,85 @@
+{
+    "components": {
+        "schemas": {
+            "Root": {
+                "properties": {
+                    "a": {
+                        "$ref": "#/components/schemas/mutual-a_AUnion"
+                    },
+                    "b": {
+                        "$ref": "#/components/schemas/mutual-b_BUnion"
+                    }
+                },
+                "type": "object"
+            },
+            "mutual-a_ALeaf": {
+                "properties": {
+                    "kind": {
+                        "type": "string"
+                    },
+                    "over": {
+                        "$ref": "#/components/schemas/mutual-b_BUnion"
+                    },
+                    "self": {
+                        "$ref": "#/components/schemas/mutual-a_AUnion"
+                    }
+                },
+                "required": [
+                    "kind"
+                ],
+                "type": "object"
+            },
+            "mutual-a_AUnion": {
+                "discriminator": {
+                    "mapping": {
+                        "across": "#/components/schemas/mutual-b_BUnion",
+                        "aleaf": "#/components/schemas/mutual-a_ALeaf"
+                    },
+                    "propertyName": "kind"
+                },
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/mutual-a_ALeaf"
+                    }
+                ]
+            },
+            "mutual-b_BLeaf": {
+                "properties": {
+                    "back": {
+                        "$ref": "#/components/schemas/mutual-a_AUnion"
+                    },
+                    "kind": {
+                        "type": "string"
+                    },
+                    "self": {
+                        "$ref": "#/components/schemas/mutual-b_BUnion"
+                    }
+                },
+                "required": [
+                    "kind"
+                ],
+                "type": "object"
+            },
+            "mutual-b_BUnion": {
+                "discriminator": {
+                    "mapping": {
+                        "across": "#/components/schemas/mutual-a_AUnion",
+                        "bleaf": "#/components/schemas/mutual-b_BLeaf"
+                    },
+                    "propertyName": "kind"
+                },
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/mutual-b_BLeaf"
+                    }
+                ]
+            }
+        }
+    },
+    "info": {
+        "title": "mutually recursive unions across documents",
+        "version": "1.0.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {}
+}

--- a/openapi3/testdata/issue1205/openapi.yml
+++ b/openapi3/testdata/issue1205/openapi.yml
@@ -1,0 +1,12 @@
+openapi: 3.1.0
+info:
+  title: external recursive discriminated union
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    Probe:
+      type: object
+      properties:
+        deep:
+          $ref: './ext.yml#/components/schemas/Comp'

--- a/openapi3/testdata/issue1205/openapi.yml.internalized.yml
+++ b/openapi3/testdata/issue1205/openapi.yml.internalized.yml
@@ -1,0 +1,50 @@
+{
+    "components": {
+        "schemas": {
+            "Probe": {
+                "properties": {
+                    "deep": {
+                        "$ref": "#/components/schemas/ext_Comp"
+                    }
+                },
+                "type": "object"
+            },
+            "ext_Comp": {
+                "discriminator": {
+                    "mapping": {
+                        "container": "#/components/schemas/ext_Container"
+                    },
+                    "propertyName": "type"
+                },
+                "oneOf": [
+                    {
+                        "$ref": "#/components/schemas/ext_Container"
+                    }
+                ]
+            },
+            "ext_Container": {
+                "properties": {
+                    "children": {
+                        "items": {
+                            "$ref": "#/components/schemas/ext_Comp"
+                        },
+                        "type": "array"
+                    },
+                    "type": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "type"
+                ],
+                "type": "object"
+            }
+        }
+    },
+    "info": {
+        "title": "external recursive discriminated union",
+        "version": "1.0.0"
+    },
+    "openapi": "3.1.0",
+    "paths": {}
+}


### PR DESCRIPTION
Fixes #1205.

## What happens today

`InternalizeRefs` panics with `unable to resolve reference to name`, from the discriminator branch of `derefSchema`:

```
panic: unable to resolve reference to name
  openapi3.DefaultRefNameResolver   internalize_refs.go:32
  openapi3.(*T).addSchemaToSpec     internalize_refs.go:137
  openapi3.(*T).derefSchema         internalize_refs.go:354
```

Two inputs reach it:

1. **A plain-name mapping, in a document with no external refs at all.** The spec says a discriminator mapping value may be a schema name or a `$ref`, so `mapping: {dog: Dog}` is valid — and it panics. This one isn't in #1205; I hit it while tracking the reported case down, and it needs no external document, so it's the smaller reproduction of the two.
2. **A document-local `#/components/schemas/...` mapping inside an externally referenced schema** — what #1205 reports.

One note on #1205 itself: it describes a *stack overflow* on v0.140.0. On current master that input produces the panic above instead, so this fixes the reported case but not the symptom the title names.

## Root cause

`loader.go` resolves a discriminator mapping value only when it looks like an external file ref (`strings.Contains(v.Ref, "/") && !strings.HasPrefix(v.Ref, "#")`), so plain names and document-local pointers get no `Value` and no `refPath`. `internalize_refs.go` hands them to `addSchemaToSpec` anyway — `isExternalRef` is always true for a plain name, and true for `#/components/...` whenever `parentIsExternal` — and `DefaultRefNameResolver` panics when `RefPath() == nil`.

So the two sides disagree about which refs are resolved. The invariant this restores: **`InternalizeRefs` may only hand the `RefNameResolver` a reference the loader actually resolved.**

## The change

- `loader.go` resolves a document-local mapping **when it lives in a document other than the root**, so `InternalizeRefs` can rewrite it against the document it came from. Errors propagate as they do for every other ref in that document. A mapping in the root document is untouched — it is already written against the document it will end up in.
- `internalize_refs.go` skips a mapping with no resolved path instead of handing it to the resolver.

Two things I tried first and backed out of, in case they come up in review:

- Resolving document-local mappings *everywhere* turned `mapping: {dog: '#/components/schemas/DoesNotExist'}` from a spec that loads into `map key "DoesNotExist" not found`. Too much collateral for this fix.
- Resolving everywhere but swallowing the error is worse. `resolveSchemaRef` marks a ref visited before it can fail, so a swallowed failure makes a later legitimate `$ref` to the same target get skipped and come back with `Value == nil` — a clean load error turned into a silently broken document. It only shows up when the mapping is visited before the `$ref`, so component ordering hides it.

Scoping to non-root documents avoids both: nothing about root-document loading changes.

## Coverage

Three rows added to `TestInternalizeRefs`, following the existing table + golden convention:

- `testdata/discriminatorLocalMapping.yml` — no external refs; maps by plain name *and* by document-local pointer. Both must survive unchanged.
- `testdata/issue1205/openapi.yml` (+ `ext.yml`) — a recursive `oneOf` + discriminator union reached across files. The mapping must be rewritten to the internalized component:

  ```json
  "ext_Comp": {
    "discriminator": {"mapping": {"container": "#/components/schemas/ext_Container"}},
    "oneOf": [{"$ref": "#/components/schemas/ext_Container"}]
  }
  ```

- `testdata/issue1205/mutual.yml` (+ `mutual-a.yml`, `mutual-b.yml`) — mutually recursive discriminated unions across two documents, since the issue is about recursion terminating. All four mappings internalize.

The first two panic on master. No existing golden changed.

## Validation

Linux, Go 1.25.12, the commands from `.github/workflows/go.yml`: `gofmt -l` clean, `go vet ./...`, `go test ./...`, `go test -count=10 -short ./...`, `go test -count=2 -short -covermode=atomic ./...`, and the three `-race` tests — all pass. The unmodified base passes the same commands, so nothing here is introduced.

Two things worth a closer look than the rest:

- `documentPath.Path != loader.rootLocation` is a string comparison. I checked absolute, relative, `./`, `../` traversal and `LoadFromData` (no path), and all five classify the root document as root, but this is the line to be suspicious of.
- For document-local mappings in external documents the loader now writes the resolved `MappingRef` back into the map, which it did not before. `MappingRef.MarshalText` serialises only `.Ref` and every golden is unchanged, but it is a new behavioural surface.
