### PR TITLE
openapi3filter: append only the bytes read in ZipFileBodyDecoder

### DIFF
--- a/openapi3filter/issue1246_test.go
+++ b/openapi3filter/issue1246_test.go
@@ -1,0 +1,55 @@
+package openapi3filter_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3filter"
+)
+
+// ZipFileBodyDecoder must return exactly the archived files' bytes: the read
+// loop used to append the whole reused 256-byte buffer per read instead of
+// the n bytes actually read, padding the result with NUL bytes and leaking
+// bytes of previously read files into later ones. See #1246.
+func TestIssue1246(t *testing.T) {
+	buildZip := func(t *testing.T, files [][2]string) []byte {
+		t.Helper()
+		var buf bytes.Buffer
+		zw := zip.NewWriter(&buf)
+		for _, f := range files {
+			w, err := zw.Create(f[0])
+			require.NoError(t, err)
+			_, err = w.Write([]byte(f[1]))
+			require.NoError(t, err)
+		}
+		require.NoError(t, zw.Close())
+		return buf.Bytes()
+	}
+
+	t.Run("file shorter than the read buffer is not padded", func(t *testing.T) {
+		data := buildZip(t, [][2]string{
+			{"a.txt", "hello world"},
+		})
+
+		got, err := openapi3filter.ZipFileBodyDecoder(bytes.NewReader(data), http.Header{}, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, "hello world", got)
+	})
+
+	t.Run("later file does not see bytes of an earlier one", func(t *testing.T) {
+		first := strings.Repeat("A", 256)
+		data := buildZip(t, [][2]string{
+			{"first.txt", first},
+			{"second.txt", "B"},
+		})
+
+		got, err := openapi3filter.ZipFileBodyDecoder(bytes.NewReader(data), http.Header{}, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, first+"B", got)
+	})
+}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1694,7 +1694,7 @@ func ZipFileBodyDecoder(body io.Reader, header http.Header, schema *openapi3.Sch
 			for {
 				n, err := rc.Read(buffer)
 				if 0 < n {
-					content = append(content, buffer...)
+					content = append(content, buffer[:n]...)
 				}
 				if err == io.EOF {
 					break


### PR DESCRIPTION
Fixes #1246

## What

`ZipFileBodyDecoder`'s read loop appended the entire reused 256-byte buffer
on every `Read`, instead of only the `n` bytes the read reported:

```go
n, err := rc.Read(buffer)
if 0 < n {
    content = append(content, buffer...) // whole buffer, not buffer[:n]
}
```

Per the `io.Reader` contract only `buffer[:n]` holds valid data, so the
decoded string came back corrupted in two ways:

- files whose reads come back shorter than 256 bytes were padded with the
  buffer's untouched NUL bytes (an 11-byte file decoded to 256 bytes), and
- because the buffer is reused across files, bytes of a previously read file
  leaked into the next one's content.

## Change

- Append `buffer[:n]` instead of `buffer` (one line).
- Regression test `TestIssue1246` asserting the decoded value byte-for-byte
  for both corruption modes; it fails on master and passes with the fix.

## Test evidence

```
$ go test ./openapi3filter/ -run TestIssue1246 -v
--- PASS: TestIssue1246 (0.00s)
    --- PASS: TestIssue1246/file_shorter_than_the_read_buffer_is_not_padded (0.00s)
    --- PASS: TestIssue1246/later_file_does_not_see_bytes_of_an_earlier_one (0.00s)

$ go test ./...
ok  	github.com/getkin/kin-openapi/openapi2           29.441s
ok  	github.com/getkin/kin-openapi/openapi2conv       1.273s
ok  	github.com/getkin/kin-openapi/openapi3           100.367s
ok  	github.com/getkin/kin-openapi/openapi3conv       0.783s
ok  	github.com/getkin/kin-openapi/openapi3filter     3.392s
ok  	github.com/getkin/kin-openapi/openapi3gen        4.001s
ok  	github.com/getkin/kin-openapi/routers            2.745s
ok  	github.com/getkin/kin-openapi/routers/gorillamux 4.629s
ok  	github.com/getkin/kin-openapi/routers/legacy     5.358s
ok  	github.com/getkin/kin-openapi/routers/legacy/pathpattern 3.336s
```

Without the fix, the new test fails with e.g. `A`×256+`B` decoding to 512
bytes whose tail is the first file's `A` bytes.

---
This fix was prepared with AI assistance; I reproduced the issue and reviewed every change locally.
