### PR TITLE
openapi3: fix nil pointer panic in resolveExampleRef on null examples entry

### DIFF
--- a/openapi3/loader.go
+++ b/openapi3/loader.go
@@ -1298,6 +1298,10 @@ func applyExampleRefMetadata(value *Example, component *ExampleRef, isOpenAPI31O
 func (loader *Loader) resolveExampleRef(doc *T, component *ExampleRef, documentPath *url.URL) (err error) {
 	isOpenAPI31OrLater := doc.IsOpenAPI31OrLater()
 
+	if component.isEmpty() {
+		return errMUSTExample
+	}
+
 	if ref := component.Ref; ref != "" {
 		if component.Value != nil {
 			return nil

--- a/openapi3/refs_example_nil_test.go
+++ b/openapi3/refs_example_nil_test.go
@@ -1,0 +1,34 @@
+package openapi3_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+func TestExampleRefNil(t *testing.T) {
+	spec := []byte(`
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+paths:
+  /health:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            text/plain:
+              schema: { type: string }
+              examples:
+                alive:
+`[1:])
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData(spec)
+	require.EqualError(t, err, `invalid example: value MUST be an object`)
+	require.Nil(t, doc)
+}


### PR DESCRIPTION
## Summary

`resolveExampleRef` panics with a nil pointer dereference when a document contains an `examples:` map entry with a null value, e.g.:

```yaml
content:
  text/plain:
    schema: { type: string }
    examples:
      alive:
```

A null YAML/JSON value for such an entry unmarshals to a `nil *ExampleRef`, which `resolveExampleRef` dereferences (`component.Ref`) without a nil check.

Every other `resolve*Ref` function (`resolveHeaderRef`, `resolveParameterRef`, `resolveRequestBodyRef`, `resolveResponseRef`, `resolveSchemaRef`, `resolveSecuritySchemeRef`, `resolveCallbackRef`, `resolveLinkRef`) already guards against this with:

```go
if component.isEmpty() {
	return errMUSTX // type-appropriate sentinel
}
```

`resolveExampleRef` was missing the equivalent guard — even though `errMUSTExample` already exists and is referenced later in the same function for the analogous case where a `$ref` chain resolves to an empty example.

Bisected the regression to #1215 ("openapi31: support 3.1+ reference metadata overrides"), which added a call to `applyExampleRefMetadata(component.Value, component, ...)` inside `resolveExampleRef` without an accompanying nil-check on `component` itself. First reproduces in v0.144.0, still present in v0.149.0 and master.

## Fix

Adds the same `component.isEmpty()` guard used by every sibling `resolve*Ref` function, so a null examples-map entry now fails cleanly with `invalid example: value MUST be an object` instead of panicking.

## Test plan

- Added `TestExampleRefNilPanic` in `openapi3/refs_example_nil_test.go`, following the style of the existing `TestIssue222` regression test for the analogous null-response panic.
- `go test ./openapi3/...` passes.
