### PR TITLE
openapi3: reject every value for `not: {}`

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1281,7 +1281,12 @@ func (schema *Schema) IsEmpty() bool {
 		schema.Const != nil {
 		return false
 	}
-	if n := schema.Not; n != nil && n.Value != nil && !n.Value.IsEmpty() {
+	// A `not` is a constraint whatever it holds, and an empty one is the
+	// strongest of all: `not: {}` matches nothing, since the empty schema
+	// matches everything. Judging it by whether its own value is empty had the
+	// effect of dropping it, and visitJSON skips an empty schema entirely, so
+	// `not: {}` accepted every value instead of rejecting every value.
+	if schema.Not != nil {
 		return false
 	}
 	if ap := schema.AdditionalProperties.Schema; ap != nil && ap.Value != nil && !ap.Value.IsEmpty() {

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1281,11 +1281,9 @@ func (schema *Schema) IsEmpty() bool {
 		schema.Const != nil {
 		return false
 	}
-	// A `not` is a constraint whatever it holds, and an empty one is the
-	// strongest of all: `not: {}` matches nothing, since the empty schema
-	// matches everything. Judging it by whether its own value is empty had the
-	// effect of dropping it, and visitJSON skips an empty schema entirely, so
-	// `not: {}` accepted every value instead of rejecting every value.
+	// A `not` constrains the schema whatever it holds, and an empty one is the
+	// strongest constraint of all: `not: {}` matches nothing, since the empty
+	// schema matches everything.
 	if schema.Not != nil {
 		return false
 	}

--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -1281,9 +1281,8 @@ func (schema *Schema) IsEmpty() bool {
 		schema.Const != nil {
 		return false
 	}
-	// A `not` constrains the schema whatever it holds, and an empty one is the
-	// strongest constraint of all: `not: {}` matches nothing, since the empty
-	// schema matches everything.
+	// Any `not` makes the schema non-empty, an empty one included: `not: {}`
+	// matches nothing, since the empty schema matches everything.
 	if schema.Not != nil {
 		return false
 	}

--- a/openapi3/schema_not_empty_test.go
+++ b/openapi3/schema_not_empty_test.go
@@ -1,0 +1,69 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// The empty schema matches every instance, so `not: {}` matches none. Judging
+// the `not` by whether its own value is empty dropped it from IsEmpty, and
+// visitJSON skips an empty schema, so the schema accepted every value instead.
+func TestNot_EmptySubschemaRejectsEverything(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info:
+  title: t
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Nothing:
+      not: {}
+    NothingNested:
+      properties:
+        a:
+          not: {}
+`
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(loader.Context))
+
+	nothing := doc.Components.Schemas["Nothing"].Value
+	require.False(t, nothing.IsEmpty(), "a not is a constraint whatever it holds")
+
+	for _, value := range []any{"a string", float64(1), true, []any{}, map[string]any{}} {
+		require.Error(t, nothing.VisitJSON(value))
+	}
+
+	// The same through a property, so the fix is not limited to a root schema.
+	nested := doc.Components.Schemas["NothingNested"].Value
+	require.Error(t, nested.VisitJSON(map[string]any{"a": "anything"}))
+	require.NoError(t, nested.VisitJSON(map[string]any{}))
+}
+
+// A non-empty `not` was already rejected and stays rejected.
+func TestNot_NonEmptySubschemaUnchanged(t *testing.T) {
+	const spec = `
+openapi: 3.0.0
+info:
+  title: t
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    NotAString:
+      not:
+        type: string
+`
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+
+	s := doc.Components.Schemas["NotAString"].Value
+	require.Error(t, s.VisitJSON("a string"))
+	require.NoError(t, s.VisitJSON(float64(1)))
+}

--- a/openapi3/schema_not_empty_test.go
+++ b/openapi3/schema_not_empty_test.go
@@ -33,7 +33,9 @@ components:
 	nothing := doc.Components.Schemas["Nothing"].Value
 	require.False(t, nothing.IsEmpty(), "a not constrains the schema whatever it holds")
 
-	for _, value := range []any{"a string", float64(1), true, []any{}, map[string]any{}} {
+	// null included: `{}` places no type constraint, so it matches every
+	// instance and `not: {}` matches none of them.
+	for _, value := range []any{"a string", float64(1), true, nil, []any{}, map[string]any{}} {
 		require.Error(t, nothing.VisitJSON(value))
 	}
 
@@ -41,6 +43,32 @@ components:
 	nested := doc.Components.Schemas["NothingNested"].Value
 	require.Error(t, nested.VisitJSON(map[string]any{"a": "anything"}))
 	require.NoError(t, nested.VisitJSON(map[string]any{}))
+}
+
+// 3.1 reaches the same result. `{}` is a JSON Schema 2020-12 schema there
+// rather than an OAS Schema Object, but an empty one is unconstrained either
+// way, so there is nothing version dependent to gate.
+func TestNot_EmptySubschemaRejectsEverythingIn31(t *testing.T) {
+	const spec = `
+openapi: 3.1.0
+info:
+  title: t
+  version: "1.0"
+paths: {}
+components:
+  schemas:
+    Nothing:
+      not: {}
+`
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(spec))
+	require.NoError(t, err)
+	require.NoError(t, doc.Validate(loader.Context))
+
+	nothing := doc.Components.Schemas["Nothing"].Value
+	for _, value := range []any{"a string", float64(1), true, nil, []any{}, map[string]any{}} {
+		require.Error(t, nothing.VisitJSON(value))
+	}
 }
 
 // A `not` holding a schema rejects exactly the values that schema matches.

--- a/openapi3/schema_not_empty_test.go
+++ b/openapi3/schema_not_empty_test.go
@@ -8,9 +8,7 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// The empty schema matches every instance, so `not: {}` matches none. Judging
-// the `not` by whether its own value is empty dropped it from IsEmpty, and
-// visitJSON skips an empty schema, so the schema accepted every value instead.
+// The empty schema matches every instance, so `not: {}` matches none.
 func TestNot_EmptySubschemaRejectsEverything(t *testing.T) {
 	const spec = `
 openapi: 3.0.0
@@ -33,19 +31,19 @@ components:
 	require.NoError(t, doc.Validate(loader.Context))
 
 	nothing := doc.Components.Schemas["Nothing"].Value
-	require.False(t, nothing.IsEmpty(), "a not is a constraint whatever it holds")
+	require.False(t, nothing.IsEmpty(), "a not constrains the schema whatever it holds")
 
 	for _, value := range []any{"a string", float64(1), true, []any{}, map[string]any{}} {
 		require.Error(t, nothing.VisitJSON(value))
 	}
 
-	// The same through a property, so the fix is not limited to a root schema.
+	// The same through a property, not only on a root schema.
 	nested := doc.Components.Schemas["NothingNested"].Value
 	require.Error(t, nested.VisitJSON(map[string]any{"a": "anything"}))
 	require.NoError(t, nested.VisitJSON(map[string]any{}))
 }
 
-// A non-empty `not` was already rejected and stays rejected.
+// A `not` holding a schema rejects exactly the values that schema matches.
 func TestNot_NonEmptySubschemaUnchanged(t *testing.T) {
 	const spec = `
 openapi: 3.0.0


### PR DESCRIPTION
The empty schema matches every instance, so `not: {}` matches none. Today it accepts every value instead.

```yaml
components:
  schemas:
    Nothing:
      not: {}
```

```go
nothing.IsEmpty()          // true
nothing.VisitJSON("x")     // nil, accepted
nothing.VisitJSON(1)       // nil, accepted
```

## Cause

`IsEmpty` judged the `not` by whether its own value was empty:

```go
if n := schema.Not; n != nil && n.Value != nil && !n.Value.IsEmpty() {
    return false
}
```

An empty `not` therefore did not make the schema non-empty, and `visitJSON` short-circuits on an empty schema before `visitNotOperation` runs. So the one keyword present was never applied, and the strictest schema expressible became the most permissive one.

A `not` is a constraint whatever it holds, so its presence alone makes the schema non-empty:

```go
if schema.Not != nil {
    return false
}
```

A non-empty `not` already made the schema non-empty and is unaffected.

## Tests

`openapi3/schema_not_empty_test.go` covers `not: {}` at the root and through a property, across every JSON type, and pins that a non-empty `not` still behaves as before.

Full suite green, no golden files move, and `docs.sh` reports no public API change.

## Note

Found while reviewing #1258, which lets a schema be written as a boolean. `not: true` is the same defect through the new syntax and is fixed there, since that PR introduces the syntax. This one is independent and reproduces on master today.