### PR TITLE
openapi3: compare multipleOf on exact rationals, not fixed-precision decimals

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -2361,6 +2361,80 @@ func (schema *Schema) visitJSONBoolean(settings *schemaValidationSettings, value
 	return
 }
 
+// multipleOfSlack bounds, as a negative power of two, how far a value may sit
+// from the nearest multiple and still count as one, measured relative to the
+// value itself. A float64 carries about 2^-53 of relative error, so this is a
+// couple of units in the last place: enough to absorb the error a caller's own
+// arithmetic introduced, small enough that a genuine remainder never fits.
+//
+// The window must be measured against the value and not against the quotient.
+// A quotient-relative window grows without bound, and once value/multipleOf
+// reaches 2^49 it exceeds one half, at which point every number validates.
+const multipleOfSlack = 51
+
+// multipleOfFailure reports whether value satisfies multipleOf, and the reason
+// when it does not.
+//
+// The comparison runs on exact rationals rather than on decimals formatted at a
+// fixed precision. A fixed precision is only correct inside a narrow magnitude
+// band: above it the formatting emits binary representation error and rejects
+// valid values, and below it every operand formats to zero, which both accepts
+// any value and divides by zero.
+func multipleOfFailure(value, multipleOf float64) (string, bool) {
+	// A non-finite multipleOf cannot be reported: SchemaError renders the whole
+	// schema as JSON and NaN has no JSON encoding, so building that error would
+	// panic instead of describing the problem. Treat it as no constraint, which
+	// at least replaces the division-by-zero panic the fixed-precision
+	// formatting produced here.
+	if math.IsNaN(multipleOf) || math.IsInf(multipleOf, 0) {
+		return "", true
+	}
+	// JSON Schema requires multipleOf to be strictly greater than zero. Without
+	// this guard a zero or negative value either divided by zero or accepted
+	// every number.
+	if multipleOf <= 0 {
+		return fmt.Sprintf("multipleOf must be greater than zero, got %g", multipleOf), false
+	}
+	// VisitJSON rejects a non-finite number before any keyword runs, but the
+	// exported VisitJSONNumber does not, so one can still reach this point.
+	// Reporting it here is out of scope: SchemaError marshals Value, and NaN has
+	// no JSON encoding, so the error would panic when rendered. Preserve the
+	// existing outcome and leave that entry point to a separate change.
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return "", true
+	}
+	notAMultiple := fmt.Sprintf("number must be a multiple of %g", multipleOf)
+
+	exactValue := new(big.Rat).SetFloat64(value)
+	exactMultipleOf := new(big.Rat).SetFloat64(multipleOf)
+	quotient := new(big.Rat).Quo(exactValue, exactMultipleOf)
+	if quotient.IsInt() {
+		return "", true
+	}
+
+	// The quotient is not an integer, so floor and floor+1 bracket it. Both are
+	// computed through big.Int, which no quotient can overflow. Compare the two
+	// candidate multiples against the value itself rather than comparing the
+	// quotient against an integer, so the window stays tied to the value's own
+	// precision at every magnitude.
+	floor := new(big.Int).Div(quotient.Num(), quotient.Denom())
+	var distance *big.Rat
+	for _, k := range []*big.Int{floor, new(big.Int).Add(floor, big.NewInt(1))} {
+		gap := new(big.Rat).Sub(exactValue, new(big.Rat).Mul(new(big.Rat).SetInt(k), exactMultipleOf))
+		gap.Abs(gap)
+		if distance == nil || gap.Cmp(distance) < 0 {
+			distance = gap
+		}
+	}
+
+	slack := new(big.Rat).SetFrac(big.NewInt(1), new(big.Int).Lsh(big.NewInt(1), multipleOfSlack))
+	tolerance := new(big.Rat).Mul(new(big.Rat).Abs(exactValue), slack)
+	if distance.Cmp(tolerance) <= 0 {
+		return "", true
+	}
+	return notAMultiple, false
+}
+
 func (schema *Schema) VisitJSONNumber(value float64) error {
 	settings := newSchemaValidationSettings()
 	return schema.visitJSONNumber(settings, value)
@@ -2563,10 +2637,8 @@ func (schema *Schema) visitJSONNumber(settings *schemaValidationSettings, value 
 	if v := schema.MultipleOf; v != nil {
 		// "A numeric instance is valid only if division by this keyword's
 		//    value results in an integer."
-		numRat, denRat := &big.Rat{}, &big.Rat{}
-		numRat.SetString(fmt.Sprintf("%.10f", value))
-		denRat.SetString(fmt.Sprintf("%.10f", *v))
-		if !(&big.Rat{}).Quo(numRat, denRat).IsInt() {
+		reason, ok := multipleOfFailure(value, *v)
+		if !ok {
 			if settings.failfast {
 				return errSchema
 			}
@@ -2574,7 +2646,7 @@ func (schema *Schema) visitJSONNumber(settings *schemaValidationSettings, value 
 				Value:                 value,
 				Schema:                schema,
 				SchemaField:           "multipleOf",
-				Reason:                fmt.Sprintf("number must be a multiple of %g", *v),
+				Reason:                reason,
 				customizeMessageError: settings.customizeMessageError,
 			}
 			if !settings.multiError {

--- a/openapi3/schema_test.go
+++ b/openapi3/schema_test.go
@@ -1501,7 +1501,7 @@ func TestIssue817(t *testing.T) {
 		Min:        &min,
 		MultipleOf: &mulOf,
 	}
-	validData := []float64{2.07, 8.1, 19628.87, 323.39, 40428.2, 1.13}
+	validData := []float64{2.07, 8.1, 19628.87, 323.39, 40428.2, 1.13, 999999999.99, 999999999.90, -999999999.99}
 	for _, data := range validData {
 		require.NoError(t, schema.VisitJSON(data))
 	}
@@ -1527,4 +1527,107 @@ func TestIssue817(t *testing.T) {
 		schema.MultipleOf = &data.mulfOf
 		require.ErrorContains(t, schema.VisitJSON(data.data), fmt.Sprintf("number must be a multiple of %+v", data.mulfOf))
 	}
+}
+
+// computedFloat keeps an expression off the constant-folding path so the test
+// sees the float64 a caller would actually produce at run time. Written as a
+// literal, 0.1+0.2 is evaluated exactly by the compiler and never carries the
+// binary noise these cases exist to cover.
+//
+//go:noinline
+func computedFloat(a, b float64) float64 { return a + b }
+
+//go:noinline
+func scaledFloat(a, b float64) float64 { return a * b }
+
+func TestSchemaMultipleOfAcrossMagnitudes(t *testing.T) {
+	numberSchema := func(multipleOf float64) *Schema {
+		return &Schema{Type: &Types{"number"}, MultipleOf: &multipleOf}
+	}
+
+	t.Run("large magnitudes are multiples of their own precision", func(t *testing.T) {
+		for _, value := range []float64{999999999.99, 999999999.90, -999999999.99, 1e15} {
+			require.NoError(t, numberSchema(0.01).VisitJSON(value), "value %v", value)
+		}
+	})
+
+	t.Run("representation error in a computed value is tolerated", func(t *testing.T) {
+		require.NoError(t, numberSchema(0.1).VisitJSON(computedFloat(0.1, 0.2)))
+		require.NoError(t, numberSchema(0.1).VisitJSON(computedFloat(0.3, -0.1)))
+		require.NoError(t, numberSchema(0.1).VisitJSON(scaledFloat(1.1, 3)))
+		require.NoError(t, numberSchema(1).VisitJSON(scaledFloat(4.35, 100)))
+	})
+
+	t.Run("a multipleOf smaller than the value precision still divides", func(t *testing.T) {
+		require.NoError(t, numberSchema(1e-12).VisitJSON(5.0))
+		require.NoError(t, numberSchema(1e-15).VisitJSON(1e15))
+		require.NoError(t, numberSchema(1e-323).VisitJSON(5e-323))
+		require.ErrorContains(t, numberSchema(1e-12).VisitJSON(0.0000000000015),
+			"number must be a multiple of 1e-12")
+	})
+
+	t.Run("a value far below the multipleOf is not a multiple", func(t *testing.T) {
+		require.ErrorContains(t, numberSchema(0.01).VisitJSON(1e-300),
+			"number must be a multiple of 0.01")
+	})
+
+	t.Run("zero is a multiple of anything positive", func(t *testing.T) {
+		require.NoError(t, numberSchema(0.01).VisitJSON(0.0))
+	})
+
+	t.Run("a non-finite value keeps its existing outcome", func(t *testing.T) {
+		// VisitJSON rejects these before any keyword runs; VisitJSONNumber does
+		// not. Reporting them from multipleOf is a separate change, because
+		// SchemaError marshals Value and NaN has no JSON encoding.
+		for _, value := range []float64{math.NaN(), math.Inf(1), math.Inf(-1)} {
+			require.NoError(t, numberSchema(0.01).VisitJSONNumber(value))
+			require.Error(t, numberSchema(0.01).VisitJSON(value))
+		}
+	})
+
+	t.Run("multipleOf must be greater than zero", func(t *testing.T) {
+		for _, multipleOf := range []float64{0, -0.01, -5} {
+			require.ErrorContains(t, numberSchema(multipleOf).VisitJSON(5.0),
+				"multipleOf must be greater than zero")
+		}
+	})
+
+	t.Run("a degenerate multipleOf does not crash the validator", func(t *testing.T) {
+		// Every one of these divided by zero before: the fixed-precision
+		// formatting turned them into a zero denominator.
+		for _, multipleOf := range []float64{0, -0.01, math.NaN(), math.Inf(1), 1e-12, 1e-323} {
+			require.NotPanics(t, func() { _ = numberSchema(multipleOf).VisitJSON(5.0) },
+				"multipleOf %v", multipleOf)
+		}
+	})
+
+	t.Run("a large quotient does not widen the accepted window", func(t *testing.T) {
+		// The window is relative to the value, not to value/multipleOf. Tied to
+		// the quotient it would exceed one half around 2^49 and accept
+		// everything; 2^50 leaves a remainder of 1 against 3 and of 4 against 5,
+		// and both operands here are exact integers, so no rounding is involved.
+		require.ErrorContains(t, numberSchema(3).VisitJSON(math.Pow(2, 50)),
+			"number must be a multiple of 3")
+		require.ErrorContains(t, numberSchema(5).VisitJSON(math.Pow(2, 50)),
+			"number must be a multiple of 5")
+		require.NoError(t, numberSchema(3).VisitJSON(math.Pow(2, 50)-1))
+	})
+
+	t.Run("the window does not reach a half step", func(t *testing.T) {
+		for _, multipleOf := range []float64{0.01, 0.1, 1, 3, 1e-7} {
+			for _, k := range []float64{1, 7, 1000, 999999} {
+				value := k*multipleOf + multipleOf/2
+				require.Error(t, numberSchema(multipleOf).VisitJSON(value),
+					"multipleOf %v at k %v", multipleOf, k)
+			}
+		}
+	})
+
+	t.Run("the failure names the offending keyword", func(t *testing.T) {
+		err := numberSchema(0.01).VisitJSON(0.005)
+		var schemaErr *SchemaError
+		require.ErrorAs(t, err, &schemaErr)
+		require.Equal(t, "multipleOf", schemaErr.SchemaField)
+		require.Equal(t, "number must be a multiple of 0.01", schemaErr.Reason)
+	})
 }


### PR DESCRIPTION
Fixes #1109.

### What breaks

`multipleOf` formats both operands with `"%.10f"` before parsing them into
`big.Rat`. That fixed precision is deliberate — #1068 introduced it to absorb
float64 representation error, and #1194 carried it across when `decimal128` was
removed — but the tolerance is *absolute*, so it is only correct inside a narrow
band of magnitudes.

**Above roughly `1e6`**, ten fractional digits behind a large integer part demand
more significant digits than a float64 carries, so the format prints the binary
error rather than the value. `999999999.99` becomes `"999999999.9900000095"` and
is rejected, even though the reporter's schema declares that same number as its
`maximum`:

```go
schema := &Schema{Type: &Types{"number"}, MultipleOf: Ptr(0.01),
    Min: Ptr(-999999999.99), Max: Ptr(999999999.99)}
schema.VisitJSON(999999999.99)  // error: number must be a multiple of 0.01
```

**Below roughly `5e-11`**, every operand formats to `"0.0000000000"`. A value
then becomes a multiple of anything, and a small `multipleOf` collapses the
denominator to zero, so `big.Rat.Quo` panics. Validating a document that merely
declares a small `multipleOf` takes the process down:

```go
var s Schema
json.Unmarshal([]byte(`{"type":"number","multipleOf":1e-12}`), &s)
s.Validate(context.Background())  // no error: nothing rejects this schema
s.VisitJSON(5.0)                  // panic: division by zero
```

`multipleOf: 0` panics the same way, and a negative `multipleOf` accepted every
number. `Schema.Validate` has no check that would stop such a document from
loading, so this is reachable from an ordinary specification.

### The change

Compare exact rationals instead of formatted decimals. `big.Rat.SetFloat64` is
exact, so there is no formatting step, no parse that can fail silently, and no
denominator that can collapse to zero.

The tolerance becomes relative to the value: accept when the quotient is an
integer, or when the nearest candidate multiple sits within `|value| * 2^-51` of
the value — a couple of units in the last place.

Measuring against the value rather than against the quotient matters. A
quotient-relative window grows without bound and would pass one half around
`2^49`, after which every number validates; `2^50` against `multipleOf: 3` is a
concrete case, and there is a regression test for it. The candidate multiples are
derived through `big.Int`, so no quotient can overflow.

### Behaviour changes

| input | before | after |
| --- | --- | --- |
| `999999999.99` with `multipleOf: 0.01` | rejected | accepted |
| `multipleOf` below the old decimal grid, e.g. `1e-12`, incl. subnormals | panic | validated |
| `multipleOf: 0` | panic | `multipleOf must be greater than zero` |
| negative `multipleOf` | accepted everything | `multipleOf must be greater than zero` |
| `1e-300` with `multipleOf: 0.01` | accepted (treated as zero) | rejected |
| `1.00000000004` with `multipleOf: 1` | accepted | rejected |

The last row is the one worth flagging: the window is now tied to float64
precision rather than to ten decimal places, so a value that differs from a
multiple by more than a few ULP is rejected where the old grid rounded it in.
Computed floats such as `0.1+0.2` against `multipleOf: 0.1` are unaffected.

One limit is inherent rather than chosen. When `multipleOf` is smaller than the
value's own ULP — `1e16` against `multipleOf: 3`, where consecutive float64
values are 2 apart — the question is not decidable from the stored number, and
the check accepts. No relative tolerance can both absorb one ULP at `0.3` and
reject a one-unit gap at `1e16`.

Two cases are deliberately left alone, with comments saying why: a non-finite
`multipleOf` is treated as no constraint, and a non-finite value keeps its
current outcome through the exported `VisitJSONNumber`. `SchemaError.Error()`
marshals both the value and the schema as JSON, and NaN has no JSON encoding, so
reporting either would panic while *formatting the error* — a worse outcome than
what is there now. Making `SchemaError` renderable for non-finite input is a
separate change. Note that `VisitJSON` already rejects non-finite input before
any keyword runs; only the exported number entry point reaches this code.

### Testing

`TestIssue817` gains the values from the report. A new
`TestSchemaMultipleOfAcrossMagnitudes` covers the invariant by scenario: large
magnitudes, preserved tolerance for computed floats, a `multipleOf` smaller than
the value's precision including a subnormal, a value far below the `multipleOf`,
zero, non-finite input, `multipleOf` bounds, a no-panic case for every previously
crashing input, and an assertion that the failure still names `multipleOf` in
`SchemaError.SchemaField`.

The computed-float cases go through a `//go:noinline` helper on purpose. Written
as a literal, `0.1+0.2` is folded exactly at compile time and the case would
assert nothing.

`go test ./openapi3/`, `go vet ./...`, and `gofmt -l .` are clean.
`go test ./...` is clean except `openapi2conv/TestIssue440`, which fails
identically on an unpatched checkout of the same base
(`invalid character '.' looking for beginning of value`) and is unrelated.
