### PR TITLE
openapi3: match media types case-insensitively

### DIFF
--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -61,6 +61,33 @@ func NewContentWithFormDataSchemaRef(schema *SchemaRef) Content {
 	}
 }
 
+func (content Content) get(mime string) *MediaType {
+	if v := content[mime]; v != nil {
+		return v
+	}
+
+	i := strings.IndexByte(mime, ';')
+	if i < 0 {
+		i = len(mime)
+	}
+	mediaType, parameters := mime[:i], mime[i:]
+	if !strings.ContainsRune(mediaType, '/') {
+		return nil
+	}
+
+	for _, candidate := range componentNames(content) {
+		i = strings.IndexByte(candidate, ';')
+		if i < 0 {
+			i = len(candidate)
+		}
+		candidateType, candidateParameters := candidate[:i], candidate[i:]
+		if parameters == candidateParameters && strings.EqualFold(mediaType, candidateType) {
+			return content[candidate]
+		}
+	}
+	return nil
+}
+
 func (content Content) Get(mime string) *MediaType {
 	// If the mime is empty then short-circuit to the wildcard.
 	// We do this here so that we catch only the specific case of
@@ -70,7 +97,7 @@ func (content Content) Get(mime string) *MediaType {
 	}
 	// Start by making the most specific match possible
 	// by using the mime type in full.
-	if v := content[mime]; v != nil {
+	if v := content.get(mime); v != nil {
 		return v
 	}
 	// If an exact match is not found then we strip all
@@ -83,7 +110,7 @@ func (content Content) Get(mime string) *MediaType {
 		i = len(mime)
 	}
 	mime = mime[:i]
-	if v := content[mime]; v != nil {
+	if v := content.get(mime); v != nil {
 		return v
 	}
 	// If the x/y pattern has no specific match then we
@@ -96,7 +123,7 @@ func (content Content) Get(mime string) *MediaType {
 		return nil
 	}
 	mime = mime[:i] + "/*"
-	if v := content[mime]; v != nil {
+	if v := content.get(mime); v != nil {
 		return v
 	}
 	// Finally, the most generic match of */* is returned

--- a/openapi3/content.go
+++ b/openapi3/content.go
@@ -61,31 +61,44 @@ func NewContentWithFormDataSchemaRef(schema *SchemaRef) Content {
 	}
 }
 
+// splitMediaType separates the type/subtype portion of a mime from its
+// parameters, which keep the leading ';' and their original case: RFC 9110
+// section 5.6.6 leaves parameter values case-sensitive unless the parameter
+// itself says otherwise.
+func splitMediaType(mime string) (mediaType, parameters string) {
+	if i := strings.IndexByte(mime, ';'); i >= 0 {
+		return mime[:i], mime[i:]
+	}
+	return mime, ""
+}
+
 func (content Content) get(mime string) *MediaType {
 	if v := content[mime]; v != nil {
 		return v
 	}
 
-	i := strings.IndexByte(mime, ';')
-	if i < 0 {
-		i = len(mime)
-	}
-	mediaType, parameters := mime[:i], mime[i:]
+	mediaType, parameters := splitMediaType(mime)
 	if !strings.ContainsRune(mediaType, '/') {
 		return nil
 	}
 
-	for _, candidate := range componentNames(content) {
-		i = strings.IndexByte(candidate, ';')
-		if i < 0 {
-			i = len(candidate)
+	// Compare against each declaration. The lexicographically smallest match is
+	// taken so that a document declaring several case variants of one media
+	// type still resolves deterministically.
+	match := ""
+	for candidate := range content {
+		if match != "" && candidate >= match {
+			continue
 		}
-		candidateType, candidateParameters := candidate[:i], candidate[i:]
+		candidateType, candidateParameters := splitMediaType(candidate)
 		if parameters == candidateParameters && strings.EqualFold(mediaType, candidateType) {
-			return content[candidate]
+			match = candidate
 		}
 	}
-	return nil
+	if match == "" {
+		return nil
+	}
+	return content[match]
 }
 
 func (content Content) Get(mime string) *MediaType {
@@ -102,28 +115,25 @@ func (content Content) Get(mime string) *MediaType {
 	}
 	// If an exact match is not found then we strip all
 	// metadata from the mime type and only use the x/y
-	// portion.
-	i := strings.IndexByte(mime, ';')
-	if i < 0 {
-		// If there is no metadata then preserve the full mime type
-		// string for later wildcard searches.
-		i = len(mime)
-	}
-	mime = mime[:i]
-	if v := content.get(mime); v != nil {
-		return v
+	// portion. Without metadata the full mime type is
+	// preserved for later wildcard searches, and retrying
+	// it here would repeat the search above.
+	mime, parameters := splitMediaType(mime)
+	if parameters != "" {
+		if v := content.get(mime); v != nil {
+			return v
+		}
 	}
 	// If the x/y pattern has no specific match then we
 	// try the x/* pattern.
-	i = strings.IndexByte(mime, '/')
+	i := strings.IndexByte(mime, '/')
 	if i < 0 {
 		// In the case that the given mime type is not valid because it is
 		// missing the subtype we return nil so that this does not accidentally
 		// resolve with the wildcard.
 		return nil
 	}
-	mime = mime[:i] + "/*"
-	if v := content.get(mime); v != nil {
+	if v := content.get(mime[:i] + "/*"); v != nil {
 		return v
 	}
 	// Finally, the most generic match of */* is returned

--- a/openapi3/content_bench_test.go
+++ b/openapi3/content_bench_test.go
@@ -1,0 +1,48 @@
+package openapi3
+
+import (
+	"fmt"
+	"testing"
+)
+
+var benchMediaType *MediaType
+
+// benchmarkContent returns a document content with n declared media types.
+func benchmarkContent(n int) Content {
+	content := Content{
+		"application/json":    NewMediaType(),
+		"text/plain":          NewMediaType(),
+		"multipart/form-data": NewMediaType(),
+	}
+	for i := len(content); i < n; i++ {
+		content[fmt.Sprintf("application/vnd.example.v%d+json", i)] = NewMediaType()
+	}
+	return content
+}
+
+func BenchmarkContent_Get(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		keys int
+		mime string
+	}{
+		// Declared verbatim: resolves on the first map lookup.
+		{"exact", 3, "application/json"},
+		// The most common shape on the wire: matches once parameters are stripped.
+		{"parameters", 3, "application/json;charset=utf-8"},
+		{"case_variant", 3, "APPLICATION/JSON"},
+		{"case_variant_parameters", 3, "APPLICATION/JSON;charset=utf-8"},
+		// Undeclared: walks every matching stage before giving up.
+		{"no_match", 3, "image/png"},
+		{"parameters_many_media_types", 20, "application/json;charset=utf-8"},
+	}
+	for _, bb := range benchmarks {
+		content := benchmarkContent(bb.keys)
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				benchMediaType = content.Get(bb.mime)
+			}
+		})
+	}
+}

--- a/openapi3/content_test.go
+++ b/openapi3/content_test.go
@@ -11,6 +11,8 @@ func TestContent_Get(t *testing.T) {
 	wildcard := NewMediaType()
 	stripped := NewMediaType()
 	fullMatch := NewMediaType()
+	caseVariant := NewMediaType()
+	malformed := NewMediaType()
 	content := Content{
 		"*/*":                             fallback,
 		"application/*":                   wildcard,
@@ -20,6 +22,13 @@ func TestContent_Get(t *testing.T) {
 	contentWithoutWildcards := Content{
 		"application/json":                stripped,
 		"application/json;encoding=utf-8": fullMatch,
+	}
+	contentWithCaseVariants := Content{
+		"application/json": stripped,
+		"APPLICATION/JSON": caseVariant,
+	}
+	contentWithMalformedType := Content{
+		"text": malformed,
 	}
 	tests := []struct {
 		name    string
@@ -40,15 +49,39 @@ func TestContent_Get(t *testing.T) {
 			want:    fullMatch,
 		},
 		{
+			name:    "full match case insensitive",
+			content: content,
+			mime:    "APPLICATION/JSON;encoding=utf-8",
+			want:    fullMatch,
+		},
+		{
+			name:    "parameter value case sensitive",
+			content: content,
+			mime:    "APPLICATION/JSON;encoding=UTF-8",
+			want:    stripped,
+		},
+		{
 			name:    "stripped match",
 			content: content,
 			mime:    "application/json;encoding=utf-16",
 			want:    stripped,
 		},
 		{
+			name:    "stripped match case insensitive",
+			content: content,
+			mime:    "APPLICATION/JSON;encoding=utf-16",
+			want:    stripped,
+		},
+		{
 			name:    "wildcard match",
 			content: content,
 			mime:    "application/yaml;encoding=utf-16",
+			want:    wildcard,
+		},
+		{
+			name:    "wildcard match case insensitive",
+			content: content,
+			mime:    "APPLICATION/YAML;encoding=utf-16",
 			want:    wildcard,
 		},
 		{
@@ -91,6 +124,18 @@ func TestContent_Get(t *testing.T) {
 			name:    "invalid mime type no encoding",
 			content: content,
 			mime:    "text",
+			want:    nil,
+		},
+		{
+			name:    "exact match takes precedence",
+			content: contentWithCaseVariants,
+			mime:    "APPLICATION/JSON",
+			want:    caseVariant,
+		},
+		{
+			name:    "invalid mime type remains case sensitive",
+			content: contentWithMalformedType,
+			mime:    "TEXT",
 			want:    nil,
 		},
 		{

--- a/openapi3/content_test.go
+++ b/openapi3/content_test.go
@@ -133,6 +133,14 @@ func TestContent_Get(t *testing.T) {
 			want:    caseVariant,
 		},
 		{
+			// No declaration matches verbatim, so the case-insensitive search
+			// decides between them: the lexicographically smallest one wins.
+			name:    "case variants resolve deterministically",
+			content: contentWithCaseVariants,
+			mime:    "Application/Json",
+			want:    caseVariant,
+		},
+		{
 			name:    "invalid mime type remains case sensitive",
 			content: contentWithMalformedType,
 			mime:    "TEXT",

--- a/openapi3filter/internal.go
+++ b/openapi3filter/internal.go
@@ -13,6 +13,39 @@ func parseMediaType(contentType string) string {
 	return before
 }
 
+// lookupByContentType returns the entry registered for contentType.
+//
+// An exact key always wins. Otherwise the lookup falls back to a
+// case-insensitive comparison, as RFC 9110 section 8.3.1 defines media type and
+// subtype tokens as case-insensitive. Values missing a subtype are not valid
+// media types and are matched exactly so they cannot resolve through the
+// fallback.
+func lookupByContentType[V any](registered map[string]V, contentType string) (V, bool) {
+	if v, ok := registered[contentType]; ok {
+		return v, true
+	}
+	var zero V
+	if !strings.ContainsRune(contentType, '/') {
+		return zero, false
+	}
+	// Compare against each entry. The lexicographically smallest match is taken
+	// so that several registered case variants of one content type still
+	// resolve deterministically.
+	match := ""
+	for candidate := range registered {
+		if match != "" && candidate >= match {
+			continue
+		}
+		if strings.EqualFold(contentType, candidate) {
+			match = candidate
+		}
+	}
+	if match == "" {
+		return zero, false
+	}
+	return registered[match], true
+}
+
 func isNilValue(value any) bool {
 	if value == nil {
 		return true

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1299,6 +1299,21 @@ func UnregisterBodyDecoder(contentType string) {
 	delete(bodyDecoders, contentType)
 }
 
+func getBodyDecoder(contentType string) (BodyDecoder, bool) {
+	if decoder, ok := bodyDecoders[contentType]; ok {
+		return decoder, true
+	}
+	if !strings.ContainsRune(contentType, '/') {
+		return nil, false
+	}
+	for _, candidate := range slices.Sorted(maps.Keys(bodyDecoders)) {
+		if strings.EqualFold(contentType, candidate) {
+			return bodyDecoders[candidate], true
+		}
+	}
+	return nil, false
+}
+
 var headerCT = http.CanonicalHeaderKey("Content-Type")
 
 const (
@@ -1394,7 +1409,7 @@ func decodeBody(body io.Reader, header http.Header, schema *openapi3.SchemaRef, 
 		}
 	}
 
-	decoder, ok := bodyDecoders[mediaType]
+	decoder, ok := getBodyDecoder(mediaType)
 	if !ok {
 		// A binary part with no registered decoder (e.g. image/png) is read as
 		// raw bytes: encoding.contentType restricts the accepted media types but

--- a/openapi3filter/req_resp_decoder.go
+++ b/openapi3filter/req_resp_decoder.go
@@ -1300,18 +1300,7 @@ func UnregisterBodyDecoder(contentType string) {
 }
 
 func getBodyDecoder(contentType string) (BodyDecoder, bool) {
-	if decoder, ok := bodyDecoders[contentType]; ok {
-		return decoder, true
-	}
-	if !strings.ContainsRune(contentType, '/') {
-		return nil, false
-	}
-	for _, candidate := range slices.Sorted(maps.Keys(bodyDecoders)) {
-		if strings.EqualFold(contentType, candidate) {
-			return bodyDecoders[candidate], true
-		}
-	}
-	return nil, false
+	return lookupByContentType(bodyDecoders, contentType)
 }
 
 var headerCT = http.CanonicalHeaderKey("Content-Type")

--- a/openapi3filter/req_resp_decoder_bench_test.go
+++ b/openapi3filter/req_resp_decoder_bench_test.go
@@ -1,0 +1,63 @@
+package openapi3filter
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+var benchBodyDecoder BodyDecoder
+
+func BenchmarkGetBodyDecoder(b *testing.B) {
+	benchmarks := []struct {
+		name        string
+		contentType string
+	}{
+		// Registered verbatim: resolves on the first map lookup.
+		{"exact", "application/json"},
+		{"case_variant", "APPLICATION/JSON"},
+		// Unregistered: binary multipart parts take this path on every request.
+		{"unregistered", "image/png"},
+	}
+	for _, bb := range benchmarks {
+		b.Run(bb.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				benchBodyDecoder, _ = getBodyDecoder(bb.contentType)
+			}
+		})
+	}
+}
+
+// BenchmarkValidateRequestBody puts the media type lookups above in proportion
+// to a whole body validation.
+func BenchmarkValidateRequestBody(b *testing.B) {
+	schema := openapi3.NewObjectSchema().
+		WithProperty("name", openapi3.NewStringSchema()).
+		WithProperty("code", openapi3.NewIntegerSchema())
+	requestBody := openapi3.NewRequestBody().WithJSONSchema(schema).WithRequired(true)
+	payload := []byte(`{"name":"foo","code":123}`)
+
+	for _, contentType := range []string{
+		"application/json",
+		"application/json;charset=utf-8",
+		"APPLICATION/JSON",
+	} {
+		b.Run(contentType, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				req, err := http.NewRequest(http.MethodPost, "/", bytes.NewReader(payload))
+				if err != nil {
+					b.Fatal(err)
+				}
+				req.Header.Set(headerCT, contentType)
+				input := &RequestValidationInput{Request: req}
+				if err := ValidateRequestBody(b.Context(), input, requestBody); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/openapi3filter/req_resp_encoder.go
+++ b/openapi3filter/req_resp_encoder.go
@@ -7,13 +7,21 @@ import (
 )
 
 func encodeBody(body any, mediaType string) ([]byte, error) {
-	if encoder := RegisteredBodyEncoder(mediaType); encoder != nil {
+	if encoder, ok := getBodyEncoder(mediaType); ok {
 		return encoder(body)
 	}
 	return nil, &ParseError{
 		Kind:   KindUnsupportedFormat,
 		Reason: fmt.Sprintf("%s %q", prefixUnsupportedCT, mediaType),
 	}
+}
+
+// getBodyEncoder mirrors getBodyDecoder so that a body matched and decoded
+// under a case variant of its declared media type can also be re-encoded.
+func getBodyEncoder(contentType string) (BodyEncoder, bool) {
+	bodyEncodersM.RLock()
+	defer bodyEncodersM.RUnlock()
+	return lookupByContentType(bodyEncoders, contentType)
 }
 
 // BodyEncoder really is an (encoding/json).Marshaler

--- a/openapi3filter/req_resp_encoder_test.go
+++ b/openapi3filter/req_resp_encoder_test.go
@@ -37,3 +37,29 @@ func TestRegisterAndUnregisterBodyEncoder(t *testing.T) {
 		Reason: prefixUnsupportedCT + ` "text/csv"`,
 	}, err)
 }
+
+func TestGetBodyEncoderCaseVariantsAreDeterministic(t *testing.T) {
+	var encoder BodyEncoder = func(body any) ([]byte, error) { return nil, nil }
+	for _, contentType := range []string{"TEXT/CSV", "text/CSV", "text/csv"} {
+		RegisterBodyEncoder(contentType, encoder)
+		defer UnregisterBodyEncoder(contentType)
+	}
+
+	// None of the registrations match verbatim, so the case-insensitive search
+	// decides between them: the lexicographically smallest one wins.
+	got, ok := getBodyEncoder("Text/Csv")
+	require.True(t, ok)
+	require.Equal(t, fmt.Sprint(RegisteredBodyEncoder("TEXT/CSV")), fmt.Sprint(got))
+}
+
+func TestEncodeBodyCaseInsensitiveMediaType(t *testing.T) {
+	got, err := encodeBody(map[string]any{"name": "default"}, "APPLICATION/JSON")
+	require.NoError(t, err)
+	require.JSONEq(t, `{"name":"default"}`, string(got))
+
+	_, err = encodeBody(map[string]any{}, "APPLICATION")
+	require.Equal(t, &ParseError{
+		Kind:   KindUnsupportedFormat,
+		Reason: prefixUnsupportedCT + ` "APPLICATION"`,
+	}, err)
+}

--- a/openapi3filter/validate_response_test.go
+++ b/openapi3filter/validate_response_test.go
@@ -9,7 +9,33 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/getkin/kin-openapi/routers"
 )
+
+func TestValidateResponseContentTypeCaseInsensitive(t *testing.T) {
+	content := openapi3.Content{
+		"text/plain": openapi3.NewMediaType().WithSchema(openapi3.NewStringSchema()),
+	}
+	operation := openapi3.NewOperation()
+	operation.Responses = openapi3.NewResponses(openapi3.WithStatus(
+		http.StatusOK,
+		&openapi3.ResponseRef{Value: openapi3.NewResponse().WithContent(content)},
+	))
+	input := &ResponseValidationInput{
+		RequestValidationInput: &RequestValidationInput{
+			Request: &http.Request{Method: http.MethodGet},
+			Route: &routers.Route{
+				Spec:      &openapi3.T{OpenAPI: "3.0.3"},
+				Operation: operation,
+			},
+		},
+		Status: http.StatusOK,
+		Header: http.Header{headerCT: []string{"TEXT/PLAIN"}},
+		Body:   io.NopCloser(strings.NewReader("hello")),
+	}
+
+	require.NoError(t, ValidateResponse(t.Context(), input))
+}
 
 func Test_validateResponseHeader(t *testing.T) {
 	type args struct {

--- a/openapi3filter/validate_set_default_test.go
+++ b/openapi3filter/validate_set_default_test.go
@@ -801,3 +801,20 @@ func TestValidateRequestBodyAndSetDefault(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateRequestBodyAndSetDefaultCaseInsensitiveContentType(t *testing.T) {
+	schema := openapi3.NewObjectSchema().
+		WithProperty("name", openapi3.NewStringSchema().WithDefault("default"))
+	requestBody := openapi3.NewRequestBody().WithJSONSchema(schema).WithRequired(true)
+
+	httpReq, err := http.NewRequest(http.MethodPost, "/accounts", bytes.NewReader([]byte(`{}`)))
+	require.NoError(t, err)
+	httpReq.Header.Add(headerCT, "APPLICATION/JSON")
+
+	err = ValidateRequestBody(t.Context(), &RequestValidationInput{Request: httpReq}, requestBody)
+	require.NoError(t, err)
+
+	validatedReqBody, err := io.ReadAll(httpReq.Body)
+	require.NoError(t, err)
+	require.JSONEq(t, `{"name":"default"}`, string(validatedReqBody))
+}

--- a/openapi3filter/validation_test.go
+++ b/openapi3filter/validation_test.go
@@ -414,6 +414,12 @@ func TestValidateRequestBody(t *testing.T) {
 			data: strings.NewReader("foo"),
 		},
 		{
+			name: "case-insensitive content type",
+			body: openapi3.NewRequestBody().WithContent(plainTextContent).WithRequired(true),
+			mime: "TEXT/PLAIN",
+			data: strings.NewReader("foo"),
+		},
+		{
 			name: "not declared content",
 			body: openapi3.NewRequestBody().WithRequired(true),
 			mime: "application/json",


### PR DESCRIPTION
## Motivation

A document that declares `text/plain` currently does not match a valid `Content-Type: TEXT/PLAIN`. `openapi3.Content.Get` returns `nil`, and request and response validation reject the body with an unexpected Content-Type error.

[RFC 9110 section 8.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-8.3.1) defines media type and subtype tokens as case-insensitive.

## Proposed changes

- Preserve direct map lookups as the highest-precedence match, then compare only the media type and subtype case-insensitively at the existing full, stripped, and `type/*` matching stages.
- Preserve parameter suffixes and their values instead of lowercasing the whole Content-Type value.
- Resolve registered body decoders case-insensitively after checking for an exact registration, allowing matched request and response bodies to be decoded.
- Resolve registered body encoders through the same lookup. A body matched under a case variant was decoded but could not be re-encoded, so setting a schema default failed after validation had already succeeded with `rewriting failed: unsupported content type "APPLICATION/JSON"`. Decoder and encoder resolution now share one helper so they cannot drift apart again.
- Match media types without allocating. The case-insensitive fallback sorted every declared media type on each miss, and a Content-Type carrying parameters reaches that fallback on every request. Candidates are now compared against the map directly, keeping the lexicographically smallest match so several declared case variants still resolve deterministically, and `Get` no longer re-searches the unparameterised mime that the previous stage already covered.
- Add regression coverage for parameterized matches, exact-match precedence, deterministic resolution between declared case variants, wildcard fallback, malformed values, default rewriting, and request and response validation.
- Add benchmarks for `Content.Get`, body decoder resolution, and whole-body validation, which the repository previously had none of.

## Unrelated changes (optional)

_None_

## Testing / Validation

- Confirmed the new focused tests fail on `master` for `Content.Get`, request validation, and response validation before applying the implementation.
- Confirmed the default-rewriting and encoder tests fail against the first commit alone, reproducing `rewriting failed: unsupported content type "APPLICATION/JSON"`.
- Checked the allocation-free matching against a copy of the previous implementation over every combination of 17 content maps and 25 mime values, requiring identical results.
- `make prepare`
- `go test -count=1 ./...`
- `go test -count=10 -short ./...`
- `go test -count=2 -short -covermode=atomic ./...`
- Targeted race tests with `-race -count=10`
- `go vet ./...`
- Go `modernize` and `nilness` analyzers
- `goimports-reviser` on changed Go files
- `shellcheck -S error maps.sh docs.sh`

### Benchmarks

`benchstat` over 10 runs, Apple M5 Pro, all deltas p=0.000. Both lookups are now allocation-free on every path.

| `Content.Get` | before | after | allocs |
| --- | --- | --- | --- |
| exact | 5.19 ns | 4.78 ns (−7.8%) | 0 → 0 |
| parameters | 71.8 ns | 51.9 ns (−27.7%) | 1 → 0 |
| case variant | 75.9 ns | 60.3 ns (−20.6%) | 1 → 0 |
| case variant + parameters | 148.7 ns | 110.1 ns (−25.9%) | 2 → 0 |
| no match | 236.2 ns | 117.6 ns (−50.2%) | 3 → 0 |
| parameters, 20 media types | 408.4 ns | 163.0 ns (−60.1%) | 1 → 0 |

| `openapi3filter` | before | after | allocs |
| --- | --- | --- | --- |
| `getBodyDecoder`, exact | 4.94 ns | 4.88 ns | 0 → 0 |
| `getBodyDecoder`, case variant | 383.6 ns | 157.6 ns (−58.9%) | 8 → 0 |
| `getBodyDecoder`, unregistered (`image/png`) | 373.3 ns | 90.0 ns (−75.9%) | 8 → 0 |
| `ValidateRequestBody`, `application/json` | 1.246 µs | 1.225 µs (−1.7%) | 37 → 37 |
| `ValidateRequestBody`, `;charset=utf-8` | 1.298 µs | 1.284 µs | 38 → 37 |
| `ValidateRequestBody`, `APPLICATION/JSON` | 1.704 µs | 1.458 µs (−14.4%) | 46 → 37 |

`image/png` is the path every binary part of a `multipart/form-data` upload takes, since binary parts legitimately have no registered decoder.

## Notes (optional)

Exact matches continue to win. Parameter values remain case-sensitive, `type/*` and `*/*` retain their existing precedence, and media types missing a subtype continue to be rejected rather than falling through to a wildcard. No public API or dependency changes are introduced: the exported `RegisteredBodyDecoder` and `RegisteredBodyEncoder` keep their exact-match behaviour, and only validation resolves content types case-insensitively.

Parameter names are still compared case-sensitively, so a document declaring `application/json;charset=utf-8` does not match `application/json;Charset=utf-8` even though RFC 9110 section 5.6.6 makes parameter names case-insensitive. Handling that needs `mime.ParseMediaType`, which allocates a map per call, so it is left for a follow-up rather than added to this path.

Related history: [#91](https://github.com/getkin/kin-openapi/issues/91), [#93](https://github.com/getkin/kin-openapi/pull/93), and [#1201](https://github.com/getkin/kin-openapi/pull/1201).

## Dependencies (optional)

_None_
