### PR TITLE
openapi3: support OAS 3.2 query and additionalOperations

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -18,6 +18,8 @@ OpenAPI 3.1 Features:
 
 OpenAPI 3.2 Features:
   - Media Type Object itemSchema for streaming sequential media types
+  - Path Item Object query field for the HTTP QUERY method
+  - Path Item Object additionalOperations for custom HTTP methods
 
 The implementation maintains 100% backward compatibility with OpenAPI 3.0.
 
@@ -79,6 +81,10 @@ const (
 	SerializationPipeDelimited  = "pipeDelimited"
 	SerializationDeepObject     = "deepObject"
 )
+const MethodQuery = "QUERY"
+    MethodQuery is the HTTP QUERY method, introduced as a fixed Path Item Object
+    field by OpenAPI 3.2. The net/http package has no constant for it.
+
 
 VARIABLES
 
@@ -293,6 +299,41 @@ type APIKeySecuritySchemeNameRequired struct{ ValidationError }
 func (e *APIKeySecuritySchemeNameRequired) As(target any) bool
 
 func (e *APIKeySecuritySchemeNameRequired) Code() string
+
+type AdditionalOperationsDuplicateMethodError struct {
+	// Method is the offending additionalOperations key.
+	Method string
+	// Origin is the source location of the offending path item when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    AdditionalOperationsDuplicateMethodError clusters "additionalOperations key
+    duplicates a fixed field" failures. OpenAPI 3.2's `additionalOperations` map
+    may only carry methods that have no dedicated Path Item Object field.
+
+func (e *AdditionalOperationsDuplicateMethodError) Code() string
+
+func (e *AdditionalOperationsDuplicateMethodError) Error() string
+
+type AdditionalOperationsFieldFor32Plus struct{ ValidationError }
+
+func (e *AdditionalOperationsFieldFor32Plus) As(target any) bool
+
+func (e *AdditionalOperationsFieldFor32Plus) Code() string
+
+type AdditionalOperationsInvalidMethodError struct {
+	// Method is the offending additionalOperations key.
+	Method string
+	// Origin is the source location of the offending path item when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+    AdditionalOperationsInvalidMethodError clusters "additionalOperations key is
+    not an HTTP method" failures. Keys must be RFC 9110 tokens.
+
+func (e *AdditionalOperationsInvalidMethodError) Code() string
+
+func (e *AdditionalOperationsInvalidMethodError) Error() string
 
 type AdditionalProperties = BoolSchema
     AdditionalProperties is a type alias for BoolSchema, kept for backward
@@ -2109,8 +2150,14 @@ type PathItem struct {
 	Post        *Operation `json:"post,omitempty" yaml:"post,omitempty"`
 	Put         *Operation `json:"put,omitempty" yaml:"put,omitempty"`
 	Trace       *Operation `json:"trace,omitempty" yaml:"trace,omitempty"`
+	Query       *Operation `json:"query,omitempty" yaml:"query,omitempty"` // OpenAPI >=3.2
 	Servers     Servers    `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Parameters  Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+
+	// AdditionalOperations maps custom HTTP method names to operations.
+	// Keys are case-sensitive HTTP method tokens and must not duplicate
+	// the methods covered by the fixed fields above.
+	AdditionalOperations map[string]*Operation `json:"additionalOperations,omitempty" yaml:"additionalOperations,omitempty"` // OpenAPI >=3.2
 }
     PathItem is specified by OpenAPI/Swagger standard version 3. See
     https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#path-item-object
@@ -2124,6 +2171,10 @@ func (pathItem PathItem) MarshalYAML() (any, error)
     MarshalYAML returns the YAML encoding of PathItem.
 
 func (pathItem *PathItem) Operations() map[string]*Operation
+    Operations returns pathItem's operations keyed by HTTP method,
+    including the OpenAPI 3.2 QUERY field and any AdditionalOperations. When an
+    AdditionalOperations key collides with a fixed field, the fixed field wins
+    (Validate reports the duplicate separately).
 
 func (pathItem *PathItem) SetOperation(method string, operation *Operation)
 
@@ -2293,6 +2344,12 @@ type PropertyNamesFieldFor31Plus struct{ ValidationError }
 func (e *PropertyNamesFieldFor31Plus) As(target any) bool
 
 func (e *PropertyNamesFieldFor31Plus) Code() string
+
+type QueryFieldFor32Plus struct{ ValidationError }
+
+func (e *QueryFieldFor32Plus) As(target any) bool
+
+func (e *QueryFieldFor32Plus) Code() string
 
 type ReadFromURIFunc func(loader *Loader, url *url.URL) ([]byte, error)
     ReadFromURIFunc defines a function which reads the contents of a resource

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 A [Go](https://go.dev) project for handling [OpenAPI](https://www.openapis.org/) files. We target:
 * [OpenAPI `v2.0`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/2.0.md) (formerly known as Swagger)
 * [OpenAPI `v3.0`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md)
-* [OpenAPI `v3.1`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md) Soon! [Tracking issue here.](https://github.com/getkin/kin-openapi/issues/230)
+* [OpenAPI `v3.1`](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.1.0.md)
+* [OpenAPI `v3.2`](https://spec.openapis.org/oas/v3.2.0.html) Partially: Media Type Object `itemSchema`, Path Item Object `query` (the HTTP `QUERY` method) and `additionalOperations` (custom HTTP methods).
 
 Licensed under the [MIT License](./LICENSE).
 
@@ -325,6 +326,11 @@ for _, path := range doc.Paths.InMatchingOrder() {
 ```
 
 ## CHANGELOG: Sub-v1 breaking API changes
+
+### v0.147.0
+* `(*openapi3.PathItem).SetOperation(string, *Operation)` no longer panics on unhandled HTTP methods: these are now stored in the new `openapi3.PathItem.AdditionalOperations` field (passing a nil operation deletes the entry).
+* `(*openapi3.PathItem).GetOperation(string)` and `(*openapi3.PathItem).Operations()` now also report the new `openapi3.PathItem.Query` field (the OpenAPI 3.2 HTTP `QUERY` method) and the `openapi3.PathItem.AdditionalOperations` entries. Routers and validators consequently match these methods.
+* `openapi2conv.FromV3(..)` and `openapi2conv.FromV3PathItem(..)` now return an error for operations whose HTTP method Swagger 2.0 cannot express (`QUERY`, `TRACE`, `CONNECT` and custom methods) instead of panic-ing.
 
 ### v0.145.0
 * `(*openapi3.PathItem).GetOperation(string)` now returns `nil` on unhandled HTTP methods instead of panic-ing.

--- a/openapi2conv/custom_methods_test.go
+++ b/openapi2conv/custom_methods_test.go
@@ -1,0 +1,69 @@
+package openapi2conv
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// TestFromV3CustomMethods checks that converting an OpenAPI 3.2 document using
+// methods Swagger 2.0 cannot express returns an error instead of panic-ing in
+// openapi2's SetOperation.
+func TestFromV3CustomMethods(t *testing.T) {
+	const specFmt = `
+openapi: 3.2.0
+info:
+  title: MyAPI
+  version: "0.1"
+paths:
+  /pets:
+    %s
+components: {}
+`
+
+	for _, tc := range []struct {
+		name    string
+		snippet string
+		method  string
+	}{
+		{
+			name: "query field",
+			snippet: `query:
+      responses:
+        "200":
+          description: OK`,
+			method: openapi3.MethodQuery,
+		},
+		{
+			name: "additionalOperations",
+			snippet: `additionalOperations:
+      COPY:
+        responses:
+          "200":
+            description: OK`,
+			method: "COPY",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			loader := openapi3.NewLoader()
+			doc3, err := loader.LoadFromData([]byte(fmt.Sprintf(specFmt, tc.snippet)))
+			require.NoError(t, err)
+			require.NoError(t, doc3.Validate(loader.Context))
+
+			require.NotPanics(t, func() {
+				_, err = FromV3(doc3)
+			})
+			require.ErrorContains(t, err, tc.method)
+			require.ErrorContains(t, err, "OpenAPI 2.0")
+
+			pathItem := doc3.Paths.Value("/pets")
+			require.NotPanics(t, func() {
+				_, err = FromV3PathItem(doc3, pathItem)
+			})
+			require.ErrorContains(t, err, tc.method)
+		})
+	}
+}

--- a/openapi2conv/openapi2_conv.go
+++ b/openapi2conv/openapi2_conv.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
@@ -715,6 +716,9 @@ func FromV3(doc3 *openapi3.T) (*openapi2.T, error) {
 			if operation == nil {
 				continue
 			}
+			if err := checkV2Method(method); err != nil {
+				return nil, fmt.Errorf("path %q: %w", path, err)
+			}
 			doc2Operation, err := FromV3Operation(doc3, operation)
 			if err != nil {
 				return nil, err
@@ -978,11 +982,37 @@ func FromV3SecurityRequirements(requirements openapi3.SecurityRequirements) open
 	return result
 }
 
+// openapi2Methods are the HTTP methods Swagger 2.0's Path Item Object is able
+// to express. Anything else - the OpenAPI 3.2 QUERY field, CONNECT, TRACE, or a
+// custom method held in additionalOperations - has no v2 counterpart.
+var openapi2Methods = map[string]struct{}{
+	http.MethodDelete:  {},
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodOptions: {},
+	http.MethodPatch:   {},
+	http.MethodPost:    {},
+	http.MethodPut:     {},
+}
+
+// checkV2Method reports whether an operation registered under method can be
+// carried over to a Swagger 2.0 document. Calling openapi2's SetOperation with
+// an unsupported method panics, so callers must guard with this first.
+func checkV2Method(method string) error {
+	if _, ok := openapi2Methods[method]; !ok {
+		return fmt.Errorf("unsupported HTTP method %q: it cannot be expressed in OpenAPI 2.0 (Swagger)", method)
+	}
+	return nil
+}
+
 func FromV3PathItem(doc3 *openapi3.T, pathItem *openapi3.PathItem) (*openapi2.PathItem, error) {
 	result := &openapi2.PathItem{
 		Extensions: stripNonExtensions(pathItem.Extensions),
 	}
 	for method, operation := range pathItem.Operations() {
+		if err := checkV2Method(method); err != nil {
+			return nil, err
+		}
 		r, err := FromV3Operation(doc3, operation)
 		if err != nil {
 			return nil, err

--- a/openapi3/doc.go
+++ b/openapi3/doc.go
@@ -14,6 +14,8 @@
 //
 // OpenAPI 3.2 Features:
 //   - Media Type Object itemSchema for streaming sequential media types
+//   - Path Item Object query field for the HTTP QUERY method
+//   - Path Item Object additionalOperations for custom HTTP methods
 //
 // The implementation maintains 100% backward compatibility with OpenAPI 3.0.
 //

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -3,9 +3,10 @@ package openapi3
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"maps"
 	"net/http"
+	"regexp"
+	"strings"
 )
 
 // PathItem is specified by OpenAPI/Swagger standard version 3.
@@ -26,9 +27,38 @@ type PathItem struct {
 	Post        *Operation `json:"post,omitempty" yaml:"post,omitempty"`
 	Put         *Operation `json:"put,omitempty" yaml:"put,omitempty"`
 	Trace       *Operation `json:"trace,omitempty" yaml:"trace,omitempty"`
+	Query       *Operation `json:"query,omitempty" yaml:"query,omitempty"` // OpenAPI >=3.2
 	Servers     Servers    `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Parameters  Parameters `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+
+	// AdditionalOperations maps custom HTTP method names to operations.
+	// Keys are case-sensitive HTTP method tokens and must not duplicate
+	// the methods covered by the fixed fields above.
+	AdditionalOperations map[string]*Operation `json:"additionalOperations,omitempty" yaml:"additionalOperations,omitempty"` // OpenAPI >=3.2
 }
+
+// MethodQuery is the HTTP QUERY method, introduced as a fixed Path Item
+// Object field by OpenAPI 3.2. The net/http package has no constant for it.
+const MethodQuery = "QUERY"
+
+// fixedPathItemMethods are the HTTP methods that have a dedicated PathItem
+// field; they must not appear as AdditionalOperations keys.
+var fixedPathItemMethods = map[string]struct{}{
+	http.MethodConnect: {},
+	http.MethodDelete:  {},
+	http.MethodGet:     {},
+	http.MethodHead:    {},
+	http.MethodOptions: {},
+	http.MethodPatch:   {},
+	http.MethodPost:    {},
+	http.MethodPut:     {},
+	http.MethodTrace:   {},
+	MethodQuery:        {},
+}
+
+// httpTokenRe matches an RFC 9110 token, the grammar HTTP method names
+// must follow.
+var httpTokenRe = regexp.MustCompile("^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$")
 
 // MarshalJSON returns the JSON encoding of PathItem.
 func (pathItem PathItem) MarshalJSON() ([]byte, error) {
@@ -45,7 +75,7 @@ func (pathItem PathItem) MarshalYAML() (any, error) {
 		return Ref{Ref: ref}, nil
 	}
 
-	m := make(map[string]any, 13+len(pathItem.Extensions))
+	m := make(map[string]any, 15+len(pathItem.Extensions))
 	maps.Copy(m, pathItem.Extensions)
 	if x := pathItem.Summary; x != "" {
 		m["summary"] = x
@@ -80,6 +110,12 @@ func (pathItem PathItem) MarshalYAML() (any, error) {
 	if x := pathItem.Trace; x != nil {
 		m["trace"] = x
 	}
+	if x := pathItem.Query; x != nil {
+		m["query"] = x
+	}
+	if x := pathItem.AdditionalOperations; len(x) != 0 {
+		m["additionalOperations"] = x
+	}
 	if x := pathItem.Servers; len(x) != 0 {
 		m["servers"] = x
 	}
@@ -109,6 +145,8 @@ func (pathItem *PathItem) UnmarshalJSON(data []byte) error {
 	delete(x.Extensions, "post")
 	delete(x.Extensions, "put")
 	delete(x.Extensions, "trace")
+	delete(x.Extensions, "query")
+	delete(x.Extensions, "additionalOperations")
 	delete(x.Extensions, "servers")
 	delete(x.Extensions, "parameters")
 	if len(x.Extensions) == 0 {
@@ -118,8 +156,50 @@ func (pathItem *PathItem) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (pathItem *PathItem) Operations() map[string]*Operation {
-	operations := make(map[string]*Operation)
+// operationEntry pairs an operation with the method it is registered under
+// and the JSON pointer suffix that addresses it inside a PathItem.
+type operationEntry struct {
+	method    string
+	operation *Operation
+	// pointerSuffix is "/get" for a fixed field and
+	// "/additionalOperations/COPY" for a custom method.
+	pointerSuffix string
+}
+
+// operationEntries returns pathItem's operations in a deterministic order
+// (fixed fields first, then AdditionalOperations, each sorted by method),
+// paired with the JSON pointer suffix addressing them. Custom methods
+// shadowed by a fixed field are skipped, matching Operations().
+func (pathItem *PathItem) operationEntries() []operationEntry {
+	fixed := pathItem.fixedOperations()
+	entries := make([]operationEntry, 0, len(fixed)+len(pathItem.AdditionalOperations))
+	for _, method := range componentNames(fixed) {
+		entries = append(entries, operationEntry{
+			method:        method,
+			operation:     fixed[method],
+			pointerSuffix: "/" + strings.ToLower(method),
+		})
+	}
+	for _, method := range componentNames(pathItem.AdditionalOperations) {
+		operation := pathItem.AdditionalOperations[method]
+		if operation == nil {
+			continue
+		}
+		if _, ok := fixed[method]; ok {
+			continue
+		}
+		entries = append(entries, operationEntry{
+			method:        method,
+			operation:     operation,
+			pointerSuffix: "/additionalOperations/" + escapeRefString(method),
+		})
+	}
+	return entries
+}
+
+// fixedOperations returns the operations held by PathItem's fixed fields.
+func (pathItem *PathItem) fixedOperations() map[string]*Operation {
+	operations := make(map[string]*Operation, len(fixedPathItemMethods))
 	if v := pathItem.Connect; v != nil {
 		operations[http.MethodConnect] = v
 	}
@@ -147,6 +227,27 @@ func (pathItem *PathItem) Operations() map[string]*Operation {
 	if v := pathItem.Trace; v != nil {
 		operations[http.MethodTrace] = v
 	}
+	if v := pathItem.Query; v != nil {
+		operations[MethodQuery] = v
+	}
+	return operations
+}
+
+// Operations returns pathItem's operations keyed by HTTP method, including
+// the OpenAPI 3.2 QUERY field and any AdditionalOperations. When an
+// AdditionalOperations key collides with a fixed field, the fixed field
+// wins (Validate reports the duplicate separately).
+func (pathItem *PathItem) Operations() map[string]*Operation {
+	operations := pathItem.fixedOperations()
+	for method, operation := range pathItem.AdditionalOperations {
+		if operation == nil {
+			continue
+		}
+		if _, ok := operations[method]; ok {
+			continue
+		}
+		operations[method] = operation
+	}
 	return operations
 }
 
@@ -170,8 +271,10 @@ func (pathItem *PathItem) GetOperation(method string) *Operation {
 		return pathItem.Put
 	case http.MethodTrace:
 		return pathItem.Trace
+	case MethodQuery:
+		return pathItem.Query
 	default:
-		return nil
+		return pathItem.AdditionalOperations[method]
 	}
 }
 
@@ -195,8 +298,18 @@ func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
 		pathItem.Put = operation
 	case http.MethodTrace:
 		pathItem.Trace = operation
+	case MethodQuery:
+		pathItem.Query = operation
 	default:
-		panic(fmt.Errorf("unsupported HTTP method %q", method))
+		// Custom (OpenAPI >=3.2) methods live in AdditionalOperations.
+		if operation == nil {
+			delete(pathItem.AdditionalOperations, method)
+			return
+		}
+		if pathItem.AdditionalOperations == nil {
+			pathItem.AdditionalOperations = make(map[string]*Operation, 1)
+		}
+		pathItem.AdditionalOperations[method] = operation
 	}
 }
 
@@ -204,6 +317,33 @@ func (pathItem *PathItem) SetOperation(method string, operation *Operation) {
 func (pathItem *PathItem) Validate(ctx context.Context, opts ...ValidationOption) error {
 	ctx = WithValidationOptions(ctx, opts...)
 	me := newErrCollector(ctx)
+
+	if !getValidationOptions(ctx).isOpenAPI32OrLater {
+		if pathItem.Query != nil {
+			if err := me.emit(errFieldFor32Plus("query", pathItem.Origin)); err != nil {
+				return err
+			}
+		}
+		if len(pathItem.AdditionalOperations) != 0 {
+			if err := me.emit(errFieldFor32Plus("additionalOperations", pathItem.Origin)); err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, method := range componentNames(pathItem.AdditionalOperations) {
+		if _, ok := fixedPathItemMethods[method]; ok {
+			if err := me.emit(newAdditionalOperationsDuplicateMethod(method, pathItem.Origin)); err != nil {
+				return err
+			}
+			continue
+		}
+		if !httpTokenRe.MatchString(method) {
+			if err := me.emit(newAdditionalOperationsInvalidMethod(method, pathItem.Origin)); err != nil {
+				return err
+			}
+		}
+	}
 
 	operations := pathItem.Operations()
 
@@ -239,6 +379,8 @@ func (pathItem *PathItem) isEmpty() bool {
 		pathItem.Post == nil &&
 		pathItem.Put == nil &&
 		pathItem.Trace == nil &&
+		pathItem.Query == nil &&
+		len(pathItem.AdditionalOperations) == 0 &&
 		len(pathItem.Servers) == 0 &&
 		len(pathItem.Parameters) == 0
 }

--- a/openapi3/path_item_custom_methods_test.go
+++ b/openapi3/path_item_custom_methods_test.go
@@ -1,0 +1,328 @@
+package openapi3
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// customMethodsSpec exercises both OpenAPI 3.2 path item additions: the fixed
+// `query` field and an `additionalOperations` entry, each with a $ref so ref
+// resolution through the new operations is covered too.
+const customMethodsSpec = `
+openapi: 3.2.0
+info:
+  title: Custom methods
+  version: 1.0.0
+paths:
+  /things:
+    query:
+      parameters:
+        - $ref: "#/components/parameters/Trace"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                filter:
+                  type: string
+      responses:
+        "200":
+          description: results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Query"
+    additionalOperations:
+      COPY:
+        parameters:
+          - name: destination
+            in: header
+            required: true
+            schema:
+              type: string
+        responses:
+          "204":
+            description: copied
+components:
+  parameters:
+    Trace:
+      name: trace
+      in: query
+      schema:
+        type: boolean
+  schemas:
+    Query:
+      type: object
+      properties:
+        filter:
+          type: string
+`
+
+func TestOpenAPI32PathItemCustomMethods(t *testing.T) {
+	loader := NewLoader()
+	doc, err := loader.LoadFromData([]byte(customMethodsSpec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(t.Context()))
+
+	pathItem := doc.Paths.Value("/things")
+	require.NotNil(t, pathItem)
+	require.NotNil(t, pathItem.Query)
+	require.Len(t, pathItem.AdditionalOperations, 1)
+	require.NotNil(t, pathItem.AdditionalOperations["COPY"])
+
+	// $ref inside the query operation got resolved.
+	schemaRef := pathItem.Query.Responses.Status(200).Value.Content.Get("application/json").Schema
+	require.Equal(t, "#/components/schemas/Query", schemaRef.Ref)
+	require.NotNil(t, schemaRef.Value)
+	require.True(t, schemaRef.Value.Type.Is(TypeObject))
+	require.NotNil(t, pathItem.Query.Parameters[0].Value)
+	require.Equal(t, "trace", pathItem.Query.Parameters[0].Value.Name)
+
+	ops := pathItem.Operations()
+	require.Contains(t, ops, "QUERY")
+	require.Contains(t, ops, "COPY")
+	require.Same(t, pathItem.Query, ops["QUERY"])
+	require.Same(t, pathItem.AdditionalOperations["COPY"], ops["COPY"])
+
+	require.Same(t, pathItem.Query, pathItem.GetOperation("QUERY"))
+	require.Same(t, pathItem.AdditionalOperations["COPY"], pathItem.GetOperation("COPY"))
+	require.Nil(t, pathItem.GetOperation("PURGE"))
+}
+
+func TestPathItemSetOperationCustomMethod(t *testing.T) {
+	pathItem := &PathItem{}
+	op := &Operation{Responses: NewResponses()}
+
+	// Used to panic with "unsupported HTTP method".
+	require.NotPanics(t, func() { pathItem.SetOperation("COPY", op) })
+	require.Same(t, op, pathItem.AdditionalOperations["COPY"])
+	require.Same(t, op, pathItem.GetOperation("COPY"))
+
+	query := &Operation{Responses: NewResponses()}
+	pathItem.SetOperation("QUERY", query)
+	require.Same(t, query, pathItem.Query)
+
+	// A nil operation removes the custom method instead of storing nil.
+	pathItem.SetOperation("COPY", nil)
+	require.NotContains(t, pathItem.AdditionalOperations, "COPY")
+	require.Nil(t, pathItem.GetOperation("COPY"))
+
+	// Fixed fields keep their nil-assignment semantics.
+	pathItem.SetOperation("QUERY", nil)
+	require.Nil(t, pathItem.Query)
+}
+
+func TestPathItemCustomMethodsRoundTrip(t *testing.T) {
+	loader := NewLoader()
+	doc, err := loader.LoadFromData([]byte(customMethodsSpec))
+	require.NoError(t, err)
+
+	pathItem := doc.Paths.Value("/things")
+	require.Empty(t, pathItem.Extensions)
+
+	data, err := json.Marshal(pathItem)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(data, &raw))
+	require.Contains(t, raw, "query")
+	require.Contains(t, raw, "additionalOperations")
+	additional, ok := raw["additionalOperations"].(map[string]any)
+	require.True(t, ok)
+	require.Contains(t, additional, "COPY")
+
+	var back PathItem
+	require.NoError(t, json.Unmarshal(data, &back))
+	require.Empty(t, back.Extensions)
+	require.NotNil(t, back.Query)
+	require.NotNil(t, back.AdditionalOperations["COPY"])
+}
+
+func TestPathItemCustomMethodsValidationErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec string
+		code string
+	}{
+		{
+			name: "query needs OpenAPI 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    query:
+      responses:
+        "200": {description: ok}
+`,
+			code: "query-field-for-3-2-plus",
+		},
+		{
+			name: "additionalOperations needs OpenAPI 3.2",
+			spec: `
+openapi: 3.1.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    additionalOperations:
+      COPY:
+        responses:
+          "204": {description: copied}
+`,
+			code: "additional-operations-field-for-3-2-plus",
+		},
+		{
+			name: "additionalOperations duplicates a fixed field",
+			spec: `
+openapi: 3.2.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    additionalOperations:
+      GET:
+        responses:
+          "200": {description: ok}
+`,
+			code: "additional-operations-duplicate-method",
+		},
+		{
+			name: "additionalOperations duplicates the query field",
+			spec: `
+openapi: 3.2.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    additionalOperations:
+      QUERY:
+        responses:
+          "200": {description: ok}
+`,
+			code: "additional-operations-duplicate-method",
+		},
+		{
+			name: "additionalOperations key is not an HTTP token",
+			spec: `
+openapi: 3.2.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    additionalOperations:
+      "BAD METHOD":
+        responses:
+          "200": {description: ok}
+`,
+			code: "additional-operations-invalid-method",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			loader := NewLoader()
+			doc, err := loader.LoadFromData([]byte(tc.spec))
+			require.NoError(t, err)
+
+			err = doc.Validate(t.Context())
+			require.Error(t, err)
+			var coded CodedError
+			require.ErrorAs(t, err, &coded)
+			require.Equal(t, tc.code, coded.Code())
+		})
+	}
+}
+
+func TestPathItemCustomMethodsVersionSentinels(t *testing.T) {
+	loader := NewLoader()
+	doc, err := loader.LoadFromData([]byte(`
+openapi: 3.1.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    query:
+      responses:
+        "200": {description: ok}
+    additionalOperations:
+      COPY:
+        responses:
+          "204": {description: copied}
+`))
+	require.NoError(t, err)
+
+	err = doc.Validate(t.Context(), EnableMultiError())
+	require.Error(t, err)
+
+	var multi MultiError
+	require.ErrorAs(t, err, &multi)
+
+	var query *QueryFieldFor32Plus
+	var additional *AdditionalOperationsFieldFor32Plus
+	var mismatches int
+	for _, e := range multi {
+		var fvm *FieldVersionMismatchError
+		if errors.As(e, &fvm) {
+			mismatches++
+		}
+		if q := new(QueryFieldFor32Plus); errors.As(e, &q) {
+			query = q
+		}
+		if a := new(AdditionalOperationsFieldFor32Plus); errors.As(e, &a) {
+			additional = a
+		}
+	}
+	require.Equal(t, 2, mismatches)
+	require.NotNil(t, query)
+	require.NotNil(t, additional)
+	require.Equal(t, "field query is for OpenAPI >=3.2", query.Error())
+	require.Equal(t, "field additionalOperations is for OpenAPI >=3.2", additional.Error())
+}
+
+// A lowercase key is a valid RFC 9110 token, so it must not be rejected even
+// though the convention is uppercase.
+func TestPathItemCustomMethodsLowercaseKeyIsValid(t *testing.T) {
+	loader := NewLoader()
+	doc, err := loader.LoadFromData([]byte(`
+openapi: 3.2.0
+info: {title: t, version: "1"}
+paths:
+  /things:
+    additionalOperations:
+      copy:
+        responses:
+          "204": {description: copied}
+`))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(t.Context()))
+}
+
+func TestPathItemIsEmptyWithCustomMethods(t *testing.T) {
+	require.True(t, (&PathItem{}).isEmpty())
+	require.False(t, (&PathItem{Query: &Operation{}}).isEmpty())
+	require.False(t, (&PathItem{AdditionalOperations: map[string]*Operation{
+		"COPY": {},
+	}}).isEmpty())
+}
+
+func TestWalkersVisitCustomMethodOperations(t *testing.T) {
+	loader := NewLoader()
+	doc, err := loader.LoadFromData([]byte(customMethodsSpec))
+	require.NoError(t, err)
+
+	var schemaPointers []string
+	require.NoError(t, doc.WalkSchemas(func(jsonPointer string, _ *SchemaRef) error {
+		schemaPointers = append(schemaPointers, jsonPointer)
+		return nil
+	}))
+	require.Contains(t, schemaPointers,
+		"/paths/~1things/query/requestBody/content/application~1json/schema")
+	require.Contains(t, schemaPointers,
+		"/paths/~1things/additionalOperations/COPY/parameters/0/schema")
+
+	var paramPointers []string
+	require.NoError(t, doc.WalkParameters(func(jsonPointer string, _ *ParameterRef) error {
+		paramPointers = append(paramPointers, jsonPointer)
+		return nil
+	}))
+	require.Contains(t, paramPointers,
+		"/paths/~1things/additionalOperations/COPY/parameters/0")
+}

--- a/openapi3/validation_code.go
+++ b/openapi3/validation_code.go
@@ -28,6 +28,15 @@ type CodedError interface {
 	Code() string
 }
 
+func (e *AdditionalOperationsDuplicateMethodError) Code() string {
+	return "additional-operations-duplicate-method"
+}
+func (e *AdditionalOperationsFieldFor32Plus) Code() string {
+	return "additional-operations-field-for-3-2-plus"
+}
+func (e *AdditionalOperationsInvalidMethodError) Code() string {
+	return "additional-operations-invalid-method"
+}
 func (e *AnchorFieldFor31Plus) Code() string             { return "anchor-field-for-3-1-plus" }
 func (e *APIKeyInInvalidError) Code() string             { return "security-scheme-apikey-in-invalid" }
 func (e *APIKeySecuritySchemeNameRequired) Code() string { return "security-scheme-name-required" }
@@ -119,6 +128,7 @@ func (e *PatternPropertiesFieldFor31Plus) Code() string {
 }
 func (e *PrefixItemsFieldFor31Plus) Code() string   { return "prefix-items-field-for-3-1-plus" }
 func (e *PropertyNamesFieldFor31Plus) Code() string { return "property-names-field-for-3-1-plus" }
+func (e *QueryFieldFor32Plus) Code() string         { return "query-field-for-3-2-plus" }
 func (e *RequestBodyContentRequired) Code() string  { return "request-body-content-required" }
 func (e *ResponseDescriptionRequired) Code() string { return "response-description-required" }
 func (e *ResponsesNonEmptyRequired) Code() string   { return "responses-required" }
@@ -163,6 +173,9 @@ func ValidationErrorCodes() []string {
 }
 
 var validationErrorCodes = []string{
+	"additional-operations-duplicate-method",
+	"additional-operations-field-for-3-2-plus",
+	"additional-operations-invalid-method",
 	"additional-properties-both-forms-exclusive",
 	"anchor-field-for-3-1-plus",
 	"authorization-url-forbidden",
@@ -227,6 +240,7 @@ var validationErrorCodes = []string{
 	"pattern-properties-field-for-3-1-plus",
 	"prefix-items-field-for-3-1-plus",
 	"property-names-field-for-3-1-plus",
+	"query-field-for-3-2-plus",
 	"read-only-write-only-mutually-exclusive",
 	"request-body-content-required",
 	"response-description-required",

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -17,6 +17,9 @@ import (
 // agree, which keeps the exported catalog honest.
 func codedErrorInventory() []openapi3.CodedError {
 	return []openapi3.CodedError{
+		&openapi3.AdditionalOperationsDuplicateMethodError{},
+		&openapi3.AdditionalOperationsFieldFor32Plus{},
+		&openapi3.AdditionalOperationsInvalidMethodError{},
 		&openapi3.AnchorFieldFor31Plus{},
 		&openapi3.APIKeyInInvalidError{},
 		&openapi3.APIKeySecuritySchemeNameRequired{},
@@ -88,6 +91,7 @@ func codedErrorInventory() []openapi3.CodedError {
 		&openapi3.PatternPropertiesFieldFor31Plus{},
 		&openapi3.PrefixItemsFieldFor31Plus{},
 		&openapi3.PropertyNamesFieldFor31Plus{},
+		&openapi3.QueryFieldFor32Plus{},
 		&openapi3.RequestBodyContentRequired{},
 		&openapi3.ResponseDescriptionRequired{},
 		&openapi3.ResponsesNonEmptyRequired{},

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -535,6 +535,36 @@ func (e *DuplicateParameterError) Error() string {
 	return fmt.Sprintf("more than one %q parameter has name %q", e.In, e.Name)
 }
 
+// AdditionalOperationsDuplicateMethodError clusters "additionalOperations
+// key duplicates a fixed field" failures. OpenAPI 3.2's
+// `additionalOperations` map may only carry methods that have no dedicated
+// Path Item Object field.
+type AdditionalOperationsDuplicateMethodError struct {
+	// Method is the offending additionalOperations key.
+	Method string
+	// Origin is the source location of the offending path item when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *AdditionalOperationsDuplicateMethodError) Error() string {
+	return fmt.Sprintf("additionalOperations key %q duplicates a fixed path item field", e.Method)
+}
+
+// AdditionalOperationsInvalidMethodError clusters "additionalOperations key
+// is not an HTTP method" failures. Keys must be RFC 9110 tokens.
+type AdditionalOperationsInvalidMethodError struct {
+	// Method is the offending additionalOperations key.
+	Method string
+	// Origin is the source location of the offending path item when the
+	// document was loaded with Loader.IncludeOrigin = true.
+	Origin *Origin
+}
+
+func (e *AdditionalOperationsInvalidMethodError) Error() string {
+	return fmt.Sprintf("additionalOperations key %q is not a valid HTTP method token", e.Method)
+}
+
 // DuplicateRequiredFieldError clusters "duplicate field in required" failures.
 // The elements of a schema's `required` array MUST be unique (JSON Schema
 // 2020-12 §6.5.3 for OpenAPI 3.1, draft-04 for OpenAPI 3.0).
@@ -1531,8 +1561,24 @@ func (e *ItemSchemaFieldFor32Plus) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type QueryFieldFor32Plus struct{ ValidationError }
+
+func (e *QueryFieldFor32Plus) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type AdditionalOperationsFieldFor32Plus struct{ ValidationError }
+
+func (e *AdditionalOperationsFieldFor32Plus) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 var fieldFor32PlusLeaves = map[string]func(msg string) error{
 	"itemSchema": func(m string) error { return &ItemSchemaFieldFor32Plus{ValidationError{Message: m}} },
+	"query":      func(m string) error { return &QueryFieldFor32Plus{ValidationError{Message: m}} },
+	"additionalOperations": func(m string) error {
+		return &AdditionalOperationsFieldFor32Plus{ValidationError{Message: m}}
+	},
 }
 
 func errFieldFor32Plus(field string, origin *Origin) error {
@@ -1544,6 +1590,14 @@ func errFieldFor32Plus(field string, origin *Origin) error {
 		leaf = &ValidationError{Message: msg}
 	}
 	return newFieldVersionMismatch(field, "3.2", leaf, origin)
+}
+
+func newAdditionalOperationsDuplicateMethod(method string, origin *Origin) error {
+	return &AdditionalOperationsDuplicateMethodError{Method: method, Origin: origin}
+}
+
+func newAdditionalOperationsInvalidMethod(method string, origin *Origin) error {
+	return &AdditionalOperationsInvalidMethodError{Method: method, Origin: origin}
 }
 
 func newPathParameterRequired(param string, origin *Origin) error {

--- a/openapi3/walk_parameters.go
+++ b/openapi3/walk_parameters.go
@@ -4,7 +4,6 @@ import (
 	"maps"
 	"slices"
 	"strconv"
-	"strings"
 )
 
 // WalkParametersFunc is called once for each parameter visited by
@@ -86,10 +85,9 @@ func (w *parameterWalker) pathItem(ptr string, item *PathItem) error {
 			return err
 		}
 	}
-	ops := item.Operations()
-	for _, method := range slices.Sorted(maps.Keys(ops)) {
-		op := ops[method]
-		opPtr := ptr + "/" + strings.ToLower(method)
+	for _, entry := range item.operationEntries() {
+		op := entry.operation
+		opPtr := ptr + entry.pointerSuffix
 		for i, pr := range op.Parameters {
 			if err := w.parameter(opPtr+"/parameters/"+strconv.Itoa(i), pr); err != nil {
 				return err

--- a/openapi3/walk_schemas.go
+++ b/openapi3/walk_schemas.go
@@ -130,9 +130,8 @@ func (w *schemaWalker) pathItem(ptr string, item *PathItem) error {
 			return err
 		}
 	}
-	ops := item.Operations()
-	for _, method := range slices.Sorted(maps.Keys(ops)) {
-		if err := w.operation(ptr+"/"+strings.ToLower(method), ops[method]); err != nil {
+	for _, entry := range item.operationEntries() {
+		if err := w.operation(ptr+entry.pointerSuffix, entry.operation); err != nil {
 			return err
 		}
 	}

--- a/openapi3filter/validate_request_custom_methods_test.go
+++ b/openapi3filter/validate_request_custom_methods_test.go
@@ -1,0 +1,108 @@
+package openapi3filter
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// TestValidateRequestCustomMethods checks that request validation is oblivious
+// to the HTTP method: the OpenAPI 3.2 `query` operation and custom methods held
+// in `additionalOperations` get their request body validated like any other.
+func TestValidateRequestCustomMethods(t *testing.T) {
+	const spec = `
+openapi: 3.2.0
+info:
+  title: 'Validator'
+  version: 0.0.1
+paths:
+  /search:
+    query:
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - term
+              properties:
+                term:
+                  type: string
+      responses:
+        '200':
+          description: OK
+    additionalOperations:
+      COPY:
+        requestBody:
+          required: true
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - destination
+                properties:
+                  destination:
+                    type: string
+        responses:
+          '200':
+            description: OK
+`
+
+	router := setupTestRouter(t, spec)
+
+	for _, tc := range []struct {
+		name    string
+		method  string
+		body    string
+		wantErr bool
+	}{
+		{"QUERY valid body", openapi3.MethodQuery, `{"term":"cats"}`, false},
+		{"QUERY missing required property", openapi3.MethodQuery, `{}`, true},
+		{"QUERY wrong property type", openapi3.MethodQuery, `{"term":42}`, true},
+		{"COPY valid body", "COPY", `{"destination":"/elsewhere"}`, false},
+		{"COPY missing required property", "COPY", `{}`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, "/search", strings.NewReader(tc.body))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+
+			route, pathParams, err := router.FindRoute(req)
+			require.NoError(t, err)
+			require.Equal(t, tc.method, route.Method)
+
+			err = ValidateRequest(t.Context(), &RequestValidationInput{
+				Request:    req,
+				PathParams: pathParams,
+				Route:      route,
+			})
+			if tc.wantErr {
+				require.Error(t, err)
+				require.IsType(t, &RequestError{}, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+
+	t.Run("missing required body", func(t *testing.T) {
+		req, err := http.NewRequest(openapi3.MethodQuery, "/search", nil)
+		require.NoError(t, err)
+
+		route, pathParams, err := router.FindRoute(req)
+		require.NoError(t, err)
+
+		err = ValidateRequest(t.Context(), &RequestValidationInput{
+			Request:    req,
+			PathParams: pathParams,
+			Route:      route,
+		})
+		require.Error(t, err)
+	})
+}

--- a/routers/gorillamux/router_custom_methods_test.go
+++ b/routers/gorillamux/router_custom_methods_test.go
@@ -1,0 +1,103 @@
+package gorillamux
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers"
+)
+
+// customMethodsSpec exercises the OpenAPI 3.2 `query` field and custom methods
+// held in `additionalOperations`.
+const customMethodsSpec = `
+openapi: 3.2.0
+info:
+  title: MyAPI
+  version: "0.1"
+paths:
+  /pets:
+    query:
+      responses:
+        "200":
+          description: OK
+    additionalOperations:
+      COPY:
+        responses:
+          "200":
+            description: OK
+  /pets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      responses:
+        "200":
+          description: OK
+    query:
+      responses:
+        "200":
+          description: OK
+    additionalOperations:
+      COPY:
+        responses:
+          "200":
+            description: OK
+`
+
+func TestRouterCustomMethods(t *testing.T) {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(customMethodsSpec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(context.Background()))
+
+	router, err := NewRouter(doc)
+	require.NoError(t, err)
+
+	pets := doc.Paths.Value("/pets")
+	petsID := doc.Paths.Value("/pets/{id}")
+
+	for _, tc := range []struct {
+		method    string
+		uri       string
+		operation *openapi3.Operation
+		params    map[string]string
+	}{
+		{openapi3.MethodQuery, "/pets", pets.Query, nil},
+		{"COPY", "/pets", pets.AdditionalOperations["COPY"], nil},
+		{openapi3.MethodQuery, "/pets/fido", petsID.Query, map[string]string{"id": "fido"}},
+		{"COPY", "/pets/fido", petsID.AdditionalOperations["COPY"], map[string]string{"id": "fido"}},
+		{http.MethodGet, "/pets/fido", petsID.Get, map[string]string{"id": "fido"}},
+	} {
+		t.Run(tc.method+" "+tc.uri, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, tc.uri, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(req)
+			require.NoError(t, err)
+			require.Same(t, tc.operation, route.Operation)
+			require.Equal(t, tc.method, route.Method)
+			for name, want := range tc.params {
+				require.Equal(t, want, pathParams[name])
+			}
+		})
+	}
+
+	t.Run("unregistered method", func(t *testing.T) {
+		for _, uri := range []string{"/pets", "/pets/fido"} {
+			req, err := http.NewRequest("PURGE", uri, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(req)
+			require.EqualError(t, err, routers.ErrMethodNotAllowed.Error())
+			require.Nil(t, route)
+			require.Nil(t, pathParams)
+		}
+	})
+}

--- a/routers/legacy/router.go
+++ b/routers/legacy/router.go
@@ -150,6 +150,13 @@ func (router *Router) FindRoute(req *http.Request) (*routers.Route, map[string]s
 		if pathItem.GetOperation(method) == nil {
 			return nil, nil, &routers.RouteError{Reason: routers.ErrMethodNotAllowed.Error()}
 		}
+		if node == nil {
+			// The document declares this operation but the route trie holds no
+			// matching node, so there is nothing to extract path parameters
+			// from. This happens when the document was mutated after the
+			// router was built.
+			return nil, nil, &routers.RouteError{Reason: routers.ErrPathNotFound.Error()}
+		}
 	}
 
 	if pathParams == nil {

--- a/routers/legacy/router_custom_methods_test.go
+++ b/routers/legacy/router_custom_methods_test.go
@@ -1,0 +1,110 @@
+package legacy_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers"
+	"github.com/getkin/kin-openapi/routers/legacy"
+)
+
+// customMethodsSpec exercises the OpenAPI 3.2 `query` field and custom methods
+// held in `additionalOperations`.
+const customMethodsSpec = `
+openapi: 3.2.0
+info:
+  title: MyAPI
+  version: "0.1"
+paths:
+  /pets:
+    query:
+      responses:
+        "200":
+          description: OK
+    additionalOperations:
+      COPY:
+        responses:
+          "200":
+            description: OK
+  /pets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      responses:
+        "200":
+          description: OK
+    query:
+      responses:
+        "200":
+          description: OK
+    additionalOperations:
+      COPY:
+        responses:
+          "200":
+            description: OK
+`
+
+func TestRouterCustomMethods(t *testing.T) {
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(customMethodsSpec))
+	require.NoError(t, err)
+
+	// NewRouter validates the document: a 3.2 spec using query and
+	// additionalOperations must pass validation.
+	router, err := legacy.NewRouter(doc)
+	require.NoError(t, err)
+
+	pets := doc.Paths.Value("/pets")
+	petsID := doc.Paths.Value("/pets/{id}")
+
+	for _, tc := range []struct {
+		method    string
+		uri       string
+		operation *openapi3.Operation
+		params    map[string]string
+	}{
+		{openapi3.MethodQuery, "/pets", pets.Query, nil},
+		{"COPY", "/pets", pets.AdditionalOperations["COPY"], nil},
+		{openapi3.MethodQuery, "/pets/fido", petsID.Query, map[string]string{"id": "fido"}},
+		{"COPY", "/pets/fido", petsID.AdditionalOperations["COPY"], map[string]string{"id": "fido"}},
+		{http.MethodGet, "/pets/fido", petsID.Get, map[string]string{"id": "fido"}},
+	} {
+		t.Run(tc.method+" "+tc.uri, func(t *testing.T) {
+			req, err := http.NewRequest(tc.method, tc.uri, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(req)
+			require.NoError(t, err)
+			require.Same(t, tc.operation, route.Operation)
+			require.Equal(t, tc.method, route.Method)
+			for name, want := range tc.params {
+				require.Equal(t, want, pathParams[name])
+			}
+		})
+	}
+
+	t.Run("unregistered method", func(t *testing.T) {
+		for uri, wantErr := range map[string]error{
+			"/pets": routers.ErrMethodNotAllowed,
+			// The legacy router can only report "method not allowed" for paths
+			// it can look up verbatim in the document: a templated path that
+			// matches no route falls back to "path not found".
+			"/pets/fido": routers.ErrPathNotFound,
+		} {
+			req, err := http.NewRequest("PURGE", uri, nil)
+			require.NoError(t, err)
+
+			route, pathParams, err := router.FindRoute(req)
+			require.EqualError(t, err, wantErr.Error())
+			require.Nil(t, route)
+			require.Nil(t, pathParams)
+		}
+	})
+}


### PR DESCRIPTION
Add the OpenAPI 3.2 Path Item Object fields for custom HTTP methods: the fixed query field (HTTP QUERY) and additionalOperations, a map of custom method names to operations.

- PathItem gains Query and AdditionalOperations; Operations(), GetOperation() and SetOperation() cover them. SetOperation no longer panics on unknown methods; they are stored in AdditionalOperations.
- Both fields are version-gated: validating a pre-3.2 document that uses them fails with query-field-for-3-2-plus / additional-operations-field-for-3-2-plus. AdditionalOperations keys must be RFC 9110 tokens and must not duplicate a fixed-field method.
- Schema/parameter walkers address custom methods with /additionalOperations/<METHOD> JSON pointers, preserving case.
- openapi2conv.FromV3 and FromV3PathItem return an error instead of panicking for methods Swagger 2.0 cannot express.
- routers/legacy: guard a nil-node dereference in the FindRoute fallback when the document declares an operation absent from the route trie.
- Routers and openapi3filter need no changes: both derive method sets from Operations(), proven by new routing and request-validation tests for QUERY and custom methods.