### PR TITLE
openapi3filter: handle deserializing deepObject param with additionalProperties into maps

### DIFF
--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -113,3 +113,13 @@ func TestIssue1112KnownPropertyKeepsTypedValue(t *testing.T) {
 		"color": "black",
 	}, value)
 }
+
+func TestIssue1112AdditionalPropertiesFalseDoesNotBecomeFreeForm(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(false)})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[color]=black", schema)
+
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, map[string]any{}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -1,0 +1,57 @@
+package openapi3filter
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func issue1112ObjectSchema(additional openapi3.AdditionalProperties) *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type:                 &openapi3.Types{"object"},
+			Properties:           make(map[string]*openapi3.SchemaRef),
+			AdditionalProperties: additional,
+		},
+	}
+}
+
+func issue1112Decode(t *testing.T, paramName, rawQuery string, schema *openapi3.SchemaRef) (any, bool, error) {
+	t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.test/?"+rawQuery, nil)
+	require.NoError(t, err)
+
+	param := &openapi3.Parameter{
+		Name:    paramName,
+		In:      openapi3.ParameterInQuery,
+		Style:   "deepObject",
+		Explode: openapi3.Ptr(true),
+		Schema:  schema,
+	}
+
+	return decodeStyledParameter(param, &RequestValidationInput{Request: req})
+}
+
+func TestIssue1112FreeFormDeepObject(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(
+		t,
+		"properties",
+		"properties[vaccinated]=true&properties[color]=black&properties[coat_length]=large",
+		schema,
+	)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{
+		"vaccinated":  "true",
+		"color":       "black",
+		"coat_length": "large",
+	}, value)
+	require.NoError(t, schema.Value.VisitJSON(value))
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -77,3 +77,13 @@ func TestIssue1112NestedFreeFormProperty(t *testing.T) {
 		"meta": map[string]any{"color": "black"},
 	}, value)
 }
+
+func TestIssue1112URLDecodedFreeFormValue(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[color]=blue%20green", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{"color": "blue green"}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -97,3 +97,19 @@ func TestIssue1112EmptyFreeFormValue(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, map[string]any{"color": ""}, value)
 }
+
+func TestIssue1112KnownPropertyKeepsTypedValue(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+	schema.Value.Properties["limit"] = &openapi3.SchemaRef{
+		Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}},
+	}
+
+	value, found, err := issue1112Decode(t, "properties", "properties[limit]=7&properties[color]=black", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{
+		"limit": int64(7),
+		"color": "black",
+	}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -133,3 +133,16 @@ func TestIssue1112UnspecifiedAdditionalPropertiesRemainUnchanged(t *testing.T) {
 	require.False(t, found)
 	require.Equal(t, map[string]any{}, value)
 }
+
+func TestIssue1112SchemaValuedAdditionalPropertiesStayTyped(t *testing.T) {
+	integerSchema := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}},
+	}
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Schema: integerSchema})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[count]=7", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{"count": int64(7)}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -123,3 +123,13 @@ func TestIssue1112AdditionalPropertiesFalseDoesNotBecomeFreeForm(t *testing.T) {
 	require.False(t, found)
 	require.Equal(t, map[string]any{}, value)
 }
+
+func TestIssue1112UnspecifiedAdditionalPropertiesRemainUnchanged(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[color]=black", schema)
+
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, map[string]any{}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -166,3 +166,13 @@ func TestIssue1112ParameterNameWithRegexpCharacters(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, map[string]any{"color": "black"}, value)
 }
+
+func TestIssue1112RepeatedFreeFormValueStillRequiresIndexes(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	_, found, err := issue1112Decode(t, "properties", "properties[tag]=one&properties[tag]=two", schema)
+
+	require.False(t, found)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "array items must be set with indexes")
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -146,3 +146,13 @@ func TestIssue1112SchemaValuedAdditionalPropertiesStayTyped(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, map[string]any{"count": int64(7)}, value)
 }
