### PR TITLE
openapi3: export PathItemMethods

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -203,6 +203,12 @@ func Int64Ptr(value int64) *int64
 
     Deprecated: Use Ptr instead.
 
+func PathItemMethods() []string
+    PathItemMethods returns the HTTP methods that have a dedicated Path Item
+    Object field, sorted. Any other method an operation is registered under
+    lives in AdditionalOperations, so a caller that treats the two groups
+    differently can tell them apart without listing the fixed methods itself.
+
 func Ptr[T any](value T) *T
     Ptr is a helper for defining OpenAPI schemas.
 

--- a/openapi3/path_item.go
+++ b/openapi3/path_item.go
@@ -56,6 +56,14 @@ var fixedPathItemMethods = map[string]struct{}{
 	MethodQuery:        {},
 }
 
+// PathItemMethods returns the HTTP methods that have a dedicated Path Item
+// Object field, sorted. Any other method an operation is registered under
+// lives in AdditionalOperations, so a caller that treats the two groups
+// differently can tell them apart without listing the fixed methods itself.
+func PathItemMethods() []string {
+	return componentNames(fixedPathItemMethods)
+}
+
 // httpTokenRe matches an RFC 9110 token, the grammar HTTP method names
 // must follow.
 var httpTokenRe = regexp.MustCompile("^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$")

--- a/openapi3/path_item_custom_methods_test.go
+++ b/openapi3/path_item_custom_methods_test.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"encoding/json"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -325,4 +326,26 @@ func TestWalkersVisitCustomMethodOperations(t *testing.T) {
 	}))
 	require.Contains(t, paramPointers,
 		"/paths/~1things/additionalOperations/COPY/parameters/0")
+}
+
+func TestPathItemMethods_MatchTheFixedFields(t *testing.T) {
+	methods := PathItemMethods()
+	require.True(t, slices.IsSorted(methods))
+
+	// Every listed method is held by a fixed field, so setting it leaves
+	// AdditionalOperations empty and GetOperation reads it back.
+	for _, method := range methods {
+		pathItem := &PathItem{}
+		operation := &Operation{}
+		pathItem.SetOperation(method, operation)
+
+		require.Empty(t, pathItem.AdditionalOperations, method)
+		require.Same(t, operation, pathItem.GetOperation(method), method)
+	}
+
+	// A method the list omits is a custom one, and lands in the map.
+	pathItem := &PathItem{}
+	pathItem.SetOperation("PURGE", &Operation{})
+	require.NotContains(t, methods, "PURGE")
+	require.Contains(t, pathItem.AdditionalOperations, "PURGE")
 }


### PR DESCRIPTION
Follow-up to #1240.

`fixedPathItemMethods` records which HTTP methods have a dedicated Path Item Object field. `Operations()`, `GetOperation()` and `SetOperation()` all consult it, but it is unexported, so a caller outside the package that needs the same distinction has to write the list out again.

A list written out again is one that silently misses the next method the spec adds, and #1240 has just made that concrete. OpenAPI 3.2 promoted QUERY to a fixed field, so a consumer carrying its own nine-method list now classifies QUERY as a custom method: it reads `additionalOperations` for it, finds nothing, and treats an operation the document does declare as absent. The same will happen to whatever 3.3 adds.

`PathItemMethods()` returns the set, sorted, so a caller can ask instead of guess:

```go
for method, operation := range pathItem.Operations() {
    if slices.Contains(openapi3.PathItemMethods(), method) {
        // fixed field
    } else {
        // custom method, from additionalOperations
    }
}
```

The test pins the export against the behaviour it describes rather than against a copy of the list: every method it returns must round-trip through `SetOperation`/`GetOperation` leaving `AdditionalOperations` empty, and a method it omits must land in that map. So the two cannot drift.

Sorted rather than in spec order, matching `Operations()` and `operationEntries()`, which already order methods with `componentNames`.
