### PR TITLE
openapi3: stop validation panicking on an uncompilable pattern

### DIFF
--- a/openapi3/issue1044_test.go
+++ b/openapi3/issue1044_test.go
@@ -1,0 +1,36 @@
+package openapi3_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Go's regexp is RE2 and rejects the lookarounds ECMA 262 allows, so this
+// pattern cannot be compiled.
+const issue1044Pattern = `^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$`
+
+func TestIssue1044(t *testing.T) {
+	schema := openapi3.NewStringSchema().WithPattern(issue1044Pattern)
+
+	err := schema.VisitJSON("example.com", openapi3.MultiErrors())
+
+	var patternErr *openapi3.SchemaPatternRegexError
+	require.ErrorAs(t, err, &patternErr)
+	require.Equal(t, issue1044Pattern, patternErr.Pattern)
+}
+
+// A custom compiler reports failure by returning no matcher at all.
+func TestIssue1044CustomRegexCompiler(t *testing.T) {
+	schema := openapi3.NewStringSchema().WithPattern(`^whatever$`)
+	compile := func(string) (openapi3.RegexMatcher, error) {
+		return nil, errors.New("compiler said no")
+	}
+
+	err := schema.VisitJSON("example.com", openapi3.MultiErrors(), openapi3.SetSchemaRegexCompiler(compile))
+
+	require.ErrorContains(t, err, "compiler said no")
+}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -2663,7 +2663,7 @@ func (schema *Schema) visitJSONString(settings *schemaValidationSettings, value 
 				me = append(me, err)
 			}
 		}
-		if !cp.MatchString(value) {
+		if cp != nil && !cp.MatchString(value) {
 			err := &SchemaError{
 				Value:                 value,
 				Schema:                schema,

--- a/openapi3/schema_pattern.go
+++ b/openapi3/schema_pattern.go
@@ -27,8 +27,9 @@ func (schema *Schema) compilePattern(c RegexCompilerFunc) (cp RegexMatcher, err 
 			Origin:      err,
 			Reason:      fmt.Sprintf("cannot compile pattern %q: %v", pattern, err),
 		}
-		err = newSchemaPatternRegexError(pattern, schemaErr, schema.Origin)
-		return
+		// Returning cp would hand back regexp.Compile's nil *regexp.Regexp
+		// inside a non-nil interface, which no nil check at a call site catches.
+		return nil, newSchemaPatternRegexError(pattern, schemaErr, schema.Origin)
 	}
 
 	compiledPatterns.Store(pattern, cp)

--- a/openapi3/schema_pattern.go
+++ b/openapi3/schema_pattern.go
@@ -27,9 +27,10 @@ func (schema *Schema) compilePattern(c RegexCompilerFunc) (cp RegexMatcher, err 
 			Origin:      err,
 			Reason:      fmt.Sprintf("cannot compile pattern %q: %v", pattern, err),
 		}
-		// Returning cp would hand back regexp.Compile's nil *regexp.Regexp
-		// inside a non-nil interface, which no nil check at a call site catches.
-		return nil, newSchemaPatternRegexError(pattern, schemaErr, schema.Origin)
+		// A failed compile can yield a typed nil, which no call site's nil check catches.
+		cp = nil
+		err = newSchemaPatternRegexError(pattern, schemaErr, schema.Origin)
+		return
 	}
 
 	compiledPatterns.Store(pattern, cp)


### PR DESCRIPTION
Fixes #1044.

A schema whose `pattern` cannot be compiled makes `visitJSONString` panic with a nil pointer dereference instead of reporting the failure.

```go
schema := openapi3.NewStringSchema().WithPattern(`^((?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,6}$`)
schema.VisitJSON("example.com", openapi3.MultiErrors())
// panic: runtime error: invalid memory address or nil pointer dereference
//   regexp.(*Regexp).MatchString(0x0?, ...)
//   openapi3.(*Schema).visitJSONString(...) schema.go:2666
```

OpenAPI 3.0 takes `pattern` from ECMA 262, which has lookarounds; Go's RE2 does not, so specs written against the spec's own regex dialect land here. Such patterns are common in auto-generated schemas, and #1044 reports the panic surfacing through `openapi3filter.ValidateRequest`, which validates in multi-error mode.

## Why it panics

`compilePattern` passes `regexp.Compile`'s result back through its named result:

```go
func (schema *Schema) compilePattern(c RegexCompilerFunc) (cp RegexMatcher, err error) {
	...
	cp, err = regexp.Compile(intoGoRegexp(pattern))
	if err != nil {
		...
		return
	}
```

On failure that is a nil `*regexp.Regexp` boxed in a non-nil `RegexMatcher`, so `cp == nil` is false at every call site. In `visitJSONString`, single-error mode returns the compile error, but multi-error mode records it and falls through to `cp.MatchString(value)`, which dereferences the nil receiver.

## The fix

Return an explicit nil from `compilePattern` so the failure cannot be mistaken for a usable matcher, and skip the match when there is none. The compile error is already recorded, so validation reports it rather than swallowing it.

Fixing it in `compilePattern` rather than at the call site keeps the trap from reaching any future caller. The other caller, `Schema.validate`, discards the matcher and is unaffected.

Two tests, both of which fail without the change: the reported case, and a custom `SetSchemaRegexCompiler` that reports failure by returning no matcher, which is the remaining reason the call site checks at all.