+
+func TestIssue1112IgnoresUnrelatedQueryKeys(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(t, "properties", "other[color]=black", schema)
+
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Nil(t, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -87,3 +87,13 @@ func TestIssue1112URLDecodedFreeFormValue(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, map[string]any{"color": "blue green"}, value)
 }
+
+func TestIssue1112EmptyFreeFormValue(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[color]=", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{"color": ""}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -156,3 +156,13 @@ func TestIssue1112IgnoresUnrelatedQueryKeys(t *testing.T) {
 	require.False(t, found)
 	require.Nil(t, value)
 }
+
+func TestIssue1112ParameterNameWithRegexpCharacters(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(t, "properties.v1", "properties.v1[color]=black", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{"color": "black"}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -190,3 +190,29 @@ func TestIssue1112NestedKnownFreeFormObject(t *testing.T) {
 		"meta": map[string]any{"color": "black"},
 	}, value)
 }
+
+func TestIssue1112SchemaValuedNestedExtraneousPropertyRemainsIgnored(t *testing.T) {
+	childSchema := &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: map[string]*openapi3.SchemaRef{
+				"item1": {
+					Value: &openapi3.Schema{Type: &openapi3.Types{"integer"}},
+				},
+			},
+		},
+	}
+	dynamicObject := issue1112ObjectSchema(openapi3.AdditionalProperties{Schema: childSchema})
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{})
+	schema.Value.Properties["obj"] = dynamicObject
+
+	value, found, err := issue1112Decode(t, "param", "param[obj][prop1][inexistent]=1", schema)
+
+	require.NoError(t, err)
+	require.False(t, found)
+	require.Equal(t, map[string]any{
+		"obj": map[string]any{
+			"prop1": map[string]any{},
+		},
+	}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -55,3 +55,13 @@ func TestIssue1112FreeFormDeepObject(t *testing.T) {
 	}, value)
 	require.NoError(t, schema.Value.VisitJSON(value))
 }
+
+func TestIssue1112SingleFreeFormProperty(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[color]=black", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{"color": "black"}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -176,3 +176,17 @@ func TestIssue1112RepeatedFreeFormValueStillRequiresIndexes(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "array items must be set with indexes")
 }
+
+func TestIssue1112NestedKnownFreeFormObject(t *testing.T) {
+	metaSchema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{})
+	schema.Value.Properties["meta"] = metaSchema
+
+	value, found, err := issue1112Decode(t, "properties", "properties[meta][color]=black", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{
+		"meta": map[string]any{"color": "black"},
+	}, value)
+}

--- a/openapi3filter/issue1112_test.go
+++ b/openapi3filter/issue1112_test.go
@@ -65,3 +65,15 @@ func TestIssue1112SingleFreeFormProperty(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, map[string]any{"color": "black"}, value)
 }
+
+func TestIssue1112NestedFreeFormProperty(t *testing.T) {
+	schema := issue1112ObjectSchema(openapi3.AdditionalProperties{Has: openapi3.Ptr(true)})
+
+	value, found, err := issue1112Decode(t, "properties", "properties[meta][color]=black", schema)
+
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, map[string]any{
+		"meta": map[string]any{"color": "black"},
+	}, value)
+}

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -664,6 +664,13 @@ const (
 	urlDecoderDelimiter = "\x1F" // should not conflict with URL characters
 )
 
+func decodesAdditionalProperties(schema *openapi3.Schema) bool {
+	if schema.AdditionalProperties.Schema != nil {
+		return true
+	}
+	return schema.AdditionalProperties.Has != nil && *schema.AdditionalProperties.Has
+}
+
 func (d *urlValuesDecoder) DecodeObject(param string, sm *openapi3.SerializationMethod, schema *openapi3.SchemaRef) (map[string]any, bool, error) {
 	var propsFn func(url.Values) (map[string]string, error)
 	switch sm.Style {

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1079,6 +1079,15 @@ func buildResObj(params map[string]any, parentKeys []string, key string, schema 
 					resultMap[k] = r
 				}
 			}
+		} else if schema.Value.AdditionalProperties.Has != nil && *schema.Value.AdditionalProperties.Has {
+			// additionalProperties: true is free-form: retain dynamic values as
+			// decoded query-string data, but never overwrite schema-decoded
+			// properties.
+			for k, v := range objectParams {
+				if _, exists := resultMap[k]; !exists {
+					resultMap[k] = v
+				}
+			}
 		}
 
 		return resultMap, nil

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -740,7 +740,7 @@ func (d *urlValuesDecoder) DecodeObject(param string, sm *openapi3.Serialization
 		return nil, false, err
 	}
 
-	found := false
+	found := sm.Style == "deepObject" && len(props) > 0 && decodesAdditionalProperties(schema.Value)
 	for propName := range schema.Value.Properties {
 		if _, ok := props[propName]; ok {
 			found = true


### PR DESCRIPTION
## Summary

Fixes `deepObject` query decoding for objects with explicit free-form `additionalProperties: true`.

- recognizes dynamic-only deepObject parameters as present
- retains values allowed by explicit `additionalProperties: true`
- keeps schema-valued additional properties typed
- preserves the existing behavior for `additionalProperties: false` and an unspecified keyword
- preserves the existing nested schema-valued decoding behavior
- leaves form/path/header/cookie object decoding unchanged
- adds regression coverage for the reported case and relevant edge cases

## Validation

- `go test ./openapi3filter -run '^TestIssue1112' -count=1`
- `go test ./openapi3filter -count=1`
- `go vet ./openapi3filter`
- `git diff --check`
- exactly 17 Signed-off-by commits

Fixes #1112