### PR TITLE
openapi3: accept boolean schemas

### DIFF
--- a/.github/docs/openapi3.txt
+++ b/.github/docs/openapi3.txt
@@ -373,6 +373,12 @@ func (bs BoolSchema) MarshalYAML() (any, error)
 func (bs *BoolSchema) UnmarshalJSON(data []byte) error
     UnmarshalJSON sets BoolSchema to a copy of data.
 
+type BooleanSchemaFor31Plus struct{ ValidationError }
+
+func (e *BooleanSchemaFor31Plus) As(target any) bool
+
+func (e *BooleanSchemaFor31Plus) Code() string
+
 type Callback struct {
 	Extensions map[string]any `json:"-" yaml:"-"`
 	Origin     *Origin        `json:"-" yaml:"-"`
@@ -2774,6 +2780,17 @@ type Schema struct {
 
 	DependentRequired map[string][]string `json:"dependentRequired,omitempty" yaml:"dependentRequired,omitempty"` // OpenAPI >=3.1
 
+	// Always is set when the schema was written as a JSON Schema boolean
+	// schema rather than an object, and says what that schema always does:
+	// `true` accepts every instance, `false` accepts none. It is nil for an
+	// ordinary object schema, and Validate rejects one that carries any other
+	// keyword.
+	//
+	// Neither direction goes through a struct tag, hence the "-" on both:
+	// UnmarshalJSON takes the bare boolean before the field decode, and
+	// MarshalYAML emits it again ahead of the field map. OpenAPI >=3.1.
+	Always *bool `json:"-" yaml:"-"`
+
 	Defs          Schemas `json:"$defs,omitempty" yaml:"$defs,omitempty"`       // OpenAPI >=3.1
 	SchemaDialect string  `json:"$schema,omitempty" yaml:"$schema,omitempty"`   // OpenAPI >=3.1
 	Comment       string  `json:"$comment,omitempty" yaml:"$comment,omitempty"` // OpenAPI >=3.1
@@ -2941,6 +2958,12 @@ type SchemaAdditionalPropertiesBothForms struct{ ValidationError }
 func (e *SchemaAdditionalPropertiesBothForms) As(target any) bool
 
 func (e *SchemaAdditionalPropertiesBothForms) Code() string
+
+type SchemaBooleanFieldsExclusive struct{ ValidationError }
+
+func (e *SchemaBooleanFieldsExclusive) As(target any) bool
+
+func (e *SchemaBooleanFieldsExclusive) Code() string
 
 type SchemaBothFormsExclusive struct {
 	// Field is the name of the union-typed schema property

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -151,6 +151,17 @@ type Schema struct {
 
 	DependentRequired map[string][]string `json:"dependentRequired,omitempty" yaml:"dependentRequired,omitempty"` // OpenAPI >=3.1
 
+	// Always is set when the schema was written as a JSON Schema boolean
+	// schema rather than an object, and says what that schema always does:
+	// `true` accepts every instance, `false` accepts none. It is nil for an
+	// ordinary object schema, and Validate rejects one that carries any other
+	// keyword.
+	//
+	// Neither direction goes through a struct tag, hence the "-" on both:
+	// UnmarshalJSON takes the bare boolean before the field decode, and
+	// MarshalYAML emits it again ahead of the field map. OpenAPI >=3.1.
+	Always *bool `json:"-" yaml:"-"`
+
 	Defs          Schemas `json:"$defs,omitempty" yaml:"$defs,omitempty"`       // OpenAPI >=3.1
 	SchemaDialect string  `json:"$schema,omitempty" yaml:"$schema,omitempty"`   // OpenAPI >=3.1
 	Comment       string  `json:"$comment,omitempty" yaml:"$comment,omitempty"` // OpenAPI >=3.1
@@ -480,6 +491,10 @@ func (schema Schema) MarshalJSON() ([]byte, error) {
 
 // MarshalYAML returns the YAML encoding of Schema.
 func (schema Schema) MarshalYAML() (any, error) {
+	if x := schema.Always; x != nil {
+		return *x, nil
+	}
+
 	m := make(map[string]any, 61+len(schema.Extensions))
 	maps.Copy(m, schema.Extensions)
 
@@ -684,8 +699,28 @@ func (schema Schema) MarshalYAML() (any, error) {
 	return m, nil
 }
 
+// unmarshalBooleanSchema reports whether data is a JSON Schema boolean schema,
+// and its value if so. Only a bare `true` or `false` qualifies; an object, a
+// string or anything else is an ordinary schema for the caller to decode.
+func unmarshalBooleanSchema(data []byte) (bool, bool) {
+	var boolean bool
+	if err := json.Unmarshal(data, &boolean); err != nil {
+		return false, false
+	}
+	return boolean, true
+}
+
 // UnmarshalJSON sets Schema to a copy of data.
 func (schema *Schema) UnmarshalJSON(data []byte) error {
+	// JSON Schema 2020-12 allows a boolean wherever a schema is expected, so
+	// every SchemaRef position can hold one. SchemaRef.UnmarshalJSON funnels
+	// into here, which is why this one case covers them all.
+	if boolean, ok := unmarshalBooleanSchema(data); ok {
+		origin := schema.Origin
+		*schema = Schema{Always: &boolean, Origin: origin}
+		return nil
+	}
+
 	type SchemaBis Schema
 	var x SchemaBis
 	if err := json.Unmarshal(data, &x); err != nil {
@@ -1379,6 +1414,14 @@ func (schema *Schema) IsEmpty() bool {
 	if cs := schema.ContentSchema; cs != nil && cs.Value != nil && !cs.Value.IsEmpty() {
 		return false
 	}
+	// Last, so a schema carrying both a boolean and other keywords is judged by
+	// the keywords. Neither boolean is empty: `false` rejects every instance,
+	// and `true` is accepted by visitJSON explicitly rather than by skipping
+	// validation, which is what leaves `not: true` free to reject.
+	if schema.Always != nil {
+		return false
+	}
+
 	return true
 }
 
@@ -1401,6 +1444,23 @@ func (schema *Schema) validate(ctx context.Context, stack []*Schema) ([]*Schema,
 	validationOpts := getValidationOptions(ctx)
 
 	stack = append(stack, schema)
+
+	// A boolean schema carries no other keyword. One that does would marshal
+	// back as the bare boolean and silently drop the rest, so reject it rather
+	// than let a hand-built value lose content on the next serialization.
+	if schema.Always != nil {
+		// A boolean schema is JSON Schema 2020-12, so 3.0 has no such thing:
+		// there a schema MUST be a Schema Object.
+		if !validationOpts.isOpenAPI31OrLater {
+			return stack, newBooleanSchemaFor31Plus(schema.Origin)
+		}
+		rest := *schema
+		rest.Always = nil
+		if !rest.IsEmpty() || len(schema.Extensions) != 0 {
+			return stack, newSchemaBooleanFieldsExclusive(schema.Origin)
+		}
+		return stack, nil
+	}
 
 	if schema.ReadOnly && schema.WriteOnly {
 		return stack, newSchemaReadOnlyWriteOnlyExclusive(schema.Origin)
@@ -1971,6 +2031,22 @@ func (schema *Schema) visitJSON(settings *schemaValidationSettings, value any) (
 		}
 		if math.IsInf(value, 0) {
 			return ErrSchemaInputInf
+		}
+	}
+
+	if x := schema.Always; x != nil {
+		if *x {
+			return
+		}
+		if settings.failfast {
+			return errSchema
+		}
+		return &SchemaError{
+			Value:                 value,
+			Schema:                schema,
+			SchemaField:           "boolean",
+			Reason:                "the false schema accepts no value",
+			customizeMessageError: settings.customizeMessageError,
 		}
 	}
 

--- a/openapi3/schema_boolean_test.go
+++ b/openapi3/schema_boolean_test.go
@@ -1,0 +1,245 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// JSON Schema 2020-12, which OpenAPI 3.1 adopts, allows a boolean wherever a
+// schema is expected: `true` accepts every instance and `false` accepts none.
+const booleanSchemaSpec = `
+openapi: 3.1.0
+info:
+  title: boolean schemas
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    ClosedTuple:
+      type: array
+      prefixItems:
+        - type: string
+        - type: integer
+      items: false
+    OpenPosition:
+      type: array
+      prefixItems:
+        - true
+        - type: string
+    Anything:
+      not: false
+    Nothing:
+      not: true
+    NoExtraProps:
+      type: object
+      properties:
+        name:
+          type: string
+        anything: true
+`
+
+func loadBooleanSchemas(t *testing.T) *openapi3.T {
+	t.Helper()
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(booleanSchemaSpec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(loader.Context))
+
+	return doc
+}
+
+// Every position that holds a SchemaRef accepts a boolean, since they all
+// decode through Schema.UnmarshalJSON.
+func TestBooleanSchema_Positions(t *testing.T) {
+	schemas := loadBooleanSchemas(t).Components.Schemas
+
+	for _, test := range []struct {
+		name   string
+		schema *openapi3.Schema
+		want   bool
+	}{
+		{"items", schemas["ClosedTuple"].Value.Items.Value, false},
+		{"prefixItems", schemas["OpenPosition"].Value.PrefixItems[0].Value, true},
+		{"not false", schemas["Anything"].Value.Not.Value, false},
+		{"not true", schemas["Nothing"].Value.Not.Value, true},
+		{"properties", schemas["NoExtraProps"].Value.Properties["anything"].Value, true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotNil(t, test.schema.Always, "should have decoded as a boolean schema")
+			require.Equal(t, test.want, *test.schema.Always)
+		})
+	}
+}
+
+// `true` accepts anything, including null; `false` accepts nothing, including
+// null. A boolean schema constrains the instance and nothing else.
+func TestBooleanSchema_VisitJSON(t *testing.T) {
+	schemas := loadBooleanSchemas(t).Components.Schemas
+
+	trueSchema := schemas["OpenPosition"].Value.PrefixItems[0].Value
+	falseSchema := schemas["ClosedTuple"].Value.Items.Value
+
+	for _, value := range []any{"a string", float64(1), true, nil, []any{}, map[string]any{}} {
+		require.NoError(t, trueSchema.VisitJSON(value))
+		require.Error(t, falseSchema.VisitJSON(value))
+	}
+}
+
+// `items: false` closes a tuple at the prefixItems length: an array that is a
+// prefix of the tuple is valid, and any element past the prefix is rejected,
+// since no prefixItems entry covers that position and items forbids it.
+func TestBooleanSchema_FalseItemsClosesTuple(t *testing.T) {
+	closed := loadBooleanSchemas(t).Components.Schemas["ClosedTuple"].Value
+
+	require.NoError(t, closed.VisitJSON([]any{}))
+	require.NoError(t, closed.VisitJSON([]any{"a"}))
+	require.NoError(t, closed.VisitJSON([]any{"a", float64(1)}))
+
+	require.Error(t, closed.VisitJSON([]any{"a", float64(1), "extra"}), "items: false forbids a third element")
+	require.Error(t, closed.VisitJSON([]any{float64(1), "a"}), "prefixItems is positional")
+}
+
+// A boolean schema marshals back to the bare boolean it was written as, not to
+// the object it is equivalent to.
+func TestBooleanSchema_RoundTrip(t *testing.T) {
+	const spec = `{"openapi":"3.1.0","info":{"title":"t","version":"1.0"},"paths":{},"components":{"schemas":{"Tuple":{"items":false,"prefixItems":[{"type":"string"}],"type":"array"},"Any":{"not":true}}}}`
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	data, err := doc.MarshalJSON()
+	require.NoError(t, err)
+	require.JSONEq(t, spec, string(data))
+}
+
+// Neither boolean is empty. `false` rejects every instance, and `true` is
+// accepted by visitJSON explicitly rather than by skipping validation, which is
+// what leaves `not: true` free to reject.
+func TestBooleanSchema_IsEmpty(t *testing.T) {
+	schemas := loadBooleanSchemas(t).Components.Schemas
+
+	require.False(t, schemas["OpenPosition"].Value.PrefixItems[0].Value.IsEmpty())
+	require.False(t, schemas["ClosedTuple"].Value.Items.Value.IsEmpty())
+}
+
+// An ordinary schema is unaffected: Boolean stays nil so nothing short-circuits.
+func TestBooleanSchema_ObjectSchemaUnaffected(t *testing.T) {
+	schemas := loadBooleanSchemas(t).Components.Schemas
+
+	name := schemas["NoExtraProps"].Value.Properties["name"].Value
+	require.Nil(t, name.Always)
+	require.NoError(t, name.VisitJSON("a string"))
+	require.Error(t, name.VisitJSON(float64(1)))
+}
+
+// `not` inverts the boolean, so the composition is what matters and not just
+// the decoded value: `not: true` matches nothing and `not: false` matches
+// everything.
+func TestBooleanSchema_UnderNot(t *testing.T) {
+	schemas := loadBooleanSchemas(t).Components.Schemas
+
+	anything := schemas["Anything"].Value
+	nothing := schemas["Nothing"].Value
+
+	// Null is left out: whether a schema admits it is decided by kin's
+	// nullability rules before `not` is reached, and a boolean does not change
+	// that either way.
+	for _, value := range []any{"a string", float64(1), []any{}, map[string]any{}} {
+		require.NoError(t, anything.VisitJSON(value), "not: false matches everything")
+		require.Error(t, nothing.VisitJSON(value), "not: true matches nothing")
+	}
+}
+
+// A Schema built in code can carry a boolean alongside other keywords. It would
+// marshal back as the bare boolean and drop them, so Validate rejects it rather
+// than let the next serialization lose content.
+func TestBooleanSchema_RejectsOtherKeywords(t *testing.T) {
+	boolean := true
+
+	// A boolean schema is 3.1, so say so; without it the version gate fires
+	// first, as it does for every other 2020-12 construct.
+	as31 := openapi3.IsOpenAPI31OrLater()
+
+	require.NoError(t, (&openapi3.Schema{Always: &boolean}).Validate(t.Context(), as31))
+
+	for name, schema := range map[string]*openapi3.Schema{
+		"type":       {Always: &boolean, Type: &openapi3.Types{"string"}},
+		"properties": {Always: &boolean, Properties: openapi3.Schemas{"a": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}}}},
+		"extensions": {Always: &boolean, Extensions: map[string]any{"x-a": 1}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := schema.Validate(t.Context(), as31)
+			require.Error(t, err)
+			var exclusive *openapi3.MutuallyExclusiveFieldsError
+			require.ErrorAs(t, err, &exclusive)
+		})
+	}
+}
+
+// VisitJSON documents EnableJSONSchema2020 as the way to validate a 3.1
+// schema, and a boolean schema exists only in 3.1, so the option's path has to
+// agree with the built-in one.
+//
+// It is not purely external: useJSONSchema2020 falls back to visitJSON when the
+// schema does not compile, which is what a bare boolean at the root does, so
+// both paths are exercised here.
+func TestBooleanSchema_JSONSchema2020(t *testing.T) {
+	schemas := loadBooleanSchemas(t).Components.Schemas
+	opt := openapi3.EnableJSONSchema2020()
+
+	trueSchema := schemas["OpenPosition"].Value.PrefixItems[0].Value
+	falseSchema := schemas["ClosedTuple"].Value.Items.Value
+
+	for _, value := range []any{"a string", float64(1), []any{}, map[string]any{}} {
+		require.NoError(t, trueSchema.VisitJSON(value, opt))
+		require.Error(t, falseSchema.VisitJSON(value, opt))
+	}
+
+	require.NoError(t, schemas["Anything"].Value.VisitJSON(float64(1), opt), "not: false matches everything")
+	require.Error(t, schemas["Nothing"].Value.VisitJSON(float64(1), opt), "not: true matches nothing")
+}
+
+// The 2020-12 validator has to agree with the built-in one about a closed
+// tuple, since a document does not say which validator will read it.
+func TestBooleanSchema_ClosesTupleUnder2020(t *testing.T) {
+	closed := loadBooleanSchemas(t).Components.Schemas["ClosedTuple"].Value
+	opt := openapi3.EnableJSONSchema2020()
+
+	require.NoError(t, closed.VisitJSON([]any{"a", float64(1)}, opt))
+	require.Error(t, closed.VisitJSON([]any{"a", float64(1), "extra"}, opt),
+		"items: false must reject a position past prefixItems")
+	require.Error(t, closed.VisitJSON([]any{float64(1), "a"}, opt),
+		"prefixItems is positional")
+}
+
+// A boolean schema is JSON Schema 2020-12, so it does not exist in 3.0, where a
+// schema MUST be a Schema Object. Validate says so rather than accepting it.
+func TestBooleanSchema_RejectedBefore31(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info:
+  title: t
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Closed:
+      type: array
+      items: false
+`
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err, "it still parses; the version is a validation matter")
+
+	err = doc.Validate(loader.Context)
+	require.Error(t, err)
+
+	var mismatch *openapi3.FieldVersionMismatchError
+	require.ErrorAs(t, err, &mismatch)
+	require.Equal(t, "3.1", mismatch.MinVersion)
+}

--- a/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_commerce_1_1_openapi_yaml__load
+++ b/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_commerce_1_1_openapi_yaml__load
@@ -1,1 +1,0 @@
-failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema

--- a/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_commerce_1_1_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_commerce_1_1_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid components: schema "Companies": invalid allOf element: extra sibling fields: [definitions]

--- a/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_expenses_prealpha_openapi_yaml__load
+++ b/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_expenses_prealpha_openapi_yaml__load
@@ -1,1 +1,0 @@
-failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema

--- a/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_expenses_prealpha_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/codat_io_sync_for_expenses_prealpha_openapi_yaml__validate
@@ -1,0 +1,1 @@
+invalid components: schema "DataConnection": extra sibling fields: [definitions]

--- a/openapi3/testdata/apis_guru_openapi_directory/vercel_com_0_0_1_openapi_yaml__load
+++ b/openapi3/testdata/apis_guru_openapi_directory/vercel_com_0_0_1_openapi_yaml__load
@@ -1,1 +1,0 @@
-failed to unmarshal data: json error: invalid character 'o' looking for beginning of value, yaml error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema

--- a/openapi3/testdata/apis_guru_openapi_directory/vercel_com_0_0_1_openapi_yaml__validate
+++ b/openapi3/testdata/apis_guru_openapi_directory/vercel_com_0_0_1_openapi_yaml__validate
@@ -1,0 +1,6 @@
+invalid paths: invalid path /v1/teams/{teamId}/members/{uid}: invalid operation PATCH: invalid default: validation failed due to: at '': got array, want string
+Schema:
+  null
+
+Value:
+  null

--- a/openapi3/validation_code.go
+++ b/openapi3/validation_code.go
@@ -42,6 +42,7 @@ func (e *APIKeyInInvalidError) Code() string             { return "security-sche
 func (e *APIKeySecuritySchemeNameRequired) Code() string { return "security-scheme-name-required" }
 func (e *CommentFieldFor31Plus) Code() string            { return "comment-field-for-3-1-plus" }
 func (e *ConflictingPathsError) Code() string            { return "conflicting-paths" }
+func (e *BooleanSchemaFor31Plus) Code() string           { return "boolean-schema-for-3-1-plus" }
 func (e *ConstFieldFor31Plus) Code() string              { return "const-field-for-3-1-plus" }
 func (e *ContainsFieldFor31Plus) Code() string           { return "contains-field-for-3-1-plus" }
 func (e *ContentEncodingFieldFor31Plus) Code() string    { return "content-encoding-field-for-3-1-plus" }
@@ -141,6 +142,9 @@ func (e *SchemaPatternRegexError) Code() string { return "schema-pattern-regex-i
 func (e *SchemaReadOnlyWriteOnlyExclusive) Code() string {
 	return "read-only-write-only-mutually-exclusive"
 }
+func (e *SchemaBooleanFieldsExclusive) Code() string {
+	return "boolean-schema-with-other-keywords"
+}
 func (e *SchemaTypeError) Code() string { return "schema-type-unsupported" }
 func (e *SchemaUnevaluatedItemsBothForms) Code() string {
 	return "unevaluated-items-both-forms-exclusive"
@@ -180,6 +184,8 @@ var validationErrorCodes = []string{
 	"anchor-field-for-3-1-plus",
 	"authorization-url-forbidden",
 	"bearer-format-forbidden",
+	"boolean-schema-for-3-1-plus",
+	"boolean-schema-with-other-keywords",
 	"comment-field-for-3-1-plus",
 	"conflicting-paths",
 	"const-field-for-3-1-plus",

--- a/openapi3/validation_code_test.go
+++ b/openapi3/validation_code_test.go
@@ -100,6 +100,8 @@ func codedErrorInventory() []openapi3.CodedError {
 		&openapi3.SchemaItemsRequired{},
 		&openapi3.SchemaPatternRegexError{},
 		&openapi3.SchemaReadOnlyWriteOnlyExclusive{},
+		&openapi3.SchemaBooleanFieldsExclusive{},
+		&openapi3.BooleanSchemaFor31Plus{},
 		&openapi3.SchemaTypeError{},
 		&openapi3.SchemaUnevaluatedItemsBothForms{},
 		&openapi3.SchemaUnevaluatedPropertiesBothForms{},

--- a/openapi3/validation_error.go
+++ b/openapi3/validation_error.go
@@ -914,6 +914,12 @@ func (e *SchemaReadOnlyWriteOnlyExclusive) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
+type SchemaBooleanFieldsExclusive struct{ ValidationError }
+
+func (e *SchemaBooleanFieldsExclusive) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
 // ForbiddenFieldError leaves.
 
 type HeaderNameForbidden struct{ ValidationError }
@@ -972,6 +978,12 @@ func (e *JSONSchemaDialectFieldFor31Plus) As(target any) bool {
 type ConstFieldFor31Plus struct{ ValidationError }
 
 func (e *ConstFieldFor31Plus) As(target any) bool {
+	return asValidationError(target, &e.ValidationError)
+}
+
+type BooleanSchemaFor31Plus struct{ ValidationError }
+
+func (e *BooleanSchemaFor31Plus) As(target any) bool {
 	return asValidationError(target, &e.ValidationError)
 }
 
@@ -1359,6 +1371,12 @@ func newSchemaReadOnlyWriteOnlyExclusive(origin *Origin) error {
 		&SchemaReadOnlyWriteOnlyExclusive{ValidationError{Message: msg}}, origin)
 }
 
+func newSchemaBooleanFieldsExclusive(origin *Origin) error {
+	const msg = "a boolean schema carries no other keyword, and the others would be lost on marshal"
+	return newMutuallyExclusiveFields("boolean schema", "schema keywords",
+		&SchemaBooleanFieldsExclusive{ValidationError{Message: msg}}, origin)
+}
+
 // newForbiddenField wraps leaf in a *ForbiddenFieldError carrying the
 // name of the field that the spec forbids in the current context.
 func newForbiddenField(field string, leaf error, origin *Origin) error {
@@ -1487,6 +1505,12 @@ func newLicenseIdentifierFieldFor31Plus(origin *Origin) error {
 	const msg = "field identifier is for OpenAPI >=3.1"
 	return newFieldVersionMismatch("identifier",
 		"3.1", &LicenseIdentifierFieldFor31Plus{ValidationError{Message: msg}}, origin)
+}
+
+func newBooleanSchemaFor31Plus(origin *Origin) error {
+	const msg = "a boolean schema is for OpenAPI >=3.1; before that a schema MUST be a Schema Object"
+	return newFieldVersionMismatch("boolean schema",
+		"3.1", &BooleanSchemaFor31Plus{ValidationError{Message: msg}}, origin)
 }
 
 func newWebhooksFieldFor31Plus(origin *Origin) error {


### PR DESCRIPTION
Fixes #1257.

JSON Schema 2020-12, which OpenAPI 3.1 adopts, allows a boolean wherever a schema is expected. `true` accepts every instance, `false` accepts none. Every schema-valued keyword is typed `*SchemaRef` or `SchemaRefs`, so a boolean in one of those positions fails to unmarshal and takes the whole document with it:

```
json: cannot unmarshal bool into field Schema.items of type openapi3.Schema
```

## Approach

`SchemaRef.UnmarshalJSON` ends in `json.Unmarshal(data, &x.Value)`, so every schema-valued position funnels through `Schema.UnmarshalJSON`. Handling a bare boolean there covers `items`, `prefixItems`, `not`, `contains`, `if` / `then` / `else`, the values of `properties`, `$defs` and the rest in one place, rather than widening each field individually.

The result is recorded in a new field:

```go
// Boolean is set when the schema was written as a JSON Schema boolean
// schema rather than an object: `true` accepts every instance, `false`
// accepts none. It is nil for an ordinary object schema, and Validate
// rejects one that carries any other keyword.
//
// Neither direction goes through a struct tag, hence the "-" on both:
// UnmarshalJSON takes the bare boolean before the field decode, and
// MarshalYAML emits it again ahead of the field map. OpenAPI >=3.1.
Boolean *bool `json:"-" yaml:"-"`
```

Around it:

- `MarshalYAML` emits the bare boolean, so a document round-trips to what it was written as rather than to the object it is equivalent to.
- `visitJSON` accepts `true` and rejects `false` explicitly, ahead of the `IsEmpty` short circuit that would otherwise let `false` accept everything.
- `IsEmpty` reports neither boolean as empty, and consults the field last so a schema carrying both a boolean and other keywords is judged by the keywords. Reporting `true` as empty would make `visitJSON` skip validation, which is how `not: true` would come to accept every value when it should accept none.
- `Validate` rejects a `Boolean` set alongside any other keyword or extension, under a new `boolean-schema-with-other-keywords` code in the `MutuallyExclusiveFieldsError` cluster. Such a schema would marshal back as the bare boolean and drop the rest, so it is refused rather than left to lose content on the next serialization.

This is additive. `Boolean` is nil for an ordinary schema and no existing field changes type, so callers reading `schema.Items.Value` are unaffected. Choosing this over widening the fields to `BoolSchema` keeps the change out of the many call sites that use `Items` and friends today.

## Corpus

Three documents in the APIs-guru corpus were failing to load for exactly this reason. Their goldens move from `__load` to `__validate`, where they now report unrelated pre-existing complaints. For example the previous `codat.io/sync-for-commerce` golden was:

```
failed to unmarshal data: json error: invalid character 'o' looking for beginning of value,
yaml error: ... json: cannot unmarshal bool into field Schema.properties of type openapi3.Schema
```

## Tests

`openapi3/schema_boolean_test.go` covers a boolean in each of `items`, `prefixItems`, `not` and a `properties` value; instance validation of both booleans against every JSON type including null; the marshal round-trip; `IsEmpty`; and that an ordinary object schema is unchanged.

It also covers the compositions, which are where a boolean stops being trivial:

- `not: true` matches nothing and `not: false` matches everything, asserted through the composition rather than only on the decoded value.
- `Validate` refusing a `Boolean` next to a type, a property or an extension.
- Both validation paths. `VisitJSON` documents `EnableJSONSchema2020` as the way to validate a 3.1 schema, and a boolean schema exists only in 3.1, so the option's path is asserted to agree with the built-in one. It is not purely external either: `useJSONSchema2020` falls back to `visitJSON` when the schema does not compile, which a bare boolean at the root does.
- `items: false` closing a tuple at the `prefixItems` length, on both paths.

## Closed tuples

`items: false` is how a tuple is closed to a fixed length, so it is the idiom this change exists to make expressible. It works end to end now that #1259 has landed on master and `visitJSONArray` applies `items` only to the positions past `prefixItems`: under `prefixItems: [string, integer]` with `items: false`, a prefix such as `["a"]` is valid and a third element is refused. The built-in and 2020-12 validators agree on it, and both are asserted.

## Checks

`go generate`, `maps.sh`, `docs.sh`, `go mod tidy`, `go vet`, `go fmt`, `nilness` and the style greps all pass. `modernize` reports two findings, both present on master and in files this does not touch. Full suite green, including `-count=10 -short`.
