### PR TITLE
openapi3: reject integers outside the int64 range for integer formats

### DIFF
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -2563,7 +2563,7 @@ func (schema *Schema) visitJSONNumber(settings *schemaValidationSettings, value 
 				f, ok = SchemaIntegerFormats[format]
 			}
 			if ok {
-				if err := f.Validate(int64(value)); err != nil {
+				if err := validateIntegerFormat(f, value); err != nil {
 					var reason string
 					schemaErr := &SchemaError{}
 					if errors.As(err, &schemaErr) {

--- a/openapi3/schema_formats.go
+++ b/openapi3/schema_formats.go
@@ -106,6 +106,19 @@ func NewRangeFormatValidator[T int64 | float64](min, max T) FormatValidator[T] {
 	return rangeFormat[T]{min: min, max: max}
 }
 
+// validateIntegerFormat converts a JSON number for an integer format validator. A float64
+// outside the int64 range wraps back into it on conversion, so it is rejected here instead.
+func validateIntegerFormat(validator IntegerFormatValidator, value float64) error {
+	switch {
+	case value == float64(math.MaxInt64): // math.MaxInt64 has no float64 representation: it rounds up to 2^63
+		return validator.Validate(math.MaxInt64)
+	case value >= float64(math.MinInt64) && value < float64(math.MaxInt64):
+		return validator.Validate(int64(value))
+	default:
+		return fmt.Errorf("value should be between %v and %v", int64(math.MinInt64), int64(math.MaxInt64))
+	}
+}
+
 // NewRegexpFormatValidator creates a new FormatValidator that uses a regular expression to validate the value.
 func NewRegexpFormatValidator(pattern string) StringFormatValidator {
 	re, err := regexp.Compile(pattern)

--- a/openapi3/schema_formats_test.go
+++ b/openapi3/schema_formats_test.go
@@ -3,6 +3,7 @@ package openapi3
 import (
 	"errors"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -232,6 +233,79 @@ func TestNumberFormats(t *testing.T) {
 			} else {
 				require.Nil(t, err)
 			}
+		})
+	}
+}
+
+func TestIntegerFormatOutOfInt64Range(t *testing.T) {
+	type testCase struct {
+		name    string
+		format  string
+		value   float64
+		wantErr bool
+	}
+	DefineIntegerFormatValidator("anyInt64", NewCallbackValidator(func(value int64) error {
+		return nil
+	}))
+	testCases := []testCase{
+		{
+			name:    "int64 accepts the largest representable value",
+			format:  "int64",
+			value:   float64(math.MaxInt64),
+			wantErr: false,
+		},
+		{
+			name:    "int64 accepts the smallest representable value",
+			format:  "int64",
+			value:   float64(math.MinInt64),
+			wantErr: false,
+		},
+		{
+			name:    "int64 rejects 1e19",
+			format:  "int64",
+			value:   1e19,
+			wantErr: true,
+		},
+		{
+			name:    "int64 rejects -1e19",
+			format:  "int64",
+			value:   -1e19,
+			wantErr: true,
+		},
+		{
+			name:    "int64 rejects 1e30",
+			format:  "int64",
+			value:   1e30,
+			wantErr: true,
+		},
+		{
+			name:    "int32 rejects 1e19",
+			format:  "int32",
+			value:   1e19,
+			wantErr: true,
+		},
+		{
+			name:    "custom integer format rejects 1e19",
+			format:  "anyInt64",
+			value:   1e19,
+			wantErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			schema := &Schema{
+				Type:   &Types{"integer"},
+				Format: tc.format,
+			}
+			err := schema.VisitJSON(tc.value)
+			if !tc.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var schemaError = &SchemaError{}
+			require.ErrorAs(t, err, &schemaError)
+			require.NotZero(t, schemaError.Reason)
 		})
 	}
 }


### PR DESCRIPTION
### Problem

A schema of `{"type": "integer", "format": "int64"}` accepts every JSON number, however large. `1e19`, `1e30`, `-1e19` and `1.7976931348623157e+308` all validate clean.

`openapi3/schema.go:2566`:

```go
if ok {
	if err := f.Validate(int64(value)); err != nil {
```

`value` is a `float64`. When it is outside the `int64` range, `int64(value)` is [implementation-defined](https://go.dev/ref/spec#Conversions) - on `amd64` it yields `math.MinInt64`, on `arm64` `math.MaxInt64`. Either result lands *inside* the validator's own `[MinInt64, MaxInt64]` window, so the range check can never fire. The conversion destroys exactly the information the validator was about to check.

The `number` branch on the sibling path at `openapi3/schema.go:2582` passes the raw `float64` through and is unaffected.

### Why this is a bug and not a design choice

Your own `rangeFormat[int64].Validate` at `openapi3/schema_formats.go:97`, reached through the `int32` registration at `openapi3/schema_formats.go:60`, already does this - it rejects `1e19` with `integer doesn't match the format "int32": value should be between -2147483648 and 2147483647`, while the `int64` registration on the very next line, `openapi3/schema_formats.go:61`, accepts the same value.

Both registrations are built from the same `NewRangeFormatValidator` helper with the same intent. Only one of them works, and the difference is not in the validator - it is in the conversion at the call site.

### Reachability

This is on the request-validation path, not just the exported-API path.

`openapi3filter.JSONBodyDecoder` sets `dec.UseNumber()` (`openapi3filter/req_resp_decoder.go:1448`), so a request body arrives as a `json.Number`. `visitJSON` converts it back to `float64` at `openapi3/schema.go:2082` and hands it to `visitJSONNumber`. Executed on `master`, with the schema parsed from a plain user spec:

```
json.Number("10000000000000000000") -> err=<nil>
json.Number("1e19")                 -> err=<nil>
json.Number("-1e19")                -> err=<nil>
json.Number("1e30")                 -> err=<nil>
json.Number("9223372036854775807")  -> err=<nil>
```

With this patch:

```
json.Number("10000000000000000000") -> integer doesn't match the format "int64": value should be between -9223372036854775808 and 9223372036854775807
json.Number("1e19")                 -> integer doesn't match the format "int64": value should be between -9223372036854775808 and 9223372036854775807
json.Number("-1e19")                -> integer doesn't match the format "int64": value should be between -9223372036854775808 and 9223372036854775807
json.Number("1e30")                 -> integer doesn't match the format "int64": value should be between -9223372036854775808 and 9223372036854775807
json.Number("9223372036854775807")  -> err=<nil>
```

The last row is deliberately unchanged - see the scoping note below.

### Fix

Guard the conversion instead of the value after it:

```diff
--- a/openapi3/schema.go
+++ b/openapi3/schema.go
@@ -2563,7 +2563,7 @@
 				f, ok = SchemaIntegerFormats[format]
 			}
 			if ok {
-				if err := f.Validate(int64(value)); err != nil {
+				if err := validateIntegerFormat(f, value); err != nil {
```

with the helper next to `NewRangeFormatValidator` in `openapi3/schema_formats.go`:

```go
// validateIntegerFormat converts a JSON number for an integer format validator. A float64
// outside the int64 range wraps back into it on conversion, so it is rejected here instead.
func validateIntegerFormat(validator IntegerFormatValidator, value float64) error {
	switch {
	case value == float64(math.MaxInt64): // math.MaxInt64 has no float64 representation: it rounds up to 2^63
		return validator.Validate(math.MaxInt64)
	case value >= float64(math.MinInt64) && value < float64(math.MaxInt64):
		return validator.Validate(int64(value))
	default:
		return fmt.Errorf("value should be between %v and %v", int64(math.MinInt64), int64(math.MaxInt64))
	}
}
```

The first arm exists because `float64(math.MaxInt64)` is not `math.MaxInt64` - it rounds up to exactly 2^63, so a plain `value <= float64(math.MaxInt64)` bound would let 2^63 through into the conversion. `float64(math.MinInt64)` is exact, so the min side needs no such arm. The helper is unexported, so no regenerated docs are affected.

The error text reuses `rangeFormat.Validate`'s own message shape and deliberately does not echo the value, because `TestNumberFormats` asserts the reason does not contain it.

### Test

`TestIntegerFormatOutOfInt64Range` in `openapi3/schema_formats_test.go`, table-driven, next to `TestNumberFormats`:

| case | format | value | expect |
| --- | --- | --- | --- |
| largest representable value | int64 | `float64(math.MaxInt64)` | accept |
| smallest representable value | int64 | `float64(math.MinInt64)` | accept |
| rejects 1e19 | int64 | `1e19` | reject |
| rejects -1e19 | int64 | `-1e19` | reject |
| rejects 1e30 | int64 | `1e30` | reject |
| rejects 1e19 | int32 | `1e19` | reject (control - already passes on master) |
| custom integer format | `anyInt64` via `DefineIntegerFormatValidator` | `1e19` | reject |

Red on `master` (test applied to the unmodified source): exit 1, exactly four failures - `int64_rejects_1e19`, `int64_rejects_-1e19`, `int64_rejects_1e30`, `custom_integer_format_rejects_1e19`. The `int32` row passes on `master` too; it is there as the control that proves the two registrations disagree.

Mutation-checked in both directions. The three failing sets are pairwise disjoint:

| mutation | result |
| --- | --- |
| revert `validateIntegerFormat` to `f.Validate(int64(value))` | fails the four rejection cases |
| drop the `== float64(math.MaxInt64)` arm | fails only `int64 accepts the largest representable value` |
| `>=` to `>` on the min side | fails only `int64 accepts the smallest representable value` |
| `<` to `<=` on the max side | passes - equivalent mutant: the first switch arm already consumes the only value where the two forms differ. The `<` is kept so correctness does not depend on arm ordering. |

### Verification

Every gate from `.github/workflows/go.yml`, run locally with go1.26.3:

| gate | result |
| --- | --- |
| `go vet ./...` | pass |
| `go generate ./...`, `./docs.sh`, `./maps.sh` | pass, zero generator drift |
| `go mod tidy` | pass, no go.mod/go.sum drift |
| `go test -count=1 ./...` | pass, all packages |
| `GOARCH=386 go test -count=1 -short ./...` | pass |
| capitalized-error grep | pass |
| trailing-whitespace grep | pass |

The explicit `int64(...)` conversions inside the `fmt.Errorf` are load-bearing for the `GOARCH=386` row: an untyped `math.MaxInt64` passed to `%v` would default to `int` there and fail to compile.

### Two things worth flagging

**1. Reason-string change for out-of-int64-range values under a narrower format.** A value like `1e19` under `format: "int32"` now reports `value should be between -9223372036854775808 and 9223372036854775807` instead of the int32 bounds, because the value no longer reaches the int32 validator. It is still rejected, and no test asserts the old text. The alternative - calling a user-supplied validator with a saturated value it was never given - seemed worse than a slightly wider bound in the message.

**2. Scope relative to #733.** This is not a fix for #733. That issue asks for full `json.Number` precision so that `9223372036854775808` (2^63, one past int64) can be distinguished from `9223372036854775807`; both are the same `float64`, so no float64-based check can separate them. This patch deliberately still **accepts** `float64(math.MaxInt64)` (== 2^63), exactly as `master` does, and only rejects values that no longer fit in a `float64`-to-`int64` conversion at all. It neither closes #733 nor forecloses it - a later precision-preserving path can replace this helper's input without changing its contract. #738 (merged) added `UseNumber()` to the decoder, which is why the reachability probe above goes through `json.Number`; the range check it left open is what this addresses for the representable range.

---

Disclosure: this patch was prepared with AI assistance. I have reviewed and tested it myself, and I am responsible for its correctness.
