### PR TITLE
openapi3: add FormatOfStringForUUIDOfRFC9562 for UUID v6-v8

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -59,6 +59,11 @@ const (
 	// FormatOfStringForUUIDOfRFC4122 is an optional predefined format for UUID v1-v5 as specified by RFC4122
 	FormatOfStringForUUIDOfRFC4122 = `^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$`
 
+	// FormatOfStringForUUIDOfRFC9562 is an optional predefined format for UUID v1-v8 as specified by RFC9562,
+	// which obsoletes RFC4122. In addition to the versioned layout it also accepts the special Nil UUID
+	// (all zeroes) and Max UUID (all ones) defined in sections 5.9 and 5.10 of the RFC.
+	FormatOfStringForUUIDOfRFC9562 = `^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|[fF]{8}-[fF]{4}-[fF]{4}-[fF]{4}-[fF]{12})$`
+
 	// FormatOfStringForEmail pattern catches only some suspiciously wrong-looking email addresses.
 	// Use DefineStringFormat(...) if you need something stricter.
 	FormatOfStringForEmail = `^[^@]+@[^@<>",\s]+$`

--- a/openapi3/issue1244_test.go
+++ b/openapi3/issue1244_test.go
@@ -1,0 +1,56 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// TestIssue1244UUIDRFC9562 documents which UUIDs each predefined format accepts.
+// RFC 9562 obsoletes RFC 4122 and adds versions 6, 7 and 8 as well as the Max
+// UUID, none of which are matched by FormatOfStringForUUIDOfRFC4122. The RFC 4122
+// format is left untouched so existing users keep the stricter behaviour.
+// See https://github.com/getkin/kin-openapi/issues/1244.
+func TestIssue1244UUIDRFC9562(t *testing.T) {
+	rfc4122 := openapi3.NewRegexpFormatValidator(openapi3.FormatOfStringForUUIDOfRFC4122)
+	rfc9562 := openapi3.NewRegexpFormatValidator(openapi3.FormatOfStringForUUIDOfRFC9562)
+
+	for _, tc := range []struct {
+		name      string
+		value     string
+		okRFC4122 bool
+		okRFC9562 bool
+	}{
+		// Covered by both formats.
+		{"v1", "77e66540-ca29-11ed-afa1-0242ac120002", true, true},
+		{"v4", "00f4d301-b9f4-4366-8907-2b5a03430aa1", true, true},
+		{"v5", "630eb68f-e0fa-5ecc-887a-7c7a62614681", true, true},
+		{"nil UUID", "00000000-0000-0000-0000-000000000000", true, true},
+
+		// Covered by RFC 9562 only.
+		{"v6", "1ec9414c-232a-6b00-b3c8-9e6bdeced846", false, true},
+		{"v7", "017f22e2-79b0-7cc3-98c4-dc0c0c07398f", false, true},
+		{"v8", "2489e9ad-2ee2-8e00-8ec9-32d5f69181c0", false, true},
+		{"max UUID", "ffffffff-ffff-ffff-ffff-ffffffffffff", false, true},
+
+		// Covered by neither format.
+		{"not a uuid", "foo", false, false},
+		{"version 0", "00f4d301-b9f4-0366-8907-2b5a03430aa1", false, false},
+		{"version 9", "00f4d301-b9f4-9366-8907-2b5a03430aa1", false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.okRFC4122 {
+				require.NoError(t, rfc4122.Validate(tc.value))
+			} else {
+				require.Error(t, rfc4122.Validate(tc.value))
+			}
+			if tc.okRFC9562 {
+				require.NoError(t, rfc9562.Validate(tc.value))
+			} else {
+				require.Error(t, rfc9562.Validate(tc.value))
+			}
+		})
+	}
+}

--- a/openapi3/schema_formats.go
+++ b/openapi3/schema_formats.go
@@ -34,6 +34,11 @@ const (
 	// FormatOfStringForUUIDOfRFC4122 is an optional predefined format for UUID v1-v5 as specified by RFC4122
 	FormatOfStringForUUIDOfRFC4122 = `^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000)$`
 
+	// FormatOfStringForUUIDOfRFC9562 is an optional predefined format for UUID v1-v8 as specified by RFC9562,
+	// which obsoletes RFC4122. In addition to the versioned layout it also accepts the special Nil UUID
+	// (all zeroes) and Max UUID (all ones) defined in sections 5.9 and 5.10 of the RFC.
+	FormatOfStringForUUIDOfRFC9562 = `^(?:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-8][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}|00000000-0000-0000-0000-000000000000|[fF]{8}-[fF]{4}-[fF]{4}-[fF]{4}-[fF]{12})$`
+
 	// FormatOfStringForEmail pattern catches only some suspiciously wrong-looking email addresses.
 	// Use DefineStringFormat(...) if you need something stricter.
 	FormatOfStringForEmail = `^[^@]+@[^@<>",\s]+$`


### PR DESCRIPTION
## What

Adds a new predefined string format constant `FormatOfStringForUUIDOfRFC9562` for validating UUIDs as defined by [RFC 9562](https://www.rfc-editor.org/rfc/rfc9562).

## Why

`FormatOfStringForUUIDOfRFC4122` only matches UUID versions 1-5. RFC 9562 obsoletes RFC 4122 and adds versions 6, 7 and 8, plus the Max UUID. As a result a canonical UUIDv7 is currently rejected by `NewRegexpFormatValidator(FormatOfStringForUUIDOfRFC4122)`. This is the problem reported in #1244.

Rather than loosen the existing constant (which would silently change validation behaviour for everyone already relying on the RFC 4122 range), this adds a sibling constant so users can opt into the wider range explicitly. That matches the direction suggested in #1244 and in the earlier discussion on #750.

## Details

`FormatOfStringForUUIDOfRFC9562` accepts:

- the versioned layout for versions 1-8 (variant `10xx`),
- the Nil UUID (all zeroes, RFC 9562 §5.9),
- the Max UUID (all ones, RFC 9562 §5.10).

`FormatOfStringForUUIDOfRFC4122` is left untouched, so existing behaviour is unchanged and the two constants are strict supersets/subsets as expected.

## Tests

`TestIssue1244UUIDRFC9562` covers the three buckets: values matched by both formats (v1/v4/v5/Nil), values matched only by RFC 9562 (v6/v7/v8/Max), and values matched by neither (non-UUID, version 0, version 9).

The generated API doc snapshot in `.github/docs/openapi3.txt` is regenerated for the new constant.

Closes #1244