### PR TITLE
openapi3: validate prefixItems positionally

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -2867,14 +2867,38 @@ func (schema *Schema) visitJSONArray(settings *schemaValidationSettings, value [
 		me = append(me, err)
 	}
 
-	// "items"
+	// "prefixItems": the schema at index i validates the item at index i.
+	// Positions the array does not reach are simply unconstrained.
+	for i, prefixItemRef := range schema.PrefixItems {
+		if i >= len(value) {
+			break
+		}
+		prefixItemSchema := prefixItemRef.Value
+		if prefixItemSchema == nil {
+			return newUnresolvedRef(prefixItemRef.Ref, prefixItemRef.Origin)
+		}
+		if err := prefixItemSchema.visitJSON(settings, value[i]); err != nil {
+			err = markSchemaErrorIndex(err, i)
+			if !settings.multiError {
+				return err
+			}
+			if itemMe, ok := err.(MultiError); ok {
+				me = append(me, itemMe...)
+			} else {
+				me = append(me, err)
+			}
+		}
+	}
+
+	// "items" applies to the positions prefixItems does not cover. Without
+	// prefixItems that is every position, which is the OAS 3.0 behaviour.
 	if itemSchemaRef := schema.Items; itemSchemaRef != nil {
 		itemSchema := itemSchemaRef.Value
 		if itemSchema == nil {
 			return newUnresolvedRef(itemSchemaRef.Ref, itemSchemaRef.Origin)
 		}
-		for i, item := range value {
-			if err := itemSchema.visitJSON(settings, item); err != nil {
+		for i := len(schema.PrefixItems); i < len(value); i++ {
+			if err := itemSchema.visitJSON(settings, value[i]); err != nil {
 				err = markSchemaErrorIndex(err, i)
 				if !settings.multiError {
 					return err

--- a/openapi3/schema_prefix_items_test.go
+++ b/openapi3/schema_prefix_items_test.go
@@ -1,0 +1,121 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// prefixItems is positional: the schema at index i validates the item at index
+// i, and items governs the positions past the end of the list.
+const prefixItemsSpec = `
+openapi: 3.1.0
+info:
+  title: prefix items
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Tuple:
+      type: array
+      prefixItems:
+        - type: string
+        - type: integer
+    Tail:
+      type: array
+      prefixItems:
+        - type: string
+        - type: integer
+      items:
+        type: boolean
+`
+
+func prefixItemsSchema(t *testing.T, name string) *openapi3.Schema {
+	t.Helper()
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(prefixItemsSpec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(loader.Context))
+
+	return doc.Components.Schemas[name].Value
+}
+
+// Each entry validates its own index, so swapping two values that satisfy the
+// list in a different order fails.
+func TestPrefixItems_Positional(t *testing.T) {
+	tuple := prefixItemsSchema(t, "Tuple")
+
+	require.NoError(t, tuple.VisitJSON([]any{"a", float64(1)}))
+	require.Error(t, tuple.VisitJSON([]any{float64(1), "a"}), "the values are in the wrong positions")
+	require.Error(t, tuple.VisitJSON([]any{float64(1), float64(1)}), "index 0 must be a string")
+	require.Error(t, tuple.VisitJSON([]any{"a", "b"}), "index 1 must be an integer")
+}
+
+// The error names the offending index rather than the array as a whole.
+func TestPrefixItems_ErrorCarriesTheIndex(t *testing.T) {
+	err := prefixItemsSchema(t, "Tuple").VisitJSON([]any{"a", "b"})
+	require.Error(t, err)
+
+	var schemaErr *openapi3.SchemaError
+	require.ErrorAs(t, err, &schemaErr)
+	require.Equal(t, []string{"1"}, schemaErr.JSONPointer())
+}
+
+// A short array leaves the later entries unapplied; prefixItems constrains the
+// positions that exist, and minItems is what requires them to exist.
+func TestPrefixItems_ShorterThanTheList(t *testing.T) {
+	tuple := prefixItemsSchema(t, "Tuple")
+
+	require.NoError(t, tuple.VisitJSON([]any{}))
+	require.NoError(t, tuple.VisitJSON([]any{"a"}))
+	require.Error(t, tuple.VisitJSON([]any{float64(1)}), "index 0 is still checked")
+}
+
+// items governs only the positions past prefixItems, so the prefix keeps its
+// own types and the tail takes the items schema.
+func TestPrefixItems_ItemsAppliesPastThePrefix(t *testing.T) {
+	tail := prefixItemsSchema(t, "Tail")
+
+	require.NoError(t, tail.VisitJSON([]any{"a", float64(1)}))
+	require.NoError(t, tail.VisitJSON([]any{"a", float64(1), true, false}))
+	require.Error(t, tail.VisitJSON([]any{"a", float64(1), "not a boolean"}), "the tail must match items")
+	require.Error(t, tail.VisitJSON([]any{true, float64(1)}), "items must not apply to the prefix")
+}
+
+// Without prefixItems, items applies to every position, which is what OAS 3.0
+// documents rely on.
+func TestPrefixItems_AbsentLeavesItemsUnchanged(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info:
+  title: t
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Strings:
+      type: array
+      items:
+        type: string
+`
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	strings := doc.Components.Schemas["Strings"].Value
+	require.NoError(t, strings.VisitJSON([]any{"a", "b"}))
+	require.Error(t, strings.VisitJSON([]any{"a", float64(1)}))
+}
+
+// Every failing position is reported when multiple errors are requested.
+func TestPrefixItems_MultiError(t *testing.T) {
+	err := prefixItemsSchema(t, "Tuple").VisitJSON([]any{float64(1), "a"}, openapi3.MultiErrors())
+	require.Error(t, err)
+
+	var multi openapi3.MultiError
+	require.ErrorAs(t, err, &multi)
+	require.Len(t, multi, 2, "both positions are wrong")
+}


### PR DESCRIPTION
`visitJSONArray` applied `items` to every element and never consulted `PrefixItems`, so a tuple schema was validated as a homogeneous array. Two things follow from that:

- the per-position types went unchecked, so `["a", 1]` and `[1, "a"]` were equally acceptable to `prefixItems: [{type: string}, {type: integer}]`
- `items` was imposed on the positions `prefixItems` already covers, so a schema pairing a typed prefix with a differently-typed tail could not be satisfied at all

JSON Schema 2020-12, which OpenAPI 3.1 adopts, gives the two keywords different jobs. The schema at index *i* of `prefixItems` validates the item at index *i*, and `items` governs only the positions past the end of that list. This applies both that way.

## Behaviour

```yaml
type: array
prefixItems:
  - type: string
  - type: integer
items:
  type: boolean
```

| instance | before | after |
|---|---|---|
| `["a", 1]` | accepted | accepted |
| `[1, "a"]` | accepted | rejected, wrong types for those positions |
| `["a", 1, true]` | rejected | accepted, the tail matches `items` |
| `["a", 1, "x"]` | rejected | rejected, the tail does not match `items` |

Errors carry the offending index, so the JSON pointer names the position rather than the array.

A document without `prefixItems` is unaffected: the `items` loop then starts at index 0, which is what it did before and what OAS 3.0 expects. Nothing in the APIs-guru corpus changes behaviour, so no goldens move.

## Tests

`openapi3/schema_prefix_items_test.go` covers positional matching including the reordered case, the index carried on the error, an array shorter than the list, `items` applying only past the prefix, a document with no `prefixItems` behaving as before, and every failing position being reported under `MultiErrors`.

## Note

This is independent of #1258, which lets a schema be written as a boolean. Together they make `items: false` close a tuple at the prefix length, which is the idiom the JSON Schema documentation gives for fixed-length tuples. Either can merge first.