### PR TITLE
openapi3filter: trim whitespace in values of header arrays

### DIFF
--- a/openapi3filter/decode_array_test.go
+++ b/openapi3filter/decode_array_test.go
@@ -1,6 +1,7 @@
 package openapi3filter
 
 import (
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -195,6 +196,17 @@ func TestDecodeArray_IntegerItems(t *testing.T) {
 		require.ErrorAs(t, err, &pe)
 		require.Equal(t, []any{1}, pe.Path())
 	})
+}
+
+func TestHeaderDecodeArray_TrimsOptionalWhitespace(t *testing.T) {
+	sm := &openapi3.SerializationMethod{Style: "simple", Explode: false}
+	schema := decodeArrayIntSchema()
+	dec := &headerParamDecoder{header: http.Header{"X-Pages": {"1, 3, 10"}}}
+
+	got, found, err := dec.DecodeArray("X-Pages", sm, schema)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, []any{int64(1), int64(3), int64(10)}, got)
 }
 
 func TestDecodeArray_DeepObjectRejected(t *testing.T) {

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -792,7 +792,11 @@ func (d *headerParamDecoder) DecodeArray(param string, sm *openapi3.Serializatio
 		return nil, ok, nil
 	}
 
-	val, err := parseArray(strings.Split(raw[0], ","), schema)
+	parts := strings.Split(raw[0], ",")
+	for i := range parts {
+		parts[i] = strings.TrimSpace(parts[i])
+	}
+	val, err := parseArray(parts, schema)
 	return val, ok, err
 }
 


### PR DESCRIPTION
Fixes #715

## Summary

- trim optional whitespace around comma-separated header array values
- preserve existing array parsing for query, path, and cookie parameters
- add regression coverage for integer header arrays such as `1, 3, 10`

## Root cause

The header decoder split simple-style arrays on commas but passed each item through unchanged. Leading optional whitespace therefore reached primitive parsing and made valid integer values such as `" 3"` fail.

## Validation

- `go test ./openapi3filter` - passed
- `gofmt` - passed
- `git diff --check` - passed
- broader `go test ./...` - all relevant packages passed; unrelated failures remained in an existing JSON fixture and an APIs-guru GitHub tarball network download

## AI disclosure

This change was prepared with OpenAI Codex assistance and reviewed and validated locally by the contributor.
